### PR TITLE
Use "long long" for time_t.

### DIFF
--- a/enforcer/src/hsmkey/hsm_key_factory.c
+++ b/enforcer/src/hsmkey/hsm_key_factory.c
@@ -189,8 +189,8 @@ void hsm_key_factory_generate(engine_type* engine, const db_connection_t* connec
         ods_log_info("%lu zone(s) found on policy <unknown>", num_zones);
     }
     ods_log_info("[hsm_key_factory_generate] %lu keys needed for %lu "
-        "zones covering %lu seconds, generating %lu keys for policy %s",
-        generate_keys, num_zones, duration,
+        "zones covering %lld seconds, generating %lu keys for policy %s",
+        generate_keys, num_zones, (long long)duration,
         (unsigned long)(generate_keys-num_keys), /* This is safe because we checked num_keys < generate_keys */
         policy_name(policy));
     generate_keys -= num_keys;

--- a/signer/src/wire/axfr.c
+++ b/signer/src/wire/axfr.c
@@ -108,8 +108,8 @@ soa_request(query_type* q, engine_type* engine)
         expire = q->zone->xfrd->serial_xfr_acquired;
         expire += ldns_rdf2native_int32(ldns_rr_rdf(rr, SE_SOA_RDATA_EXPIRE));
         if (expire < time_now()) {
-            ods_log_warning("[%s] zone %s expired at %ld, and it is now %ld: "
-                "not serving soa", axfr_str, q->zone->name, expire, time_now());
+            ods_log_warning("[%s] zone %s expired at %lld, and it is now %lld: "
+                "not serving soa", axfr_str, q->zone->name, (long long)expire, (long long)time_now());
             ldns_rr_free(rr);
             buffer_pkt_set_rcode(q->buffer, LDNS_RCODE_SERVFAIL);
             ods_fclose(fd);


### PR DESCRIPTION
Fixes build warnings on OpenBSD (where time_t is "long long"):
```
wire/axfr.c:112: warning: format '%ld' expects type 'long int', but argument 4 has type 'time_t'
wire/axfr.c:112: warning: format '%ld' expects type 'long int', but argument 5 has type 'time_t'
[...]
hsmkey/hsm_key_factory.c:195: warning: format '%lu' expects type 'long unsigned int', but argument 4 has type 'time_t'
```