### PR TITLE
OPENDNSSEC-798 improper use of key handles across hsm reopen (2.0)

### DIFF
--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -687,7 +687,6 @@ hsm_ctx_new()
 static void
 hsm_ctx_free(hsm_ctx_t *ctx)
 {
-    struct keycache_struct* next;
     unsigned int i;
     if (ctx) {
         for (i = 0; i < ctx->session_count; i++) {
@@ -2824,7 +2823,7 @@ libhsm_key_list_free(libhsm_key_t **key_list, size_t count)
 {
     size_t i;
     for (i = 0; i < count; i++) {
-        free((char*)key_list[i]->modulename);
+        free((void*)key_list[i]->modulename);
         free(key_list[i]);
     }
     free(key_list);
@@ -3328,6 +3327,7 @@ keycache_cmpfunc(const void* a, const void* b)
 static void
 keycache_delfunc(ldns_rbnode_t* node, void* cargo)
 {
+    (void)cargo;
     free((void*)node->key);
     free((void*)node->data);
 }

--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -3351,17 +3351,20 @@ keycache_lookup(hsm_ctx_t* ctx, const char* locator)
     ldns_rbnode_t* node;
 
     node = ldns_rbtree_search(ctx->keycache, locator);
-    if (node == NULL) {
+    if (node == LDNS_RBTREE_NULL || node == NULL) {
         libhsm_key_t* key;
         if ((key = hsm_find_key_by_id(ctx, locator)) == NULL) {
-            return NULL;
+            node = NULL;
+        } else {
+            node = malloc(sizeof(ldns_rbnode_t));
+            node->key = strdup(locator);
+            node->data = key;
+            node = ldns_rbtree_insert(ctx->keycache, node);
         }
-
-        node = malloc(sizeof(ldns_rbnode_t));
-        node->key = strdup(locator);
-        node->data = key;
-        ldns_rbtree_insert(ctx->keycache, node);
     }  
 
-    return node->key;
+    if (node == LDNS_RBTREE_NULL)
+        return NULL;
+    else
+        return node->data;
 }

--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -677,6 +677,7 @@ hsm_ctx_new()
         memset(ctx->session, 0, HSM_MAX_SESSIONS);
         ctx->session_count = 0;
         ctx->error = 0;
+        ctx->keycache = NULL;
     }
     return ctx;
 }
@@ -685,12 +686,20 @@ hsm_ctx_new()
 static void
 hsm_ctx_free(hsm_ctx_t *ctx)
 {
+    struct keycache_struct* next;
     unsigned int i;
     if (ctx) {
         for (i = 0; i < ctx->session_count; i++) {
             hsm_session_free(ctx->session[i]);
         }
         free(ctx);
+    }
+    
+    while(ctx->keycache != NULL) {
+        next = ctx->keycache->next;
+        free((void*)ctx->keycache->id);
+        free((void*)ctx->keycache);
+        ctx->keycache = next;
     }
 }
 

--- a/libhsm/src/lib/libhsm.h
+++ b/libhsm/src/lib/libhsm.h
@@ -124,12 +124,6 @@ struct hsm_repository_struct {
     uint8_t use_pubkey;     /*!< use public keys in repository? */
 };
 
-struct keycache_struct {
-    struct keycache_struct* next;
-    const char* id;
-    libhsm_key_t* cached;
-};
-
 /*! HSM context to keep track of sessions */
 typedef struct {
     hsm_session_t *session[HSM_MAX_SESSIONS];  /*!< HSM sessions */

--- a/libhsm/src/lib/libhsm.h
+++ b/libhsm/src/lib/libhsm.h
@@ -123,6 +123,11 @@ struct hsm_repository_struct {
     uint8_t use_pubkey;     /*!< use public keys in repository? */
 };
 
+struct keycache_struct {
+    struct keycache_struct* next;
+    const char* id;
+    libhsm_key_t* cached;
+};
 
 /*! HSM context to keep track of sessions */
 typedef struct {
@@ -138,6 +143,8 @@ typedef struct {
 
     /*!< static string describing the first error */
     char error_message[HSM_ERROR_MSGSIZE];
+    
+    struct keycache_struct* keycache;
 } hsm_ctx_t;
 
 

--- a/libhsm/src/lib/libhsm.h
+++ b/libhsm/src/lib/libhsm.h
@@ -29,6 +29,7 @@
 #define HSM_H 1
 
 #include <stdint.h>
+#include <ldns/rbtree.h>
 
 #define HSM_MAX_SESSIONS 100
 /* 
@@ -144,7 +145,7 @@ typedef struct {
     /*!< static string describing the first error */
     char error_message[HSM_ERROR_MSGSIZE];
     
-    struct keycache_struct* keycache;
+    ldns_rbtree_t* keycache;
 } hsm_ctx_t;
 
 
@@ -534,5 +535,12 @@ void hsm_print_ctx(hsm_ctx_t *ctx);
 void hsm_print_key(hsm_ctx_t *ctx, libhsm_key_t *key);
 void hsm_print_error(hsm_ctx_t *ctx);
 void hsm_print_tokeninfo(hsm_ctx_t *ctx);
+
+/* implementation of a key cache per context, needs changing see
+ * OPENDNSSEC-799.
+ */
+extern void keycache_create(hsm_ctx_t* ctx);
+extern void keycache_destroy(hsm_ctx_t* ctx);
+extern const libhsm_key_t* keycache_lookup(hsm_ctx_t* ctx, const char* locator);
 
 #endif /* HSM_H */

--- a/signer/src/hsm.c
+++ b/signer/src/hsm.c
@@ -32,8 +32,11 @@
 #include "daemon/engine.h"
 #include "hsm.h"
 #include "log.h"
+#include "cryptoki_compat/pkcs11.h"
 
 static const char* hsm_str = "hsm";
+
+extern libhsm_key_t* getkey2(hsm_ctx_t* ctx, const char* locator);
 
 /**
  * Clear key cache.
@@ -48,10 +51,6 @@ lhsm_clear_key_cache(key_type* key)
     if (key->dnskey) {
         /* DNSKEY still exists in zone */
         key->dnskey = NULL;
-    }
-    if (key->hsmkey) {
-        free(key->hsmkey);
-        key->hsmkey = NULL;
     }
     if (key->params) {
         hsm_sign_params_free(key->params);
@@ -100,28 +99,9 @@ llibhsm_key_start:
             return ODS_STATUS_ERR;
         }
     }
-    /* lookup key */
-    if (!key_id->hsmkey) {
-        key_id->hsmkey = hsm_find_key_by_id(ctx, key_id->locator);
-    }
-    if (!key_id->hsmkey) {
-        error = hsm_get_error(ctx);
-        if (error) {
-            ods_log_error("[%s] %s", hsm_str, error);
-            free((void*)error);
-        } else if (!retries) {
-            lhsm_clear_key_cache(key_id);
-            retries++;
-            goto llibhsm_key_start;
-        }
-        /* could not find key */
-        ods_log_error("[%s] unable to get key: key %s not found", hsm_str,
-            key_id->locator?key_id->locator:"(null)");
-        return ODS_STATUS_ERR;
-    }
     /* get dnskey */
     if (!key_id->dnskey) {
-        key_id->dnskey = hsm_get_dnskey(ctx, key_id->hsmkey, key_id->params);
+        key_id->dnskey = hsm_get_dnskey(ctx, getkey2(ctx, key_id->locator), key_id->params);
     }
     if (!key_id->dnskey) {
         error = hsm_get_error(ctx);
@@ -160,7 +140,6 @@ lhsm_sign(hsm_ctx_t* ctx, ldns_rr_list* rrset, key_type* key_id,
         return NULL;
     }
     ods_log_assert(key_id->dnskey);
-    ods_log_assert(key_id->hsmkey);
     ods_log_assert(key_id->params);
     /* adjust parameters */
     params = hsm_sign_params_new();
@@ -173,7 +152,7 @@ lhsm_sign(hsm_ctx_t* ctx, ldns_rr_list* rrset, key_type* key_id,
     ods_log_deeebug("[%s] sign RRset[%i] with key %s tag %u", hsm_str,
         ldns_rr_get_type(ldns_rr_list_rr(rrset, 0)),
         key_id->locator?key_id->locator:"(null)", params->keytag);
-    result = hsm_sign_rrset(ctx, rrset, key_id->hsmkey, params);
+    result = hsm_sign_rrset(ctx, rrset, getkey2(ctx, key_id->locator), params);
     hsm_sign_params_free(params);
     if (!result) {
         error = hsm_get_error(ctx);
@@ -184,4 +163,39 @@ lhsm_sign(hsm_ctx_t* ctx, ldns_rr_list* rrset, key_type* key_id,
         ods_log_crit("[%s] error signing rrset with libhsm", hsm_str);
     }
     return result;
+}
+
+libhsm_key_t*
+getkey2(hsm_ctx_t* ctx, const char* locator)
+{
+    libhsm_key_t* key;
+    struct keycache_struct* ptr;
+    
+    ptr = ctx->keycache;
+    while (ptr) {
+        if(!strcmp(locator, ptr->id)) {
+            return ptr->cached;
+        } else {
+            ptr = ptr->next;
+        }
+    }
+    
+    if((key = hsm_find_key_by_id(ctx, locator)) == NULL) {
+        char* error = hsm_get_error(ctx);
+        if (error) {
+            ods_log_error("[%s] %s", hsm_str, error);
+            free((void*)error);
+        }
+        /* could not find key */
+        ods_log_error("[%s] unable to get key: key %s not found", hsm_str, locator);
+        return NULL;
+    }
+    
+    ptr = malloc(sizeof(struct keycache_struct));
+    ptr->id = strdup(locator);
+    ptr->cached = key;
+    ptr->next = ctx->keycache;
+    ctx->keycache = ptr;
+
+    return key;
 }

--- a/signer/src/hsm.c
+++ b/signer/src/hsm.c
@@ -36,8 +36,6 @@
 
 static const char* hsm_str = "hsm";
 
-extern libhsm_key_t* getkey2(hsm_ctx_t* ctx, const char* locator);
-
 /**
  * Clear key cache.
  *
@@ -56,6 +54,23 @@ lhsm_clear_key_cache(key_type* key)
         hsm_sign_params_free(key->params);
         key->params = NULL;
     }
+}
+
+static const libhsm_key_t*
+keylookup(hsm_ctx_t* ctx, const char* locator)
+{
+    const libhsm_key_t* key;
+    key = keycache_lookup(ctx, locator);
+    if (key == NULL) {
+        char* error = hsm_get_error(ctx);
+            if (error) {
+                ods_log_error("[%s] %s", hsm_str, error);
+                free((void*)error);
+            }
+            /* could not find key */
+            ods_log_error("[%s] unable to get key: key %s not found", hsm_str, locator);
+    }
+    return key;
 }
 
 /**
@@ -101,7 +116,7 @@ llibhsm_key_start:
     }
     /* get dnskey */
     if (!key_id->dnskey) {
-        key_id->dnskey = hsm_get_dnskey(ctx, getkey2(ctx, key_id->locator), key_id->params);
+        key_id->dnskey = hsm_get_dnskey(ctx, keylookup(ctx, key_id->locator), key_id->params);
     }
     if (!key_id->dnskey) {
         error = hsm_get_error(ctx);
@@ -152,7 +167,7 @@ lhsm_sign(hsm_ctx_t* ctx, ldns_rr_list* rrset, key_type* key_id,
     ods_log_deeebug("[%s] sign RRset[%i] with key %s tag %u", hsm_str,
         ldns_rr_get_type(ldns_rr_list_rr(rrset, 0)),
         key_id->locator?key_id->locator:"(null)", params->keytag);
-    result = hsm_sign_rrset(ctx, rrset, getkey2(ctx, key_id->locator), params);
+    result = hsm_sign_rrset(ctx, rrset, keylookup(ctx, key_id->locator), params);
     hsm_sign_params_free(params);
     if (!result) {
         error = hsm_get_error(ctx);
@@ -163,39 +178,4 @@ lhsm_sign(hsm_ctx_t* ctx, ldns_rr_list* rrset, key_type* key_id,
         ods_log_crit("[%s] error signing rrset with libhsm", hsm_str);
     }
     return result;
-}
-
-libhsm_key_t*
-getkey2(hsm_ctx_t* ctx, const char* locator)
-{
-    libhsm_key_t* key;
-    struct keycache_struct* ptr;
-    
-    ptr = ctx->keycache;
-    while (ptr) {
-        if(!strcmp(locator, ptr->id)) {
-            return ptr->cached;
-        } else {
-            ptr = ptr->next;
-        }
-    }
-    
-    if((key = hsm_find_key_by_id(ctx, locator)) == NULL) {
-        char* error = hsm_get_error(ctx);
-        if (error) {
-            ods_log_error("[%s] %s", hsm_str, error);
-            free((void*)error);
-        }
-        /* could not find key */
-        ods_log_error("[%s] unable to get key: key %s not found", hsm_str, locator);
-        return NULL;
-    }
-    
-    ptr = malloc(sizeof(struct keycache_struct));
-    ptr->id = strdup(locator);
-    ptr->cached = key;
-    ptr->next = ctx->keycache;
-    ctx->keycache = ptr;
-
-    return key;
 }

--- a/signer/src/signer/keys.c
+++ b/signer/src/signer/keys.c
@@ -118,7 +118,6 @@ keylist_push(keylist_type* kl, const char* locator, const char* resourcerecord,
     kl->keys[kl->count -1].ksk = ksk;
     kl->keys[kl->count -1].zsk = zsk;
     kl->keys[kl->count -1].dnskey = NULL;
-    kl->keys[kl->count -1].hsmkey = NULL;
     kl->keys[kl->count -1].params = NULL;
     return &kl->keys[kl->count -1];
 }
@@ -168,7 +167,6 @@ key_delfunc(key_type* key)
         return;
     }
     /* ldns_rr_free(key->dnskey); */
-    free(key->hsmkey);
     hsm_sign_params_free(key->params);
     free((void*) key->locator);
 }

--- a/signer/src/signer/keys.h
+++ b/signer/src/signer/keys.h
@@ -49,7 +49,6 @@ typedef struct keylist_struct keylist_type;
  */
 struct key_struct {
     ldns_rr* dnskey;
-    libhsm_key_t* hsmkey;
     hsm_sign_params_t* params;
     const char* locator;
     const char* resourcerecord;

--- a/signer/src/signer/zone.c
+++ b/signer/src/signer/zone.c
@@ -454,7 +454,6 @@ zone_prepare_keys(zone_type* zone)
             break;
         }
         ods_log_assert(zone->signconf->keys->keys[i].dnskey);
-        ods_log_assert(zone->signconf->keys->keys[i].hsmkey);
         ods_log_assert(zone->signconf->keys->keys[i].params);
     }
     /* done */


### PR DESCRIPTION
between re-opening HSM, perhaps even between completely logging
in again.  Therefor there is an architectural error, keys cannot
be stored stable in the zone!  This should change and we should
obtain the set of keys before starting to sign a zone, and do
away with them afterwards.  This ensures they are not used outside
of an hsm context.  This change is not feasable now.  We can
remove the HSM part of the keys effectively from the zone but we
cannot carry them around.  So for now make a cache of keys in
the hsm context.  This has major drawbacks, it is slower
and will leak memory as the HSM keys are not deallocated when
they are effectively no longer in use.  The latter will only
become severe when doing many rollbacks.

First simple implementation of the cache as a linked list.