### PR TITLE
Fix build warnings spotted on OpenBSD.

### DIFF
--- a/enforcer/utils/ksmutil.c
+++ b/enforcer/utils/ksmutil.c
@@ -6878,7 +6878,7 @@ int ListKeys(int zone_id)
     hsm_key_t *key = NULL;
     ldns_rr *dnskey_rr = NULL;
     hsm_sign_params_t *sign_params = NULL;
-    hsm_ctx_t* ctx;
+    hsm_ctx_t* ctx = NULL;
 
     if (verbose_flag) {
         /* connect to the HSM */

--- a/signer/src/signer/zone.c
+++ b/signer/src/signer/zone.c
@@ -571,7 +571,7 @@ zone_add_rr(zone_type* zone, ldns_rr* rr, int do_stats)
     rr_type* record = NULL;
     ods_status status = ODS_STATUS_OK;
     char* str = NULL;
-    int i;
+    size_t i;
 
     ods_log_assert(rr);
     ods_log_assert(zone);
@@ -694,7 +694,7 @@ zone_del_nsec3params(zone_type* zone)
 {
     domain_type* domain = NULL;
     rrset_type* rrset = NULL;
-    int i;
+    size_t i;
 
     ods_log_assert(zone);
     ods_log_assert(zone->name);


### PR DESCRIPTION
ksmutil.c:6881: warning: 'ctx' may be used uninitialized in this function
signer/zone.c:627: warning: comparison between signed and unsigned
signer/zone.c:721: warning: comparison between signed and unsigned