### PR TITLE
Initialize 'state' to NULL.

### DIFF
--- a/enforcer/src/enforcer/enforcer.c
+++ b/enforcer/src/enforcer/enforcer.c
@@ -2634,7 +2634,7 @@ removeDeadKeys(db_connection_t *dbconn, key_data_t** keylist,
 	size_t i, deplist2_size = 0;
 	int key_purgable, cmp;
 	unsigned int j;
-	const key_state_t* state;
+	const key_state_t* state = NULL;
 	key_dependency_t **deplist2 = NULL;
 
 	assert(keylist);


### PR DESCRIPTION
Fixes warning on OpenBSD:
```
enforcer/enforcer.c:2637: warning: 'state' may be used uninitialized in this function
```