### PR TITLE
incompatiblity in backup files

### DIFF
--- a/signer/src/parser/signconfparser.c
+++ b/signer/src/parser/signconfparser.c
@@ -241,9 +241,11 @@ parse_sc_sig_validity_keyset(const char* cfgfile)
     const char* str = parse_conf_string(cfgfile,
         "//SignerConfiguration/Zone/Signatures/Validity/Keyset",
         0);
-    if (!str || *str == 0 || *str == '0') {
+    /* Even if the value is 0 or NULL we want to write it in duration format. 
+       The value is written in backup file and read during startup*/
+    /*if (!str || *str == 0 || *str == '0') {
         return NULL;
-    }
+    }*/
     duration = duration_create_from_string(str);
     free((void*)str);
     return duration;

--- a/signer/src/signer/backup.c
+++ b/signer/src/signer/backup.c
@@ -82,6 +82,9 @@ backup_read_check_str(FILE* in, const char* str)
         return 0;
     }
     if (ods_strcmp(p, str) != 0) {
+        if (!strcmp(p, "rfc5011") && !strcmp(str, "keytag")) {
+            return 1;
+        }
         ods_log_debug("[%s] \'%s\' does not match \'%s\'", backup_str, p, str);
         return 0;
     }

--- a/signer/src/signer/keys.c
+++ b/signer/src/signer/keys.c
@@ -227,8 +227,9 @@ key_recover2(FILE* fd, keylist_type* kl)
     int ksk = 0;
     int zsk = 0;
     int keytag = 0; /* We are not actually interested but we must
-        parse it to continue correctly in the stream */
-
+        parse it to continue correctly in the stream.
+        When reading 1.4.8 or later version backup file, the real value of keytag is 
+        rfc5011, but not importat due to not using it.*/
     ods_log_assert(fd);
 
     if (!backup_read_check_str(fd, "locator") ||


### PR DESCRIPTION
  - ignore reading rfc5011 instead of keytag
using duration format for Keyset even when the value is not set in kasp (instead of NULL)