### PR TITLE
OPENDNSSEC-846: Compile warnings on OpenBSD

### DIFF
--- a/enforcer/src/enforcer/enforcer.c
+++ b/enforcer/src/enforcer/enforcer.c
@@ -2636,7 +2636,7 @@ removeDeadKeys(db_connection_t *dbconn, key_data_t** keylist,
 	size_t i, deplist2_size = 0;
 	int key_purgable, cmp;
 	unsigned int j;
-	const key_state_t* state;
+	const key_state_t* state = NULL;
 	key_dependency_t **deplist2 = NULL;
 
 	assert(keylist);

--- a/enforcer/src/hsmkey/hsm_key_factory.c
+++ b/enforcer/src/hsmkey/hsm_key_factory.c
@@ -195,8 +195,8 @@ hsm_key_factory_generate(engine_type* engine, const db_connection_t* connection,
         ods_log_info("%lu zone(s) found on policy <unknown>", num_zones);
     }
     ods_log_info("[hsm_key_factory_generate] %lu keys needed for %lu "
-        "zones covering %lu seconds, generating %lu keys for policy %s",
-        generate_keys, num_zones, duration,
+        "zones covering %lld seconds, generating %lu keys for policy %s",
+        generate_keys, num_zones, (long long)duration,
         (unsigned long)(generate_keys-num_keys), /* This is safe because we checked num_keys < generate_keys */
         policy_name(policy));
     generate_keys -= num_keys;

--- a/enforcer/src/keystate/key_purge.c
+++ b/enforcer/src/keystate/key_purge.c
@@ -45,7 +45,7 @@ int removeDeadKeysNow(int sockfd, db_connection_t *dbconn,
 	int key_purgable, cmp;
 	int zone_key_purgable;
 	unsigned int j;
-	const key_state_t* state;
+	const key_state_t* state = NULL;
 	key_data_list_t *key_list = NULL;
 	key_data_t** keylist = NULL;
 	key_dependency_list_t *deplist = NULL;

--- a/enforcer/src/scheduler/schedule.h
+++ b/enforcer/src/scheduler/schedule.h
@@ -36,6 +36,7 @@
 
 #include <time.h>
 #include <ldns/ldns.h>
+#include <pthread.h>
 
 #include "scheduler/task.h"
 #include "status.h"

--- a/signer/src/wire/axfr.c
+++ b/signer/src/wire/axfr.c
@@ -108,8 +108,8 @@ soa_request(query_type* q, engine_type* engine)
         expire = q->zone->xfrd->serial_xfr_acquired;
         expire += ldns_rdf2native_int32(ldns_rr_rdf(rr, SE_SOA_RDATA_EXPIRE));
         if (expire < time_now()) {
-            ods_log_warning("[%s] zone %s expired at %ld, and it is now %ld: "
-                "not serving soa", axfr_str, q->zone->name, expire, time_now());
+            ods_log_warning("[%s] zone %s expired at %lld, and it is now %lld: "
+                "not serving soa", axfr_str, q->zone->name, (long long)expire, (long long)time_now());
             ldns_rr_free(rr);
             buffer_pkt_set_rcode(q->buffer, LDNS_RCODE_SERVFAIL);
             ods_fclose(fd);


### PR DESCRIPTION
- Use "long long" for time_t.
- Initialize 'state' to NULL. (twice)
- Fix implict declaration of flush_enforce_task. (already changed)
- Include pthread.h to fix build error on OpenBSD.