### PR TITLE
OPENDNSSEC-716

### DIFF
--- a/testing/test-cases-daily.d/enforcer.conf.db_hostname/test.sh
+++ b/testing/test-cases-daily.d/enforcer.conf.db_hostname/test.sh
@@ -17,7 +17,7 @@ ods_reset_env &&
 ods_setup_conf conf.xml conf.xml &&
 
 ! ods_start_enforcer &&
-syslog_waitfor 80 "ods-enforcerd: .*ERROR: unable to connect to database - Can't connect to MySQL server on 'www.opendnssec.org'" &&
+syslog_waitfor 80 "ods-enforcerd: Could not connect to database or database not set up properly." &&
 ! pgrep -u `id -u` 'ods-enforcerd' >/dev/null 2>/dev/null &&
 return 0
 


### PR DESCRIPTION
- Error message changed
  The hostname of the target mysql is not available (because it is not
  known that we are using the mysql driver anymore).
  Note that this is a usability problem.  It makes it harder for the user
  to figure out what is misconfigured.