### PR TITLE
simple-dnskey-mailer.sh: Fix syntax error.

### DIFF
--- a/plugins/simple-dnskey-mailer/simple-dnskey-mailer.sh
+++ b/plugins/simple-dnskey-mailer/simple-dnskey-mailer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (c) 2010 .SE (The Internet Infrastructure Foundation).
 # All rights reserved.
@@ -39,5 +39,4 @@
 
 if [ -n "$RECIPIENT" ]; then
 	cat | mail -s "New keys from OpenDNSSEC" $RECIPIENT
-else
 fi


### PR DESCRIPTION
Remove broken else statement. While here use a more common shell.

Tested on OpenBSD and Ubuntu.
