### PR TITLE
Include pthread.h to fix build error on OpenBSD.

### DIFF
--- a/enforcer/src/scheduler/schedule.h
+++ b/enforcer/src/scheduler/schedule.h
@@ -36,6 +36,7 @@
 
 #include <time.h>
 #include <ldns/ldns.h>
+#include <pthread.h>
 
 #include "scheduler/task.h"
 #include "status.h"


### PR DESCRIPTION
Fixes the following error:
```
depbase=`echo ods-enforcerd.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`; cc -std=gnu99 -DHAVE_CONFIG_H -I. -I../../common     -I../../common  -I../../common  -I./../../libhsm/src/lib  -I./../../libhsm/src/lib  -I/usr/local/include/libxml2 -I/usr/local/include  -I/usr/local/include  -I/usr/include -O2 -pipe -pedantic -Wall -pthread -fno-strict-aliasing -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wno-unused-parameter -Wno-missing-field-initializers -Wformat=2 -Wcast-align -Wformat-security -Wstrict-aliasing -Wpacked -Winit-self -Wmissing-include-dirs -Wreturn-type -Wno-format-nonliteral -Wno-format-y2k -Wno-unused-function -Wno-unused-variable -Wno-sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers -Wno-error=format-nonliteral -Wno-error=format-y2k -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -MT ods-enforcerd.o -MD -MP -MF $depbase.Tpo -c -o ods-enforcerd.o ods-enforcerd.c && mv -f $depbase.Tpo $depbase.Po
In file included from ./daemon/cmdhandler.h:36,
                 from daemon/engine.h:37,
                 from ods-enforcerd.c:37:
./scheduler/schedule.h:50: error: expected specifier-qualifier-list before 'pthread_cond_t'
In file included from daemon/engine.h:37,
                 from ods-enforcerd.c:37:
./daemon/cmdhandler.h:49: error: expected specifier-qualifier-list before 'pthread_t'
In file included from daemon/engine.h:38,
                 from ods-enforcerd.c:37:
./daemon/worker.h:45: error: expected specifier-qualifier-list before 'pthread_t'
In file included from ods-enforcerd.c:37:
daemon/engine.h:69: error: expected specifier-qualifier-list before 'pthread_cond_t'
*** Error 1 in enforcer/src (Makefile:1368 'ods-enforcerd.o')
*** Error 1 in enforcer/src (Makefile:1468 'all-recursive')
*** Error 1 in enforcer (Makefile:491 'all-recursive')
*** Error 1 in /home/pobj/opendnssec-2.0.1-sqlite3/opendnssec-2.0.1 (Makefile:539 'all-recursive')
*** Error 1 in . (/usr/ports/infrastructure/mk/bsd.port.mk:2679 '/usr/ports/pobj/opendnssec-2.0.1-sqlite3/.build_done')
*** Error 1 in /usr/ports/security/opendnssec (/usr/ports/infrastructure/mk/bsd.port.mk:2397 'build')
```