### PR TITLE
OPENDNSSEC-818: warn about long paths used for SocketFile in conf.xml

### DIFF
--- a/enforcer/src/daemon/cmdhandler.c
+++ b/enforcer/src/daemon/cmdhandler.c
@@ -402,13 +402,13 @@ cmdhandler_create(const char* filename)
         return NULL;
     }
 
-    if (filename) {
-        unlink(filename);
-    }
     /* no surprises */
     bzero(&servaddr, sizeof(servaddr));
     servaddr.sun_family = AF_UNIX;
     strncpy(servaddr.sun_path, filename, sizeof(servaddr.sun_path) - 1);
+    if (filename) {
+        unlink(servaddr.sun_path);
+    }
 
     /* bind and listen... */
     ret = bind(listenfd, (const struct sockaddr*) &servaddr, sizeof(struct sockaddr_un));

--- a/enforcer/src/daemon/cmdhandler.c
+++ b/enforcer/src/daemon/cmdhandler.c
@@ -102,10 +102,6 @@
 #define SE_CMDH_CMDLEN 7
 #define MAX_CLIENT_CONN 8
 
-#ifndef SUN_LEN
-#define SUN_LEN(su) (sizeof(*(su))-sizeof((su)->sun_path)+strlen((su)->sun_path))
-#endif
-
 static char const * module_str = "cmdhandler";
 
 typedef struct cmd_func_block* (*fbgetfunctype)(void);
@@ -406,17 +402,16 @@ cmdhandler_create(const char* filename)
         return NULL;
     }
 
-    /* no surprises */
     if (filename) {
         unlink(filename);
     }
+    /* no surprises */
     bzero(&servaddr, sizeof(servaddr));
     servaddr.sun_family = AF_UNIX;
     strncpy(servaddr.sun_path, filename, sizeof(servaddr.sun_path) - 1);
 
     /* bind and listen... */
-    ret = bind(listenfd, (const struct sockaddr*) &servaddr,
-        SUN_LEN(&servaddr));
+    ret = bind(listenfd, (const struct sockaddr*) &servaddr, sizeof(struct sockaddr_un));
     if (ret != 0) {
         ods_log_error("[%s] unable to create, bind() failed: %s", module_str,
             strerror(errno));

--- a/signer/src/daemon/cmdhandler.c
+++ b/signer/src/daemon/cmdhandler.c
@@ -57,10 +57,6 @@
 
 #define SE_CMDH_CMDLEN 7
 
-#ifndef SUN_LEN
-#define SUN_LEN(su)  (sizeof(*(su)) - sizeof((su)->sun_path) + strlen((su)->sun_path))
-#endif
-
 static int count = 0;
 static char const * cmdh_str = "cmdhandler";
 
@@ -902,8 +898,7 @@ cmdhandler_create(const char* filename)
     servaddr.sun_len = strlen(servaddr.sun_path);
 #endif
     /* bind and listen... */
-    ret = bind(listenfd, (const struct sockaddr*) &servaddr,
-        SUN_LEN(&servaddr));
+    ret = bind(listenfd, (const struct sockaddr*) &servaddr, sizeof(struct sockaddr_un));
     if (ret != 0) {
         ods_log_error("[%s] unable to create cmdhandler: "
             "bind() failed (%s)", cmdh_str, strerror(errno));

--- a/signer/src/daemon/engine.c
+++ b/signer/src/daemon/engine.c
@@ -154,8 +154,7 @@ self_pipe_trick(engine_type* engine)
     } else {
         bzero(&servaddr, sizeof(servaddr));
         servaddr.sun_family = AF_UNIX;
-        strncpy(servaddr.sun_path, servsock_filename,
-            sizeof(servaddr.sun_path) - 1);
+        strncpy(servaddr.sun_path, servsock_filename, sizeof(servaddr.sun_path)-1);
         ret = connect(sockfd, (const struct sockaddr*) &servaddr,
             sizeof(servaddr));
         if (ret != 0) {

--- a/signer/src/ods-signer.c
+++ b/signer/src/ods-signer.c
@@ -285,8 +285,7 @@ interface_start(char* cmd)
     /* no suprises */
     bzero(&servaddr, sizeof(servaddr));
     servaddr.sun_family = AF_UNIX;
-    strncpy(servaddr.sun_path, servsock_filename,
-        sizeof(servaddr.sun_path) - 1);
+    strncpy(servaddr.sun_path, servsock_filename, sizeof(servaddr.sun_path)-1);
 
     /* connect */
     ret = connect(sockfd, (const struct sockaddr*) &servaddr,

--- a/signer/src/parser/confparser.c
+++ b/signer/src/parser/confparser.c
@@ -42,6 +42,7 @@
 #include <libxml/xmlreader.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/un.h>
 
 static const char* parser_str = "parser";
 
@@ -496,7 +497,7 @@ parse_conf_notify_command(const char* cfgfile)
 const char*
 parse_conf_clisock_filename(const char* cfgfile)
 {
-    const char* dup = NULL;
+    char* dup = NULL;
     const char* str = parse_conf_string(
         cfgfile,
         "//Configuration/Signer/SocketFile",
@@ -507,6 +508,10 @@ parse_conf_clisock_filename(const char* cfgfile)
         free((void*)str);
     } else {
         dup = strdup(ODS_SE_SOCKFILE);
+    }
+    if (strlen(dup) >= sizeof(((struct sockaddr_un*)0)->sun_path)) {
+        dup[sizeof(((struct sockaddr_un*)0)->sun_path)-1] = '\0'; /* don't worry about just a few bytes 'lost' */
+        ods_log_warning("[%s] SocketFile path too long, truncated to %s", parser_str, dup);
     }
     return dup;
 }

--- a/tools/ods-control.in
+++ b/tools/ods-control.in
@@ -29,9 +29,7 @@ progname="ods-control"
 bindir="@OPENDNSSEC_BIN_DIR@"
 sbindir="@OPENDNSSEC_SBIN_DIR@"
 enforcer_pid_file="@OPENDNSSEC_ENFORCER_PIDFILE@"
-enforcer_socket_file="@OPENDNSSEC_ENFORCER_SOCKETFILE@"
 signer_pid_file="@OPENDNSSEC_SIGNER_PIDFILE@"
-signer_socket_file="@OPENDNSSEC_SIGNER_SOCKET@"
 
 
 case "$1" in
@@ -52,16 +50,6 @@ case "$1" in
 		if [ $RETVAL = 0 ]; then
 			i=0
 			while [ ! -r "$signer_pid_file" ]; do
-				sleep 1
-				i=`expr $i + 1`
-				if [ $i -ge 5 ]; then
-					RETVAL=1
-					echo "Could not start signer"
-					exit $RETVAL
-				fi
-			done
-			i=0
-			while [ ! -r "$signer_socket_file" ]; do
 				sleep 1
 				i=`expr $i + 1`
 				if [ $i -ge 5 ]; then
@@ -97,16 +85,6 @@ case "$1" in
 		if [ $RETVAL = 0 ]; then
 			i=0
 			while [ ! -r "$enforcer_pid_file" ]; do
-				sleep 1
-				i=`expr $i + 1`
-				if [ $i -ge 5 ]; then
-					RETVAL=1
-					echo "Could not start enforcer"
-					exit $RETVAL
-				fi
-			done
-			i=0
-			while [ ! -r "$enforcer_socket_file" ]; do
 				sleep 1
 				i=`expr $i + 1`
 				if [ $i -ge 5 ]; then


### PR DESCRIPTION
Warn about long unix path used for SocketFile, but keep on using it anyway, but truncated.  This will keep on many tests still running correctly.