### PR TITLE
Feature/opendnssec 619

### DIFF
--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -2772,6 +2772,7 @@ hsm_sign_rrset(hsm_ctx_t *ctx,
         != LDNS_STATUS_OK) {
         ldns_buffer_free(sign_buf);
         /* ERROR */
+        ldns_rr_free(signature);
         return NULL;
     }
 
@@ -2784,6 +2785,7 @@ hsm_sign_rrset(hsm_ctx_t *ctx,
     if (ldns_rr_list2buffer_wire(sign_buf, rrset)
         != LDNS_STATUS_OK) {
         ldns_buffer_free(sign_buf);
+        ldns_rr_free(signature);
         return NULL;
     }
 
@@ -2792,6 +2794,7 @@ hsm_sign_rrset(hsm_ctx_t *ctx,
     ldns_buffer_free(sign_buf);
     if (!b64_rdf) {
         /* signing went wrong */
+        ldns_rr_free(signature);
         return NULL;
     }
 


### PR DESCRIPTION
OPENDNSSEC-619: memory leak when signer failed, solved it by add ldns_rr_free(signature) in libhsm.c
