### PR TITLE
do not timeleap after flush

### DIFF
--- a/enforcer/src/keystate/keystate_ds_submit_task.c
+++ b/enforcer/src/keystate/keystate_ds_submit_task.c
@@ -48,6 +48,7 @@ keystate_ds_submit_task_perform(task_type *task)
 		KEY_DATA_DS_AT_PARENT_SUBMIT, KEY_DATA_DS_AT_PARENT_SUBMITTED,
 		(engine_type*)task->context);
 	task_cleanup(task);
+	flush_enforce_task((engine_type*)task->context, 0);
 	return NULL;
 }
 

--- a/enforcer/src/scheduler/schedule.c
+++ b/enforcer/src/scheduler/schedule.c
@@ -314,6 +314,10 @@ schedule_flush_type(schedule_type* schedule, task_id id)
                 if (!node) break; /* stange, bail out */
                 if (node->data) { /* task */
                     ((task_type*)node->data)->flush = 1;
+                    /* This is important for our tests only. If a task is
+                     * set to flush it should not affect the current time.
+                     * Otherwise timeleap will advance time. */
+                    ((task_type*)node->data)->when = time_now();
                     if (!ldns_rbtree_insert(schedule->tasks, node)) {
                         ods_log_crit("[%s] Could not reschedule task "
                             "after flush. A task has been lost!",


### PR DESCRIPTION
PR for testing only. do not merge.
This change is required to make timeleap work a bit better. I want to see which tests break after this change.