### PR TITLE
SUPPORT-201

### DIFF
--- a/enforcer/utils/1.4-2.0_db_convert/sqlite_convert.sql
+++ b/enforcer/utils/1.4-2.0_db_convert/sqlite_convert.sql
@@ -642,6 +642,7 @@ JOIN REMOTE.keypairs
 	ON REMOTE.dnsseckeys.keypair_id = REMOTE.keypairs.id
 JOIN mapping 
 	ON REMOTE.dnsseckeys.state = mapping.state;
+WHERE EXISTS(select REMOTE.zones.id FROM REMOTE.zones WHERE REMOTE.zones.id = REMOTE.dnsseckeys.zone_id);
 --WHERE REMOTE.keypairs.generate IS NOT NULL;
 
 -- Everything that is just a ZSK must not have dsatparent set.


### PR DESCRIPTION
In 1.4, the keys of deleted zones are kept in dnsseckeys while their zones don't exist any more.
In migration script we check if the zone is available, then its associated keys will be added to keyData.