### PR TITLE
OPENDNSSEC-575: libhsm: Optimize storage in HSM by deleting the public k...

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
-OpenDNSSEC 1.13.17rc1
+OpenDNSSEC 1.3.17rc1
 
+* SUPPORT-114: libhsm: Optimize storage in HSM by deleting the public 
+  key directly if SkipPublicKey is used [OPENDNSSEC-575].
 * Signer Engine: log serial of signed zone in STATS line.
 * OPENDNSSEC-569: Build compatibility with SoftHSMv2.
 

--- a/libhsm/src/libhsm.c
+++ b/libhsm/src/libhsm.c
@@ -2148,9 +2148,12 @@ hsm_generate_rsa_key(hsm_ctx_t *ctx,
     new_key->module = session->module;
 
     if (session->module->config->use_pubkey) {
-        new_key->public_key = publicKey;        
+        new_key->public_key = publicKey;
     } else {
-        new_key->public_key = 0;        
+        /* Destroy the object directly in order to optimize storage in HSM */
+        /* Ignore return value, it is just a session object and will be destroyed later */
+        rv = ((CK_FUNCTION_LIST_PTR)session->module->sym)->C_DestroyObject(session->session, publicKey);
+        new_key->public_key = 0;
     }
 
     new_key->private_key = privateKey;


### PR DESCRIPTION
...ey directly if SkipPublicKey is used.

This is a copy of the other pull request.
