### PR TITLE
Fix implict declaration of flush_enforce_task.

### DIFF
--- a/enforcer/src/keystate/keystate_ds_submit_task.c
+++ b/enforcer/src/keystate/keystate_ds_submit_task.c
@@ -33,6 +33,7 @@
 #include "daemon/engine.h"
 #include "duration.h"
 #include "keystate/keystate_ds.h"
+#include "enforcer/enforce_task.h"
 
 #include "keystate/keystate_ds_submit_task.h"
 


### PR DESCRIPTION
Warning thrown on OpenBSD:
```
keystate/keystate_ds_submit_task.c:51: warning: implicit declaration of function 'flush_enforce_task'
```