### PR TITLE
OPENDNSSEC-776, OPENDNSSEC-53

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ AC_CHECK_MEMBER([struct sockaddr_un.sun_len],
 
 # common dependencies
 ACX_LIBXML2
-ACX_LDNS(1,6,12)
+ACX_LDNS(1,6,17)
 ACX_LDNS_NOT(1,6,14, [binary incompatibility, see http://open.nlnetlabs.nl/pipermail/ldns-users/2012-October/000564.html])
 ACX_LDNS_NOT(1,6,15, [fail to create NSEC3 bitmap for empty non-terminals, see http://www.nlnetlabs.nl/pipermail/ldns-users/2012-November/000565.html])
 ACX_PKCS11_MODULES

--- a/enforcer/src/keystate/zone_add_cmd.c
+++ b/enforcer/src/keystate/zone_add_cmd.c
@@ -75,9 +75,9 @@ help(int sockfd)
         "policy		name of the policy, if not set the default policy is used\n"
         "signerconf	specify a location for signer configuration file, default is /var/opendnssec/signconf/\n"
         "in-type		specify the type of input, should be DNS or File, default is File \n"
-        "input		specify a location for the unsigned zone, this location is set in conf.xml, default for FileAdapter is /var/opendnssec/unsigned/ \n"
+        "input		specify a location for the unsigned zone, this location is set in conf.xml, default for File Adapter is /var/opendnssec/unsigned/ and for DNS Adapter is /etc/opendnssec/addns.xml \n"
         "out-type	specify the type of output, should be DNS or File, default is File\n"
-        "output		specify a location for the signed zone, this location is set in conf.xml, default path for File Adapter is /var/opendnssec/signed/ \n"
+        "output		specify a location for the signed zone, this location is set in conf.xml, default path for File Adapter is /var/opendnssec/signed/ and for DNS Adapter is /etc/opendnssec/addns.xml \n"
         "xml		update the zonelist.xml file\n"
         "suspend		suspend this zone until running enforce command\n\n"
     );
@@ -169,8 +169,18 @@ run(int sockfd, engine_type* engine, const char *cmd, ssize_t n,
     if (zone_set_policy_id(zone, policy_id(policy))) {
         client_printf_err(sockfd, "Unable to add zone, failed to set policy!\n");
     }
-    if (input_type && zone_set_input_adapter_type(zone, input_type)) {
-        client_printf_err(sockfd, "Unable to add zone, failed to set input type!\n");
+    if (input_type) {
+        if (!strcasecmp(input_type, "DNS"))
+            input_type = "DNS";
+        else if (!strcasecmp(input_type, "File"))
+            input_type = "File";
+        else {
+            client_printf_err(sockfd, "Unable to add zone, %s is not a valid input type! in_type must be File or DNS.\n", input_type);
+            return 1;
+        }
+        if (zone_set_input_adapter_type(zone, input_type)) {
+            client_printf_err(sockfd, "Unable to add zone, failed to set input type!\n");
+        }
     }
     if (input) {
         if (input[0] == '/') {
@@ -179,38 +189,60 @@ run(int sockfd, engine_type* engine, const char *cmd, ssize_t n,
             }
         }
         else {
-            if (snprintf(path, sizeof(path), "%s/unsigned/%s", OPENDNSSEC_STATE_DIR, input) >= (int)sizeof(path)
+            if (input_type && !strcasecmp(input_type, "DNS")) {
+                if (snprintf(path, sizeof(path), "%s/%s", OPENDNSSEC_CONFIG_DIR, input) >= (int)sizeof(path)
+                    || zone_set_input_adapter_uri(zone, path))
+                {
+                    client_printf_err(sockfd, "Unable to add zone, failed to set input!\n");
+                }
+            }
+            else {
+                if (snprintf(path, sizeof(path), "%s/unsigned/%s", OPENDNSSEC_STATE_DIR, input) >= (int)sizeof(path)
+                    || zone_set_input_adapter_uri(zone, path))
+                {
+                    client_printf_err(sockfd, "Unable to add zone, failed to set input!\n");
+                }
+            }
+        }
+    }
+    else {
+        if (input_type && !strcasecmp(input_type, "DNS")) {
+            if (snprintf(path, sizeof(path), "%s/addns.xml", OPENDNSSEC_CONFIG_DIR) >= (int)sizeof(path)
                 || zone_set_input_adapter_uri(zone, path))
             {
                 client_printf_err(sockfd, "Unable to add zone, failed to set input!\n");
             }
-	    if (access(path, F_OK) == -1) {
-		client_printf_err(sockfd, "WARNING: The input file %s for zone %s does not currently exist. The zone will be added to the database anyway. \n", path, zone_name);
-		ods_log_warning("[%s] WARNING: The input file %s for zone %s does not currently exist. The zone will be added to the database anyway.", module_str, path, zone_name);
-	    }
-	    else if (access(path, R_OK)) {
-		client_printf_err(sockfd, "WARNING: Read access to input file %s for zone %s denied! \n ", path, zone_name);
-		ods_log_warning("[%s] WARNING: Read access to input file %s for zone %s denied! ", module_str, path, zone_name);
-	    }	    
+        }
+        else {
+            if (snprintf(path, sizeof(path), "%s/unsigned/%s", OPENDNSSEC_STATE_DIR, zone_name) >= (int)sizeof(path)
+                || zone_set_input_adapter_uri(zone, path))
+            {
+                client_printf_err(sockfd, "Unable to add zone, failed to set input!\n");
+            }
         }
     }
-    else {
-        if (snprintf(path, sizeof(path), "%s/unsigned/%s", OPENDNSSEC_STATE_DIR, zone_name) >= (int)sizeof(path)
-            || zone_set_input_adapter_uri(zone, path))
-        {
-            client_printf_err(sockfd, "Unable to add zone, failed to set input!\n");
-        }
-        if (access(path, F_OK) == -1) {
-            client_printf_err(sockfd, "WARNING: The input file %s for zone %s does not currently exist. The zone will be added to the database anyway. \n", path, zone_name);
-	    ods_log_warning("[%s] WARNING: The input file %s for zone %s does not currently exist. The zone will be added to the database anyway. ", module_str, path, zone_name);
-	}
-        else if (access(path, R_OK)) {
-            client_printf_err(sockfd, "WARNING: Read access to input file %s for zone %s denied! \n ", path, zone_name);
-	    ods_log_warning("[%s] WARNING: Read access to input file %s for zone %s denied! ", module_str, path, zone_name);
-        }
+    client_printf(sockfd, "input is set to %s. \n", zone_input_adapter_uri(zone));
+    if (access(zone_input_adapter_uri(zone), F_OK) == -1) {
+        client_printf_err(sockfd, "WARNING: The input file %s for zone %s does not currently exist. The zone will be added to the database anyway. \n", zone_input_adapter_uri(zone), zone_name);
+        ods_log_warning("[%s] WARNING: The input file %s for zone %s does not currently exist. The zone will be added to the database anyway.", module_str, zone_input_adapter_uri(zone), zone_name);
     }
-    if (output_type && zone_set_output_adapter_type(zone, output_type)) {
-        client_printf_err(sockfd, "Unable to add zone, failed to set output type!\n");
+    else if (access(zone_input_adapter_uri(zone), R_OK)) {
+        client_printf_err(sockfd, "WARNING: Read access to input file %s for zone %s denied! \n ", zone_input_adapter_uri(zone), zone_name);
+        ods_log_warning("[%s] WARNING: Read access to input file %s for zone %s denied! ", module_str, zone_input_adapter_uri(zone), zone_name);
+    }
+
+    if (output_type) {
+        if (!strcasecmp(output_type, "DNS"))
+            output_type = "DNS";
+        else if (!strcasecmp(output_type, "File"))
+            output_type = "File";
+        else {
+            client_printf_err(sockfd, "Unable to add zone, %s is not a valid output type! out_type must be File or DNS.\n", output_type);
+            return 1;
+        }
+        if (zone_set_output_adapter_type(zone, output_type)) {
+            client_printf_err(sockfd, "Unable to add zone, failed to set output type!\n");
+        }
     }
     if (output) {
         if (output[0] == '/') {
@@ -219,20 +251,51 @@ run(int sockfd, engine_type* engine, const char *cmd, ssize_t n,
             }
         }
         else {
-            if (snprintf(path, sizeof(path), "%s/signed/%s", OPENDNSSEC_STATE_DIR, output) >= (int)sizeof(path)
+            if (output_type && !strcasecmp(output_type, "DNS")) {
+                if (snprintf(path, sizeof(path), "%s/%s", OPENDNSSEC_CONFIG_DIR, output) >= (int)sizeof(path)
+                || zone_set_output_adapter_uri(zone, path))
+                {
+                    client_printf_err(sockfd, "Unable to add zone, failed to set output!\n");
+                }
+            }
+	    else {
+                if (snprintf(path, sizeof(path), "%s/signed/%s", OPENDNSSEC_STATE_DIR, output) >= (int)sizeof(path)
+                    || zone_set_output_adapter_uri(zone, path))
+                {
+                    client_printf_err(sockfd, "Unable to add zone, failed to set output!\n");
+                }
+            }
+        }
+    }
+    else {
+        if(output_type && !strcasecmp(output_type, "DNS")) {
+            if (snprintf(path, sizeof(path), "%s/addns.xml", OPENDNSSEC_CONFIG_DIR) >= (int)sizeof(path)
+            || zone_set_output_adapter_uri(zone, path))
+            {
+                client_printf_err(sockfd, "Unable to add zone, failed to set output!\n");
+            }
+        }
+        else {
+            if (snprintf(path, sizeof(path), "%s/signed/%s", OPENDNSSEC_STATE_DIR, zone_name) >= (int)sizeof(path)
                 || zone_set_output_adapter_uri(zone, path))
             {
                 client_printf_err(sockfd, "Unable to add zone, failed to set output!\n");
             }
         }
     }
-    else {
-        if (snprintf(path, sizeof(path), "%s/signed/%s", OPENDNSSEC_STATE_DIR, zone_name) >= (int)sizeof(path)
-            || zone_set_output_adapter_uri(zone, path))
-        {
-            client_printf_err(sockfd, "Unable to add zone, failed to set output!\n");
+
+    client_printf(sockfd, "output is set to %s. \n", zone_output_adapter_uri(zone));
+    if (output_type && !strcasecmp(output_type, "DNS")) {
+        if (access(zone_output_adapter_uri(zone), F_OK) == -1) {
+            client_printf_err(sockfd, "WARNING: The output file %s for zone %s does not currently exist. The zone will be added to the database anyway. \n", zone_output_adapter_uri(zone), zone_name);
+            ods_log_warning("[%s] WARNING: The output file %s for zone %s does not currently exist. The zone will be added to the database anyway.", module_str, zone_output_adapter_uri(zone), zone_name);
+        }
+        else if (access(zone_output_adapter_uri(zone), R_OK)) {
+            client_printf_err(sockfd, "WARNING: Read access to output file %s for zone %s denied! \n ", zone_output_adapter_uri(zone), zone_name);
+            ods_log_warning("[%s] WARNING: Read access to output file %s for zone %s denied! ", module_str, zone_output_adapter_uri(zone), zone_name);
         }
     }
+
     if (signconf) {
         if (signconf[0] == '/') {
             if (zone_set_signconf_path(zone, signconf)) {

--- a/signer/src/adapter/addns.c
+++ b/signer/src/adapter/addns.c
@@ -581,7 +581,6 @@ dnsin_update(dnsin_type** addns, const char* filename, time_t* last_mod)
     } else {
         ods_log_error("[%s] unable to update dnsin: dnsin_read(%s) "
             "failed (%s)", adapter_str, filename, ods_status2str(status));
-        dnsin_cleanup(*addns);
     }
     return status;
 }

--- a/testing/test-cases.d/enforcer.ods-enforcer.zones_and_zonelist/zonelist.xml.gold
+++ b/testing/test-cases.d/enforcer.ods-enforcer.zones_and_zonelist/zonelist.xml.gold
@@ -68,7 +68,7 @@
 				<Adapter type="File">/var/opendnssec/unsigned/ods5</Adapter>
 			</Input>
 			<Output>
-				<Adapter type="DNS">/var/opendnssec/signed/ods5</Adapter>
+				<Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
 			</Output>
 		</Adapters>
 	</Zone>
@@ -89,10 +89,10 @@
     <SignerConfiguration>/var/opendnssec/signconf/ods7.xml</SignerConfiguration>
 		<Adapters>
 			<Input>
-        <Adapter type="DNS">/var/opendnssec/unsigned/ods7</Adapter>
+        <Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
 			</Input>
 			<Output>
-				<Adapter type="DNS">/var/opendnssec/signed/ods7</Adapter>
+				<Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
 			</Output>
 		</Adapters>
 	</Zone>
@@ -113,7 +113,7 @@
     <SignerConfiguration>/var/opendnssec/signconf/ods9.xml</SignerConfiguration>
 		<Adapters>
 			<Input>
-				<Adapter type="DNS">/var/opendnssec/unsigned/ods9</Adapter>
+				<Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
 			</Input>
 			<Output>
 				<Adapter type="File">/var/opendnssec/signed/ods9</Adapter>

--- a/testing/test-cases.d/enforcer.ods-enforcer.zones_and_zonelist/zonelist.xml.gold_export
+++ b/testing/test-cases.d/enforcer.ods-enforcer.zones_and_zonelist/zonelist.xml.gold_export
@@ -91,7 +91,7 @@ file by using the command:
         <Adapter type="File">/var/opendnssec/unsigned/ods5</Adapter>
       </Input>
       <Output>
-				<Adapter type="DNS">/var/opendnssec/signed/ods5</Adapter>
+				<Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
       </Output>
     </Adapters>
   </Zone>
@@ -112,10 +112,10 @@ file by using the command:
         <SignerConfiguration>/var/opendnssec/signconf/ods7.xml</SignerConfiguration>
     <Adapters>
       <Input>
-        <Adapter type="DNS">/var/opendnssec/unsigned/ods7</Adapter>
+        <Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
       </Input>
       <Output>
-				<Adapter type="DNS">/var/opendnssec/signed/ods7</Adapter>
+				<Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
       </Output>
     </Adapters>
   </Zone>
@@ -136,7 +136,7 @@ file by using the command:
         <SignerConfiguration>/var/opendnssec/signconf/ods9.xml</SignerConfiguration>
     <Adapters>
       <Input>
-				<Adapter type="DNS">/var/opendnssec/unsigned/ods9</Adapter>
+				<Adapter type="DNS">/etc/opendnssec/addns.xml</Adapter>
       </Input>
       <Output>
         <Adapter type="File">/var/opendnssec/signed/ods9</Adapter>


### PR DESCRIPTION
for zone add command:
- checking adapter type
- the type is now case-insensitive
- if type is dns and no input/output given, the default path is used /etc/opendnsec/addns.xml as in 1.4
change ldns dependency version: 1.6.17 supports HIP record