### PR TITLE
Do not set next_change to 0. This is a job of the enforcer_engine.

### DIFF
--- a/enforcer-ng/src/enforcer/enforcer.c
+++ b/enforcer-ng/src/enforcer/enforcer.c
@@ -2926,7 +2926,7 @@ update(engine_type *engine, db_connection_t *dbconn, zone_t *zone, policy_t *pol
     /*
      * Only purge old keys if the policy says so.
      */
-	if (policy_keys_purge_after(policy)) {
+	if (policy_keys_purge_after(policy) && keylist) {
 	    purge_return_time = removeDeadKeys(dbconn, keylist, keylist_size, deplist, now,
 	        policy_keys_purge_after(policy));
 	}

--- a/enforcer-ng/src/keystate/keystate_ds.c
+++ b/enforcer-ng/src/keystate/keystate_ds.c
@@ -345,21 +345,6 @@ change_keys_from_to(db_connection_t *dbconn, int sockfd,
 			break;
 		}
 		key_mod++;
-		if (zone) {
-			if (zone_set_next_change(zone, 0) || zone_update(zone)) {
-				ods_log_error("[%s] error updating zone in DB.", module_str);
-				status = 13;
-			}
-		} else {
-			zone = key_data_get_zone(key);
-			if (zone_set_next_change(zone, 0) || zone_update(zone)) {
-				ods_log_error("[%s] error updating zone in DB.", module_str);
-				status = 15;
-			}
-			zone_free(zone);
-			zone = NULL;
-
-		}
 		key_data_free(key);
 	}
 	key_data_list_free(key_list);


### PR DESCRIPTION
We must make sure the enforce task is flushed however when the ds command
is issued by the user. This fixes display of 1970 epoch dates on
ZSKs.