### PR TITLE
OPENDNSSEC-311: Configurable default user

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,14 +30,14 @@ EXTRA_DIST =	$(srcdir)/LICENSE \
 
 install-data-hook:
 	$(INSTALL) -d $(DESTDIR)$(localstatedir)
-	$(INSTALL) -d $(DESTDIR)$(localstatedir)/opendnssec
-	$(INSTALL) -d $(DESTDIR)$(localstatedir)/opendnssec/signer
-	$(INSTALL) -d $(DESTDIR)$(localstatedir)/opendnssec/enforcer
-	$(INSTALL) -d $(DESTDIR)$(localstatedir)/opendnssec/signconf
-	$(INSTALL) -d $(DESTDIR)$(localstatedir)/opendnssec/unsigned
-	$(INSTALL) -d $(DESTDIR)$(localstatedir)/opendnssec/signed
+	$(INSTALL) @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ -d $(DESTDIR)$(localstatedir)/opendnssec
+	$(INSTALL) @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ -d $(DESTDIR)$(localstatedir)/opendnssec/signer
+	$(INSTALL) @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ -d $(DESTDIR)$(localstatedir)/opendnssec/enforcer
+	$(INSTALL) @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ -d $(DESTDIR)$(localstatedir)/opendnssec/signconf
+	$(INSTALL) @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ -d $(DESTDIR)$(localstatedir)/opendnssec/unsigned
+	$(INSTALL) @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ -d $(DESTDIR)$(localstatedir)/opendnssec/signed
 	$(INSTALL) -d $(DESTDIR)$(localstatedir)/run
-	$(INSTALL) -d $(DESTDIR)$(localstatedir)/run/opendnssec
+	$(INSTALL) @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ -d $(DESTDIR)$(localstatedir)/run/opendnssec
 
 docs:
 	(cd libhsm; $(MAKE) doxygen)

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -44,16 +44,15 @@ regress: $(RNG)
 		(echo "kasp.xml built")
 
 install-data-hook:
-	test -d ${DESTDIR}${sysconfdir} || mkdir -p ${DESTDIR}${sysconfdir}
-	test -f ${DESTDIR}${sysconfdir}/conf.xml || \
-		${INSTALL_DATA} -m 0640 conf.xml ${DESTDIR}${sysconfdir}
-	${INSTALL_DATA} -m 640 conf.xml ${DESTDIR}${sysconfdir}/conf.xml.sample
+	test -d ${DESTDIR}${sysconfdir} || ${INSTALL_DATA} -m 0775 -D -d @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ ${DESTDIR}${sysconfdir}
+	test -f ${DESTDIR}${sysconfdir}/conf.xml || ( ${INSTALL_DATA} -m 0640 conf.xml @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ ${DESTDIR}${sysconfdir} ; if which >/dev/null xmlif ; then xmlif < ${DESTDIR}${sysconfdir}/conf.xml > ${DESTDIR}${sysconfdir}/conf.xml~ privdrop=@INSTALLATIONCOND@ ; else ${GREP} -v '^<?xmlif' < ${DESTDIR}${sysconfdir}/conf.xml > ${DESTDIR}${sysconfdir}/conf.xml~ ; fi ; cat < ${DESTDIR}${sysconfdir}/conf.xml~ > ${DESTDIR}${sysconfdir}/conf.xml ; rm ${DESTDIR}${sysconfdir}/conf.xml~ )
+	${INSTALL_DATA} -m 640 conf.xml ${DESTDIR}${sysconfdir}/conf.xml.sample ; ${GREP} -v '^<?xmlif' < ${DESTDIR}${sysconfdir}/conf.xml.sample > ${DESTDIR}${sysconfdir}/conf.xml.sample~ ; cat < ${DESTDIR}${sysconfdir}/conf.xml.sample~ > ${DESTDIR}${sysconfdir}/conf.xml.sample ; rm ${DESTDIR}${sysconfdir}/conf.xml.sample~
 	test -f ${DESTDIR}${sysconfdir}/addns.xml || \
-		${INSTALL_DATA} addns.xml ${DESTDIR}${sysconfdir}
+		${INSTALL_DATA} @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ addns.xml ${DESTDIR}${sysconfdir}
 	${INSTALL_DATA} addns.xml ${DESTDIR}${sysconfdir}/addns.xml.sample
 	test -f ${DESTDIR}${sysconfdir}/zonelist.xml || \
-		${INSTALL_DATA} zonelist.xml ${DESTDIR}${sysconfdir}
+		${INSTALL_DATA} @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ zonelist.xml ${DESTDIR}${sysconfdir}
 	${INSTALL_DATA} zonelist.xml ${DESTDIR}${sysconfdir}/zonelist.xml.sample
 	test -f ${DESTDIR}${sysconfdir}/kasp.xml || \
-		${INSTALL_DATA} kasp.xml ${DESTDIR}${sysconfdir}
+		${INSTALL_DATA} @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ kasp.xml ${DESTDIR}${sysconfdir}
 	${INSTALL_DATA} kasp.xml ${DESTDIR}${sysconfdir}/kasp.xml.sample

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -44,7 +44,7 @@ regress: $(RNG)
 		(echo "kasp.xml built")
 
 install-data-hook:
-	test -d ${DESTDIR}${sysconfdir} || ${INSTALL_DATA} -m 0775 -D -d @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ ${DESTDIR}${sysconfdir}
+	test -d ${DESTDIR}${sysconfdir} || ${INSTALL_DATA} -m 0775 -d @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ ${DESTDIR}${sysconfdir}
 	test -f ${DESTDIR}${sysconfdir}/conf.xml || ( ${INSTALL_DATA} -m 0640 conf.xml @INSTALLATIONUSERARG@ @INSTALLATIONGROUPARG@ ${DESTDIR}${sysconfdir} ; if which >/dev/null xmlif ; then xmlif < ${DESTDIR}${sysconfdir}/conf.xml > ${DESTDIR}${sysconfdir}/conf.xml~ privdrop=@INSTALLATIONCOND@ ; else ${GREP} -v '^<?xmlif' < ${DESTDIR}${sysconfdir}/conf.xml > ${DESTDIR}${sysconfdir}/conf.xml~ ; fi ; cat < ${DESTDIR}${sysconfdir}/conf.xml~ > ${DESTDIR}${sysconfdir}/conf.xml ; rm ${DESTDIR}${sysconfdir}/conf.xml~ )
 	${INSTALL_DATA} -m 640 conf.xml ${DESTDIR}${sysconfdir}/conf.xml.sample ; ${GREP} -v '^<?xmlif' < ${DESTDIR}${sysconfdir}/conf.xml.sample > ${DESTDIR}${sysconfdir}/conf.xml.sample~ ; cat < ${DESTDIR}${sysconfdir}/conf.xml.sample~ > ${DESTDIR}${sysconfdir}/conf.xml.sample ; rm ${DESTDIR}${sysconfdir}/conf.xml.sample~
 	test -f ${DESTDIR}${sysconfdir}/addns.xml || \

--- a/conf/conf.xml.in
+++ b/conf/conf.xml.in
@@ -36,12 +36,10 @@
 	</Common>
 
 	<Enforcer>
-<!--
-		<Privileges>
-			<User>opendnssec</User>
-			<Group>opendnssec</Group>
-		</Privileges>
--->
+<?xmlif if condition privdrop="user|group|both"?>		<Privileges>
+<?xmlif fi?><?xmlif if condition privdrop="user|both"?>			<User>@INSTALLATIONUSER@</User>
+<?xmlif fi?><?xmlif if condition privdrop="group|both"?>			<Group>@INSTALLATIONGROUP@</Group>
+<?xmlif fi?><?xmlif if condition privdrop="user|group|both"?>		</Privileges><?xmlif fi?>
 
 		<Datastore><SQLite>@OPENDNSSEC_STATE_DIR@/kasp.db</SQLite></Datastore>
 		<!--The enforcer interval parameter is no long used in 2.0 and will be deprecated in 2.1 -->
@@ -60,12 +58,10 @@
 	</Enforcer>
 
 	<Signer>
-<!--
-		<Privileges>
-			<User>opendnssec</User>
-			<Group>opendnssec</Group>
-		</Privileges>
--->
+<?xmlif if condition privdrop="user|group|both"?>		<Privileges>
+<?xmlif fi?><?xmlif if condition privdrop="user|both"?>			<User>@INSTALLATIONUSER@</User>
+<?xmlif fi?><?xmlif if condition privdrop="group|both"?>			<Group>@INSTALLATIONGROUP@</Group>
+<?xmlif fi?><?xmlif if condition privdrop="user|group|both"?>		</Privileges><?xmlif fi?>
 
 		<WorkingDirectory>@OPENDNSSEC_STATE_DIR@/signer</WorkingDirectory>
 		<WorkerThreads>4</WorkerThreads>

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,43 @@ AH_BOTTOM([
 ])
 AM_CONDITIONAL([ENABLE_SIGNER], [test "${enable_signer}" = "yes"])
 
+INSTALLATIONCOND=""
+AC_ARG_ENABLE(installation-user,
+	AC_HELP_STRING([--enable-installation-user],
+		[Install for usage by specific user (default=disabled)]),
+		[enable_installationuser=$enableval],
+		[enable_installationuser="no"])
+AC_ARG_ENABLE(installation-group,
+	AC_HELP_STRING([--enable-installation-group],
+		[Install for usage by specific group (default=disabled)]),
+		[enable_installationgroup=$enableval],
+		[enable_installationgroup="no"])
+if test "x${enable_installationuser}" != "xno"; then
+	INSTALLATIONUSER="${enable_installationuser}"
+	INSTALLATIONUSERARG="--owner=${enable_installationuser}"
+	INSTALLATIONCOND="user"
+else
+	INSTALLATIONUSER=""
+	INSTALLATIONUSERARG=""
+fi
+if test "x${enable_installationgroup}" != "xno"; then
+	INSTALLATIONGROUP="${enable_installationgroup}"
+	INSTALLATIONGROUPARG="--group=${enable_installationgroup}"
+	if test "x${enable_installationuser}" != "xno"; then
+		INSTALLATIONCOND="both"
+	else
+		INSTALLATIONCOND="group"
+	fi
+else
+	INSTALLATIONGROUP=""
+	INSTALLATIONGROUPARG=""
+fi
+AC_SUBST([INSTALLATIONGROUP])
+AC_SUBST([INSTALLATIONGROUPARG])
+AC_SUBST([INSTALLATIONUSER])
+AC_SUBST([INSTALLATIONUSERARG])
+AC_SUBST([INSTALLATIONCOND])
+
 # doxygen
 DX_PDF_FEATURE(OFF)
 DX_PS_FEATURE(OFF)

--- a/configure.ac
+++ b/configure.ac
@@ -207,7 +207,7 @@ AC_ARG_ENABLE(installation-group,
 		[enable_installationgroup="no"])
 if test "x${enable_installationuser}" != "xno"; then
 	INSTALLATIONUSER="${enable_installationuser}"
-	INSTALLATIONUSERARG="--owner=${enable_installationuser}"
+	INSTALLATIONUSERARG="-o${enable_installationuser}"
 	INSTALLATIONCOND="user"
 else
 	INSTALLATIONUSER=""
@@ -215,7 +215,7 @@ else
 fi
 if test "x${enable_installationgroup}" != "xno"; then
 	INSTALLATIONGROUP="${enable_installationgroup}"
-	INSTALLATIONGROUPARG="--group=${enable_installationgroup}"
+	INSTALLATIONGROUPARG="-g${enable_installationgroup}"
 	if test "x${enable_installationuser}" != "xno"; then
 		INSTALLATIONCOND="both"
 	else


### PR DESCRIPTION
Introduce two new configure flags:
 --enable-installation-user=<username>
 --enable-installation-group=<groupname>
None, one or both options may be present.
The username and group names should be existing unix user and group names.
Configuration and data files with be installed as the desired user and/or
group.  Other files, executables and other, will be installed as the user
from which the "make install" is executed.