### PR TITLE
Open dnssec 725 waiting notify broken pipe

### DIFF
--- a/signer/src/adapter/addns.c
+++ b/signer/src/adapter/addns.c
@@ -797,7 +797,9 @@ addns_write(void* zone)
         return status;
     }
 
-    if (z->db->is_initialized) {
+    if (z->db->is_initialized && z->ixfr->part[0] &&
+            z->ixfr->part[0]->soamin && z->ixfr->part[0]->soaplus)
+    {
         itmpfile = ods_build_path(z->name, ".ixfr.tmp", 0, 1);
         if (!itmpfile) {
             free((void*) atmpfile);
@@ -854,7 +856,9 @@ addns_write(void* zone)
     axfrfile = NULL;
     atmpfile = NULL;
 
-    if (z->db->is_initialized) {
+    if (z->db->is_initialized  && z->ixfr->part[0] &&
+            z->ixfr->part[0]->soamin && z->ixfr->part[0]->soaplus)
+    {
         ixfrfile = ods_build_path(z->name, ".ixfr", 0, 1);
         if (!ixfrfile) {
             free((void*) axfrfile);

--- a/signer/src/adapter/addns.c
+++ b/signer/src/adapter/addns.c
@@ -640,7 +640,10 @@ dnsout_update(dnsout_type** addns, const char* filename, time_t* last_mod)
     } else {
         ods_log_error("[%s] unable to update dnsout: dnsout_read(%s) "
             "failed (%s)", adapter_str, filename, ods_status2str(status));
-        dnsout_cleanup(*addns);
+        /* Don't do this cleanup. Signer will crash on exit and will
+         * access the wrong memory runtime. Leak is only once per badly
+         * configured adapter. */
+        /* dnsout_cleanup(*addns); */
     }
     return status;
 }

--- a/signer/src/daemon/engine.c
+++ b/signer/src/daemon/engine.c
@@ -474,6 +474,7 @@ engine_setup(engine_type* engine)
         if (status != ODS_STATUS_OK) {
             ods_log_error("[%s] setup: unable to listen to sockets (%s)",
                 engine_str, ods_status2str(status));
+            return ODS_STATUS_XFRHANDLER_ERR;
         }
     }
     /* privdrop */

--- a/signer/src/signer/zone.c
+++ b/signer/src/signer/zone.c
@@ -674,12 +674,14 @@ zone_del_rr(zone_type* zone, ldns_rr* rr, int do_stats)
 /**
  * Delete NSEC3PARAM RRs.
  *
+ * Marks all NSEC3PARAM records as removed.
  */
 ods_status
 zone_del_nsec3params(zone_type* zone)
 {
     domain_type* domain = NULL;
     rrset_type* rrset = NULL;
+    int i;
 
     ods_log_assert(zone);
     ods_log_assert(zone->name);
@@ -699,8 +701,12 @@ zone_del_nsec3params(zone_type* zone)
         return ODS_STATUS_UNCHANGED;
     }
 
-    while(rrset->rr_count) {
-        rrset_del_rr(rrset, 0);
+    /* We don't actually delete the record as we still need the
+     * information in the IXFR. Just set it as removed. The code
+     * inserting the new record may flip this flag when the record
+     * hasn't changed. */
+    for (i=0; i < rrset->rr_count; i++) {
+        rrset->rrs[i].is_removed = 1;
     }
     return ODS_STATUS_OK;
 }

--- a/signer/src/wire/notify.c
+++ b/signer/src/wire/notify.c
@@ -535,12 +535,12 @@ notify_enable(notify_type* notify, ldns_rr* soa)
             zone->name);
         return; /* nothing to do */
     }
-    notify_update_soa(notify, soa);
-    if (notify->is_waiting) {
+    if (notify->is_waiting || notify->handler.fd != -1) {
         ods_log_debug("[%s] zone %s already on waiting list", notify_str,
             zone->name);
        return;
     }
+    notify_update_soa(notify, soa);
     if (xfrhandler->notify_udp_num < NOTIFY_MAX_UDP) {
         notify_setup(notify);
         xfrhandler->notify_udp_num++;


### PR DESCRIPTION
This also fixes a bug where if 2 resigns would follow up quicker than the outgoing notifies being processed the notify would wait forever (if the servers response was lost). Potentially clogging up the ixfr queue forever.