### PR TITLE
Double stack space for OpenBSD. On i386 OpenBSD has only 256K

### DIFF
--- a/signer/src/daemon/engine.c
+++ b/signer/src/daemon/engine.c
@@ -375,30 +375,70 @@ static void
 engine_start_workers(engine_type* engine)
 {
     size_t i = 0;
+    pthread_attr_t *attr_ptr = NULL;
+
+#if defined(__OpenBSD__) && defined(HAVE_PTHREAD)
+    /* On i386 OpenBSD we have only 256K stack available. This is not
+     * enough to run worker threads with. */
+    pthread_attr_t attr;
+    size_t stacksize;
+    attr_ptr = &attr;
+    if (pthread_attr_init(attr_ptr)
+        || pthread_attr_getstacksize(attr_ptr, &stacksize)
+        || pthread_attr_setstacksize(attr_ptr, stacksize * 2))
+    {
+        ods_log_warning("[%s] Failed to double stackspace for threads.",
+            engine_str);
+       attr_ptr = NULL;
+    }
+#endif /*__OpenBSD__ && HAVE_PTHREAD*/
+
     ods_log_assert(engine);
     ods_log_assert(engine->config);
     ods_log_debug("[%s] start workers", engine_str);
     for (i=0; i < (size_t) engine->config->num_worker_threads; i++) {
         engine->workers[i]->need_to_exit = 0;
         engine->workers[i]->engine = (void*) engine;
-        ods_thread_create(&engine->workers[i]->thread_id, worker_thread_start,
-            engine->workers[i]);
+        ods_thread_create_attr(&engine->workers[i]->thread_id, attr_ptr,
+            worker_thread_start, engine->workers[i]);
     }
+    if (attr_ptr)
+        (void) pthread_attr_destroy(attr_ptr);
     return;
 }
 void
 engine_start_drudgers(engine_type* engine)
 {
     size_t i = 0;
+    pthread_attr_t *attr_ptr = NULL;
+
+#if defined(__OpenBSD__) && defined(HAVE_PTHREAD)
+    /* On i386 OpenBSD we have only 256K stack available. This is not
+     * enough to run worker threads with. */
+    pthread_attr_t attr;
+    size_t stacksize;
+    attr_ptr = &attr;
+    if (pthread_attr_init(attr_ptr)
+        || pthread_attr_getstacksize(attr_ptr, &stacksize)
+        || pthread_attr_setstacksize(attr_ptr, stacksize * 2))
+    {
+        ods_log_warning("[%s] Failed to double stackspace for threads.",
+            engine_str);
+        attr_ptr = NULL;
+    }
+#endif /*__OpenBSD__ && HAVE_PTHREAD*/
+
     ods_log_assert(engine);
     ods_log_assert(engine->config);
     ods_log_debug("[%s] start drudgers", engine_str);
     for (i=0; i < (size_t) engine->config->num_signer_threads; i++) {
         engine->drudgers[i]->need_to_exit = 0;
         engine->drudgers[i]->engine = (void*) engine;
-        ods_thread_create(&engine->drudgers[i]->thread_id, worker_thread_start,
-            engine->drudgers[i]);
+        ods_thread_create_attr(&engine->drudgers[i]->thread_id, attr_ptr,
+            worker_thread_start, engine->drudgers[i]);
     }
+    if (attr_ptr)
+        (void) pthread_attr_destroy(attr_ptr);
     return;
 }
 static void

--- a/signer/src/shared/locks.h
+++ b/signer/src/shared/locks.h
@@ -73,6 +73,7 @@ int ods_thread_wait(cond_basic_type* cond, lock_basic_type* lock, time_t wait);
 typedef pthread_t ods_thread_type;
 /** Pass where to store tread_t in thr. Use default NULL attributes. */
 #define ods_thread_create(thr, func, arg) LOCKRET(pthread_create(thr, NULL, func, arg))
+#define ods_thread_create_attr(thr, attr, func, arg) LOCKRET(pthread_create(thr, attr, func, arg))
 #define ods_thread_detach(thr) LOCKRET(pthread_detach(thr))
 #define ods_thread_self() pthread_self()
 #define ods_thread_join(thr) LOCKRET(pthread_join(thr, NULL))
@@ -99,6 +100,7 @@ typedef int lock_basic_type;
 
 typedef pid_t ods_thread_type;
 #define ods_thread_create(thr, func, arg) ods_thr_fork_create(thr, func, arg)
+#define ods_thread_create_attr(thr, attr, func, arg) ods_thr_fork_create(thr, func, arg)
 #define ods_thread_detach(thr)      /* nop */
 #define ods_thread_self() getpid()
 #define ods_thread_join(thr) ods_thr_fork_wait(thr)


### PR DESCRIPTION
stack space which is not enough for the signerd. Causing mysterious
crashes. Thanks to Patrik Lundin.