### PR TITLE
OPENDNSSEC-184: Add --zone filter to 'ods-enforcer rollover list' command

### DIFF
--- a/enforcer-ng/src/keystate/rollover_list_cmd.cpp
+++ b/enforcer-ng/src/keystate/rollover_list_cmd.cpp
@@ -44,6 +44,7 @@ usage(int sockfd)
 {
 	ods_printf(sockfd, 
 		"rollover list          List upcoming rollovers.\n"
+		"     [--zone <zone>]              (aka -z)  zone.\n"
 	);
 }
 
@@ -60,8 +61,10 @@ run(int sockfd, engine_type* engine, const char *cmd, ssize_t n)
 	const int NARGV = 8;
 	const char *argv[NARGV];
 	int argc;
+	const char *zone = NULL;
 	
 	ods_log_debug("[%s] %s command", module_str, rollover_list_funcblock()->cmdname);
+	cmd = ods_check_command(cmd, n, rollover_list_funcblock()->cmdname);
 	
 	// Use buf as an intermediate buffer for the command.
 	strncpy(buf, cmd,sizeof(buf));
@@ -76,14 +79,14 @@ run(int sockfd, engine_type* engine, const char *cmd, ssize_t n)
 		return -1;
 	}
 	
-	bool bVerbose = ods_find_arg(&argc,argv,"verbose","v") != -1;
+    (void)ods_find_arg_and_param(&argc,argv,"zone","z",&zone);
 	if (argc) {
 		ods_log_warning("[%s] unknown arguments for %s command",
 						module_str, rollover_list_funcblock()->cmdname);
 		ods_printf(sockfd,"unknown arguments\n");
 		return -1;
 	}
-	return perform_rollover_list(sockfd, engine->config, bVerbose?1:0);
+	return perform_rollover_list(sockfd, engine->config, zone);
 }
 
 static struct cmd_func_block funcblock = {

--- a/enforcer-ng/src/keystate/rollover_list_task.cpp
+++ b/enforcer-ng/src/keystate/rollover_list_task.cpp
@@ -78,7 +78,7 @@ map_keytime(const EnforcerZone zone, const KeyData key)
 }
 
 int 
-perform_rollover_list(int sockfd, engineconfig_type *config, int bverbose)
+perform_rollover_list(int sockfd, engineconfig_type *config, const char *listed_zone)
 {
 	GOOGLE_PROTOBUF_VERIFY_VERSION;
 	OrmConnRef conn;
@@ -93,6 +93,41 @@ perform_rollover_list(int sockfd, engineconfig_type *config, int bverbose)
 		ods_printf(sockfd, "error enumerating zones\n");
 		return 1;
 	}
+	
+    if (NULL == listed_zone || 0 == strlen(listed_zone)) {
+        if (!OrmMessageEnum(conn, zone.descriptor(), rows)) {
+            ods_log_error("[%s] error enumerating zones", module_str);
+            ods_printf(sockfd, "error enumerating zones\n");
+            return 1;
+        }
+    }
+    else {
+        std::string qzone;
+        if (!OrmQuoteStringValue(conn, std::string(listed_zone), qzone)) {
+            const char *emsg = "quoting zone value failed";
+            ods_log_error_and_printf(sockfd,module_str,emsg);
+            return 1;
+        }
+
+        if (!OrmMessageEnumWhere(conn, 
+                    zone.descriptor(),
+                    rows,
+                    "name = %s",
+                    qzone.c_str())) {
+            ods_log_error("[%s] unable to find zone:%s", 
+                    module_str, qzone.c_str());
+            ods_printf(sockfd, "unable to find zone:%s\n", qzone.c_str());
+            return 1;
+        }
+
+        if (!OrmFirst(rows)) {
+            ods_log_error("[%s] zone:%s not found", 
+                    module_str, qzone.c_str());
+            ods_printf(sockfd, "zone:%s not found\n", qzone.c_str());
+            return 1;
+        }
+    }	
+	
 	
 	ods_printf(sockfd, "Keys:\n");
 	ods_printf(sockfd, fmt, "Zone:", "Keytype:", "Rollover expected:");

--- a/enforcer-ng/src/keystate/rollover_list_task.h
+++ b/enforcer-ng/src/keystate/rollover_list_task.h
@@ -34,6 +34,6 @@
 #include "scheduler/task.h"
 
 int perform_rollover_list(int sockfd, engineconfig_type *config,
-	int bverbose);
+	const char *listed_zone);
 
 #endif


### PR DESCRIPTION
Also remove the verbose option as this was not used. And fix a bug where the command wasn't processed properly and always reported too many arguments.

Note this is a re-implementation of the pull request #23 (OPENDNSSEC-184), not a rebase. Once this is merged, that pull request can be closed. 
