### PR TITLE
getZoneTTL had a subtle bug where sometimes it would return a TTL

### DIFF
--- a/enforcer/src/db/policy_ext.c
+++ b/enforcer/src/db/policy_ext.c
@@ -1161,17 +1161,13 @@ static int __xmlNode2policy(policy_t* policy, xmlNodePtr policy_node, int* updat
     }
     if (!signatures_max_zone_ttl) {
         ods_log_deeebug("[policy_*_from_xml] - signatures max zone ttl");
-        if (check_if_updated) {
-            update_this = 0;
-            if (policy_signatures_max_zone_ttl(policy)) {
-                *updated = 1;
-                update_this = 1;
-            }
-        }
-        if (update_this) {
-            if (policy_set_signatures_max_zone_ttl(policy, 0)) {
+
+        if (policy_signatures_max_zone_ttl(policy) != 86400)
+        {
+            if (policy_set_signatures_max_zone_ttl(policy, 86400)) {
                 return DB_ERROR_UNKNOWN;
             }
+            if (check_if_updated) *updated = 1;
         }
     }
     if (!keys_purge) {


### PR DESCRIPTION
relative to the last change of a record and sometimes a TTL relative to
*now*. This would cause drift in scheduling on every enforce of the
zone.

The bug manifest when decreasing the TTL in the kasp or when the
enforcer leaps backwards in time.