### PR TITLE
OPENDNSSEC-574: libhsm: Optimize storage in HSM by deleting the public k...

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 OpenDNSSEC 1.4.4rc1
 
+* SUPPORT-114: libhsm: Optimize storage in HSM by deleting the public 
+  key directly if SkipPublicKey is used [OPENDNSSEC-574].
 * OPENDNSSEC-549: Signer Engine: Put NSEC3 records on empty non-terminals
   derived from unsigned delegations (be compatible with servers that are
   incompatible with RFC 5155 errata 3441).

--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -2397,9 +2397,12 @@ hsm_generate_rsa_key(hsm_ctx_t *ctx,
     new_key->module = session->module;
 
     if (session->module->config->use_pubkey) {
-        new_key->public_key = publicKey;        
+        new_key->public_key = publicKey;
     } else {
-        new_key->public_key = 0;        
+        /* Destroy the object directly in order to optimize storage in HSM */
+        /* Ignore return value, it is just a session object and will be destroyed later */
+        rv = ((CK_FUNCTION_LIST_PTR)session->module->sym)->C_DestroyObject(session->session, publicKey);
+        new_key->public_key = 0;
     }
 
     new_key->private_key = privateKey;


### PR DESCRIPTION
...ey directly if SkipPublicKey is used.

This is a copy from the other pull request.
