### PR TITLE
SUPPORT-171: assert(soamin)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ OpenDNSSEC 1.4.x - 2016-xx-xx
 Bugfixes:
  * After a resalt the signer would fail to remove the old NSEC3PARAM RR until
    a manual resign or incoming transfer.
+ * SUPPORT-171: Signer would sometimes hit an assertion using DNS output 
+   adapter when .ixfr was missing or corrupt but .backup file available.
 
 OpenDNSSEC 1.4.9 - 2016-01-21
 

--- a/signer/src/adapter/addns.c
+++ b/signer/src/adapter/addns.c
@@ -840,7 +840,9 @@ addns_write(void* zone)
         return status;
     }
 
-    if (z->db->is_initialized) {
+    if (z->db->is_initialized && z->ixfr->part[0] &&
+            z->ixfr->part[0]->soamin && z->ixfr->part[0]->soaplus)
+    {
         itmpfile = ods_build_path(z->name, ".ixfr.tmp", 0, 1);
         if (!itmpfile) {
             free((void*) atmpfile);
@@ -897,7 +899,9 @@ addns_write(void* zone)
     axfrfile = NULL;
     atmpfile = NULL;
 
-    if (z->db->is_initialized) {
+    if (z->db->is_initialized  && z->ixfr->part[0] &&
+            z->ixfr->part[0]->soamin && z->ixfr->part[0]->soaplus)
+    {
         ixfrfile = ods_build_path(z->name, ".ixfr", 0, 1);
         if (!ixfrfile) {
             free((void*) axfrfile);

--- a/signer/src/signer/ixfr.c
+++ b/signer/src/signer/ixfr.c
@@ -222,7 +222,7 @@ part_print(FILE* fd, ixfr_type* ixfr, size_t i)
     }
     zone = (zone_type*) ixfr->zone;
     part = ixfr->part[i];
-    if (!part) {
+    if (!part || !part->soamin || !part->soaplus) {
         return;
     }
     ods_log_assert(part->min);

--- a/signer/src/signer/ixfr.c
+++ b/signer/src/signer/ixfr.c
@@ -279,6 +279,17 @@ ixfr_purge(ixfr_type* ixfr)
     if (!ixfr) {
         return;
     }
+
+    if (ixfr->part[0] &&
+        (!ixfr->part[0]->soamin || !ixfr->part[0]->soaplus))
+    {
+        /* Somehow the signer does a double purge without having used
+         * this part. There is no need to create a new one. In fact,
+         * we should not. It would cause an assertion later on when
+         * printing to file */
+        return;
+    }
+
     zone = (zone_type*) ixfr->zone;
     ods_log_assert(zone);
     ods_log_assert(zone->allocator);


### PR DESCRIPTION
The is_initialized flag is abused to see if a ixfr has been made yet.
Now explicitely check on soamin and soaplus