### PR TITLE
OPENDNSSEC-636:  Attempt to fix broken compile on FreeBSD testing machin...

### DIFF
--- a/enforcer-ng/src/daemon/cfg.h
+++ b/enforcer-ng/src/daemon/cfg.h
@@ -37,6 +37,7 @@
 #include "shared/status.h"
 
 #include <stdio.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/testing/build-opendnssec.sh
+++ b/testing/build-opendnssec.sh
@@ -14,7 +14,6 @@ case "$DISTRIBUTION" in
 		;;
 	netbsd | \
 	freebsd )
-		append_cflags "-std=c99"
 		;;
 	opensuse )
 		append_ldflags "-lncurses -lpthread"


### PR DESCRIPTION
...es,

the unit tests will still fail and compile might still not work due
to missin deps on the system (openjdk, protobug, cppunit, cunit).

- Missing include for FreeBSD to include time_t definition
- -std=c99 apparently used to be necessary, but is not allowed as argument
  to C++.  With the inclusion of some C++ files this argument should not
  be included.  However the build quite works without the -std=c99 build
  flag alltogether on a clean system, so attempting this.