### PR TITLE
Without the global ctx "ods-hsmutil test <repo>" would segv

### DIFF
--- a/libhsm/src/bin/hsmtest.c
+++ b/libhsm/src/bin/hsmtest.c
@@ -25,7 +25,6 @@
  */
 
 #include "config.h"
-#include "hsmtest.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -34,7 +33,7 @@
 
 #include "libhsm.h"
 #include <libhsmdns.h>
-
+#include "hsmtest.h"
 
 static int
 hsm_test_sign (hsm_ctx_t *ctx, libhsm_key_t *key, ldns_algorithm alg)
@@ -75,10 +74,8 @@ hsm_test_sign (hsm_ctx_t *ctx, libhsm_key_t *key, ldns_algorithm alg)
 }
 
 static int
-hsm_test_random()
+hsm_test_random(hsm_ctx_t *ctx)
 {
-    hsm_ctx_t *ctx = NULL;
-
     int result;
     unsigned char rnd_buf[1024];
     uint32_t r32;
@@ -107,7 +104,7 @@ hsm_test_random()
 }
 
 int
-hsm_test (const char *repository)
+hsm_test (const char *repository, hsm_ctx_t* ctx)
 {
     int result;
     const unsigned int rsa_keysizes[] = { 512, 768, 1024, 1536, 2048, 4096 };
@@ -122,7 +119,6 @@ hsm_test (const char *repository)
     ldns_algorithm curve;
 #endif
 
-    hsm_ctx_t *ctx = NULL;
     libhsm_key_t *key = NULL;
     char *id;
     int errors = 0;
@@ -391,7 +387,7 @@ hsm_test (const char *repository)
     }
 #endif
 
-    if (hsm_test_random()) {
+    if (hsm_test_random(ctx)) {
         errors++;
     }
 

--- a/libhsm/src/bin/hsmtest.h
+++ b/libhsm/src/bin/hsmtest.h
@@ -28,6 +28,6 @@
 #define HSMTEST_H 1
 
 int
-hsm_test (const char *repository);
+hsm_test (const char *repository, hsm_ctx_t* ctx);
 
 #endif /* HSMTEST_H */

--- a/libhsm/src/bin/hsmutil.c
+++ b/libhsm/src/bin/hsmutil.c
@@ -26,7 +26,6 @@
  */
 
 #include "config.h"
-#include "hsmtest.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -35,6 +34,8 @@
 #include <unistd.h>
 
 #include "libhsm.h"
+#include "hsmtest.h"
+
 #include <libhsmdns.h>
 
 extern hsm_repository_t* parse_conf_repositories(const char* cfgfile);
@@ -514,7 +515,7 @@ cmd_dnskey (int argc, char *argv[])
 }
 
 static int
-cmd_test (int argc, char *argv[])
+cmd_test (int argc, char *argv[], hsm_ctx_t* ctx)
 {
     char *repository = NULL;
 
@@ -524,7 +525,7 @@ cmd_test (int argc, char *argv[])
         argv++;
 
         printf("Testing repository: %s\n\n", repository);
-        int rv = hsm_test(repository);
+        int rv = hsm_test(repository, ctx);
         if (repository) free(repository);
         return rv;
     } else {
@@ -635,7 +636,7 @@ main (int argc, char *argv[])
     } else if (!strcasecmp(argv[0], "test")) {
         argc --;
         argv ++;
-        result = cmd_test(argc, argv);
+        result = cmd_test(argc, argv, ctx);
     } else if (!strcasecmp(argv[0], "info")) {
         argc --;
         argv ++;


### PR DESCRIPTION
Without the global ctx hsmutil test <repo> would segv