### PR TITLE
OpenDNSSEC-801: set AA on AXFR reply

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
 * OPENDNSSEC-808: Crash on query with empty query section (thanks Håvard Eidnes)
 * OpenDNSSEC-771: Signer. Do not log warning on deleting a missing 
   NSEC3PARAM RR.
+* OPENDNSSEC-801: Set AA flag on outgoing AXFR.
 
 OpenDNSSEC 2.0b1 - 2016-04-14
 

--- a/signer/src/wire/axfr.c
+++ b/signer/src/wire/axfr.c
@@ -347,6 +347,7 @@ return_axfr:
     if (q->tcp) {
         ods_log_debug("[%s] return part axfr zone %s", axfr_str,
             q->zone->name);
+        buffer_pkt_set_aa(q->buffer);
         buffer_pkt_set_ancount(q->buffer, total_added);
         buffer_pkt_set_nscount(q->buffer, 0);
         buffer_pkt_set_arcount(q->buffer, 0);
@@ -366,6 +367,7 @@ udp_overflow:
     /* UDP Overflow */
     ods_log_info("[%s] axfr udp overflow zone %s", axfr_str, q->zone->name);
     buffer_set_position(q->buffer, bufpos);
+    buffer_pkt_set_aa(q->buffer);
     buffer_pkt_set_ancount(q->buffer, 1);
     buffer_pkt_set_nscount(q->buffer, 0);
     buffer_pkt_set_arcount(q->buffer, 0);


### PR DESCRIPTION
No test created since both drill and dig refuse to give me the flags on a axfr reply.