### PR TITLE
If no keys updated don't reschedule enforce for zone. If time in the

### DIFF
--- a/enforcer/src/keystate/keystate_ds.c
+++ b/enforcer/src/keystate/keystate_ds.c
@@ -420,7 +420,7 @@ change_keys_from_to(db_connection_t *dbconn, int sockfd,
 	client_printf(sockfd, "%d KSK matches found.\n", key_match);
 	if (!key_match) status = 11;
 	client_printf(sockfd, "%d KSKs changed.\n", key_mod);
-	if (zone) {
+	if (zone && key_mod > 0) {
 		zone->next_change = 0; /* asap */
 		(void)zone_db_update(zone);
 	}

--- a/enforcer/src/keystate/keystate_list_cmd.c
+++ b/enforcer/src/keystate/keystate_list_cmd.c
@@ -148,6 +148,8 @@ map_keytime(const zone_db_t *zone, const key_data_t *key)
 	}
 	if (zone_db_next_change(zone) < 0)
 		return strdup("-");
+	else if (zone_db_next_change(zone) < time_now())
+		return strdup("now");
 
 	t = (time_t)zone_db_next_change(zone);
 	localtime_r(&t, &srtm);


### PR DESCRIPTION
past for key list display 'now' instead.