### PR TITLE
SUPPORT-171: assert(soamin)

### DIFF
--- a/signer/src/adapter/addns.c
+++ b/signer/src/adapter/addns.c
@@ -794,7 +794,9 @@ addns_write(void* zone)
         return status;
     }
 
-    if (z->db->is_initialized) {
+    if (z->db->is_initialized && z->ixfr->part[0] &&
+            z->ixfr->part[0]->soamin && z->ixfr->part[0]->soaplus)
+    {
         itmpfile = ods_build_path(z->name, ".ixfr.tmp", 0, 1);
         if (!itmpfile) {
             free((void*) atmpfile);
@@ -851,7 +853,9 @@ addns_write(void* zone)
     axfrfile = NULL;
     atmpfile = NULL;
 
-    if (z->db->is_initialized) {
+    if (z->db->is_initialized  && z->ixfr->part[0] &&
+            z->ixfr->part[0]->soamin && z->ixfr->part[0]->soaplus)
+    {
         ixfrfile = ods_build_path(z->name, ".ixfr", 0, 1);
         if (!ixfrfile) {
             free((void*) axfrfile);

--- a/signer/src/signer/ixfr.c
+++ b/signer/src/signer/ixfr.c
@@ -211,7 +211,7 @@ part_print(FILE* fd, ixfr_type* ixfr, size_t i)
     }
     zone = (zone_type*) ixfr->zone;
     part = ixfr->part[i];
-    if (!part) {
+    if (!part || !part->soamin || !part->soaplus) {
         return;
     }
     ods_log_assert(part->min);

--- a/signer/src/signer/ixfr.c
+++ b/signer/src/signer/ixfr.c
@@ -266,6 +266,17 @@ ixfr_purge(ixfr_type* ixfr)
     if (!ixfr) {
         return;
     }
+
+    if (ixfr->part[0] &&
+        (!ixfr->part[0]->soamin || !ixfr->part[0]->soaplus))
+    {
+        /* Somehow the signer does a double purge without having used
+         * this part. There is no need to create a new one. In fact,
+         * we should not. It would cause an assertion later on when
+         * printing to file */
+        return;
+    }
+
     zone = (zone_type*) ixfr->zone;
     ods_log_assert(zone);
     ods_log_debug("[%s] purge ixfr for zone %s", ixfr_str, zone->name);


### PR DESCRIPTION
The is_initialized flag is abused to see if a ixfr has been made yet.
Now explicitely check on soamin and soaplus