### PR TITLE
repair mongreal test

### DIFF
--- a/testing/build-opendnssec-mysql.sh
+++ b/testing/build-opendnssec-mysql.sh
@@ -38,6 +38,7 @@ case "$DISTRIBUTION" in
 	debian | \
 	openbsd | \
 	opensuse | \
+	slackware | \
 	suse )
 		(
 			sh autogen.sh &&

--- a/testing/test-cases.d/enforcer.timeleap.mongrel/conf-mysql.xml
+++ b/testing/test-cases.d/enforcer.timeleap.mongrel/conf-mysql.xml
@@ -10,6 +10,7 @@
 	</RepositoryList>
 	<Common>
 		<Logging>
+			<Verbosity>4</Verbosity>
 			<Syslog><Facility>local0</Facility></Syslog>
 		</Logging>
 		<PolicyFile>@INSTALL_ROOT@/etc/opendnssec/kasp.xml</PolicyFile>
@@ -19,6 +20,7 @@
 		<Datastore><MySQL><Host>localhost</Host><Database>test</Database><Username>test</Username><Password>test</Password></MySQL></Datastore>
 		<Interval>PT3600S</Interval>
 		<AutomaticKeyGenerationPeriod>PT360000S</AutomaticKeyGenerationPeriod>
+		<WorkerThreads>0</WorkerThreads>
 	</Enforcer>
 	<Signer>
 		<WorkingDirectory>@INSTALL_ROOT@/var/opendnssec/signer</WorkingDirectory>

--- a/testing/test-cases.d/enforcer.timeleap.mongrel/test.sh
+++ b/testing/test-cases.d/enforcer.timeleap.mongrel/test.sh
@@ -6,6 +6,10 @@ KEEP_LOG_ON_SUCCESS=0
 WRITE_GOLD=0
 RANGE=`seq 1 200`
 
+if [ -n "$HAVE_MYSQL" ]; then
+	ods_setup_conf conf.xml conf-mysql.xml
+fi &&
+
 ods_reset_env -i &&
 rm -rf base && mkdir base &&
 


### PR DESCRIPTION
- support for building test script under slackware distribution with …mysql
- align conf.xml and mysql version of test script
- make sure the right conf.xml is used for mysql