### PR TITLE
OPENDNSSEC-755 skip general.repository.multiple_repositories on ubuntu 10

### DIFF
--- a/testing/test-cases-daily.d/general.repository.multiple_repositories/test.sh
+++ b/testing/test-cases-daily.d/general.repository.multiple_repositories/test.sh
@@ -2,10 +2,17 @@
 
 #TEST: Configure 4 repositories and sign a single zone using 2 of these different repositories. 
 
-
 if [ -n "$HAVE_MYSQL" ]; then
 	ods_setup_conf conf.xml conf-mysql.xml
 fi &&
+
+if [ "`uname -n`" = "ubuntu10-ods01" ]; then
+	# OPENDNSSEC-755
+	# This test will fail on old, no longer in LTS Ubuntu 10 machines
+	# due to historic version of libbotan (1.8.2).
+	# see test general.basic.disconnectedksk as well.
+	return 0
+fi
 
 ods_softhsm_init_token 1 "OpenDNSSEC2" "1111" "1111" &&
 ods_softhsm_init_token 2 "OpenDNSSEC3" "2222" "2222" &&


### PR DESCRIPTION
Skip test on ubuntu 10 due to outdated libbotan which cannot
handle multiple repositories (opened multiple times).