### PR TITLE
OPENDNSSEC-710

### DIFF
--- a/testing/test-cases-daily.d/general.conf.invalid_logging/test.sh
+++ b/testing/test-cases-daily.d/general.conf.invalid_logging/test.sh
@@ -2,38 +2,56 @@
 
 #TEST: Set logging to a invalid channel and expect failure.
 
-
 if [ -n "$HAVE_MYSQL" ]; then
 	ods_setup_conf conf.xml conf-mysql.xml
 fi &&
 
 ! ods_reset_env &&
-log_grep ods-ksmutil-setup stdout 'Error validating file' &&
-log_grep ods-ksmutil-setup stderr 'element Facility: Relax-NG validity error : Error validating value' &&
-log_grep ods-ksmutil-setup stderr 'element Facility: Relax-NG validity error : Element Facility failed to validate content' &&
+! log_this confcheck-kaspcheck ods-kaspcheck &&
+! log_this confcheck-enforcerd ods-enforcerd --no-daemon &&
+! log_this confcheck-signerd ods-signerd --no-daemon &&
+log_grep confcheck-kaspcheck stdout 'ERROR: .*conf.xml fails to validate' &&
+log_grep confcheck-kaspcheck stderr 'element Logging: Relax-NG validity error.*: Element Common failed to validate content' &&
+log_grep confcheck-enforcerd stderr 'syslog facility local99 not supported, logging to log_daemon' &&
+log_grep confcheck-signerd stderr 'Relax-NG validity error.*' &&
+log_grep confcheck-signerd stderr 'element Logging: Relax-NG validity error.*: Element Common failed to validate content' &&
+
+# It is pretty disputable whether the enforcer should run when it cannot log errors, but it will
+( ods_ods-control_enforcer_stop || true ) &&
 
 if [ -n "$HAVE_MYSQL" ]; then
 	ods_setup_conf conf.xml conf-correct-mysql.xml
 else
 	ods_setup_conf conf.xml conf-correct.xml
 fi &&
+
 ods_reset_env &&
+ods_ods-control_start &&
+
 if [ -n "$HAVE_MYSQL" ]; then
 	ods_setup_conf conf.xml conf-mysql.xml
 else
 	ods_setup_conf conf.xml conf.xml
 fi &&
 
-! ods_start_enforcer &&
-syslog_waitfor 10 'ods-enforcerd: .*Error validating file' &&
-syslog_waitfor 10 'ods-enforcerd: .*Error validating value' &&
-syslog_waitfor 10 'ods-enforcerd: .*Element Facility failed to validate content' &&
-! pgrep -u `id -u` 'ods-enforcerd' >/dev/null 2>/dev/null &&
+# It is unclear whether a reload actually leads to reloading the config file
+# if it does, the signer does not output any sign the configuration is now
+# wrong, nor does the return status of the CLI has an error exit status
+# So the following test succeeds for no reason
+ods-signer reload
 
-! ods_start_signer &&
-# signer does not log anything to syslog if invalid config
-! pgrep -u `id -u` 'ods-signerd' >/dev/null 2>/dev/null &&
+# The enforcer indicates a problem, there are a number of small errors:
+# - The command line utility when run non-interactive does give a
+#   descriptive output message, however a carriage return is missing.
+# - The interactive version gives a generic message that the server
+#   did not accept, but no descriptive message.
+# - The error message output to syslog, is in fact different from the
+#   message when running the enforcerd in non-daemon modus.
+! ods-enforcer update conf
+sleep 60 &&
+syslog_waitfor 10 'ERROR: .*conf.xml fails to validate' &&
 
+ods_ods-control_stop &&
 return 0
 
 ods_kill

--- a/testing/test-cases-daily.d/general.conf.invalid_logging/test.sh
+++ b/testing/test-cases-daily.d/general.conf.invalid_logging/test.sh
@@ -38,7 +38,7 @@ fi &&
 # if it does, the signer does not output any sign the configuration is now
 # wrong, nor does the return status of the CLI has an error exit status
 # So the following test succeeds for no reason
-ods-signer reload
+ods-signer reload &&
 
 # The enforcer indicates a problem, there are a number of small errors:
 # - The command line utility when run non-interactive does give a
@@ -47,7 +47,7 @@ ods-signer reload
 #   did not accept, but no descriptive message.
 # - The error message output to syslog, is in fact different from the
 #   message when running the enforcerd in non-daemon modus.
-! ods-enforcer update conf
+! ods-enforcer update conf &&
 sleep 60 &&
 syslog_waitfor 10 'ERROR: .*conf.xml fails to validate' &&
 


### PR DESCRIPTION
- there is no longer a ksm util that indicates a problem, we can start the
  kaspcheck and the daemons in non-daemon modus.
- the output has changed, and gotten less clear in most cases.
- enforcer will start, even though logging is not available (OPENDNSSEC-689)