### PR TITLE
OPENDNSSEC-828

### DIFF
--- a/signer/src/parser/zonelistparser.c
+++ b/signer/src/parser/zonelistparser.c
@@ -135,14 +135,15 @@ parse_zonelist_adapter(xmlXPathContextPtr xpathCtx, xmlChar* expr,
                     type = NULL;
                 }
                 if (adapter) {
-                    break;
+                    xmlXPathFreeObject(xpathObj);
+                    return adapter;
                 }
                 curNode = curNode->next;
             }
         }
     }
     xmlXPathFreeObject(xpathObj);
-    return adapter;
+    return NULL;
 }
 
 


### PR DESCRIPTION
This problem is only seen while finding input adapters. Function parse_zonelist_adapter must return adapter instead of break.