### PR TITLE
do not drop enforce task

### DIFF
--- a/enforcer-ng/src/enforcer/enforce_cmd.c
+++ b/enforcer-ng/src/enforcer/enforce_cmd.c
@@ -86,8 +86,12 @@ run(int sockfd, engine_type* engine, const char *cmd, ssize_t n,
 	task = enforce_task(engine, 1);
 
 	t_next = perform_enforce_lock(sockfd, engine, 1, task, dbconn);
-	reschedule_enforce(task, t_next, "next zone");
-	schedule_task(engine->taskq, task);
+	if (t_next == -1) {
+		task_cleanup(task);
+	} else {
+		reschedule_enforce(task, t_next, "next zone");
+		schedule_task(engine->taskq, task);
+	}
 	return 0;
 }
 

--- a/enforcer-ng/src/enforcer/enforce_task.c
+++ b/enforcer-ng/src/enforcer/enforce_task.c
@@ -136,7 +136,13 @@ perform_enforce(int sockfd, engine_type *engine, int bForceUpdate,
 		/* No zones scheduled for update at this time. We must be
 		 * called out of schedule. Make sure we reset the original
 		 * scheduled time */
-		 t_reschedule = task->when;
+		if (bForceUpdate) {
+			/* we where forced to update so no zone means there are
+			 * no zones at all */
+			t_reschedule = -1;
+		} else {
+			t_reschedule = task->when;
+		}
 	}
 	
 	for (; zone && !engine->need_to_reload && !engine->need_to_exit;

--- a/enforcer-ng/src/enforcer/enforce_task.c
+++ b/enforcer-ng/src/enforcer/enforce_task.c
@@ -130,9 +130,16 @@ perform_enforce(int sockfd, engine_type *engine, int bForceUpdate,
 		/* TODO: backoff? */
 		return t_reschedule;
 	}
+
+	zone = zone_list_get_next(zonelist);
+	if (!zone) {
+		/* No zones scheduled for update at this time. We must be
+		 * called out of schedule. Make sure we reset the original
+		 * scheduled time */
+		 t_reschedule = task->when;
+	}
 	
-	for (zone = zone_list_get_next(zonelist);
-		zone && !engine->need_to_reload && !engine->need_to_exit;
+	for (; zone && !engine->need_to_reload && !engine->need_to_exit;
 		zone_free(zone), zone = zone_list_get_next(zonelist))
 	{
 		if (!bForceUpdate && (zone_next_change(zone) == -1)) {

--- a/enforcer-ng/src/scheduler/schedule.c
+++ b/enforcer-ng/src/scheduler/schedule.c
@@ -333,7 +333,6 @@ schedule_flush_type(schedule_type* schedule, task_id id)
                 if (!node) break; /* stange, bail out */
                 if (node->data) { /* task */
                     ((task_type*)node->data)->flush = 1;
-                    ((task_type*)node->data)->when = 0;
                     if (!ldns_rbtree_insert(schedule->tasks, node)) {
                         ods_log_crit("[%s] Could not reschedule task "
                             "after flush. A task has been lost!",

--- a/enforcer-ng/src/scheduler/task.c
+++ b/enforcer-ng/src/scheduler/task.c
@@ -284,6 +284,12 @@ task_compare(const void* a, const void* b)
 
     ods_log_assert(x);
     ods_log_assert(y);
+
+    /* If a task is set to flush, it should go in front. */
+    if (x->flush != y->flush) {
+        return y->flush - x->flush;
+    }
+
     /* order task on time, dname */
     if (x->when != y->when) {
         return (int) x->when - y->when;


### PR DESCRIPTION
When a task is executed out of schedule and no update is
forced, no zones are iterated. Therefore the enforcer has no
return time and decides to drop the task, no more work needs
to be done.
This fixes the problem by maintaining the original task time if
nothing can be done. 'Flushed' task now sort in front of other
tasks regardless of their due time.