### PR TITLE
Don't remove nsec3param but merely mark it as removed!

### DIFF
--- a/signer/src/signer/zone.c
+++ b/signer/src/signer/zone.c
@@ -675,12 +675,14 @@ zone_del_rr(zone_type* zone, ldns_rr* rr, int do_stats)
 /**
  * Delete NSEC3PARAM RRs.
  *
+ * Marks all NSEC3PARAM records as removed.
  */
 ods_status
 zone_del_nsec3params(zone_type* zone)
 {
     domain_type* domain = NULL;
     rrset_type* rrset = NULL;
+    int i;
 
     ods_log_assert(zone);
     ods_log_assert(zone->name);
@@ -700,8 +702,12 @@ zone_del_nsec3params(zone_type* zone)
         return ODS_STATUS_UNCHANGED;
     }
 
-    while(rrset->rr_count) {
-        rrset_del_rr(rrset, 0);
+    /* We don't actually delete the record as we still need the
+     * information in the IXFR. Just set it as removed. The code
+     * inserting the new record may flip this flag when the record
+     * hasn't changed. */
+    for (i=0; i < rrset->rr_count; i++) {
+        rrset->rrs[i].is_removed = 1;
     }
     return ODS_STATUS_OK;
 }


### PR DESCRIPTION
Fixes OpenDNSSEC-778

backport from 2.0