### PR TITLE
Kasp check dual_log has LF somewhere and somewhere not and its logging t...

### DIFF
--- a/enforcer-ng/src/utils/kaspcheck.c
+++ b/enforcer-ng/src/utils/kaspcheck.c
@@ -146,6 +146,6 @@ int main (int argc, char *argv[])
 	StrFree(zonelistfile);
 
 	if (verbose)
-		dual_log("DEBUG: finished %d\n", status);
+		dual_log("DEBUG: finished %d", status);
 	return status;
 }


### PR DESCRIPTION
...o both syslog and console, for syslog no LF is needed but its needed for console. This fixes that by adding the LF in dual_log function itself instead from the caller. Fix kasp check check_path(), it was checking the stat structure for directory even if it stat'ed a non existing directory and it may return 0 because of that, now do the checks in the correct order.
