### PR TITLE
Change in verbosity level not (immediately) propagated to worker threads

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -147,6 +147,12 @@ ods_log_verbosity(void)
 	return log_level-2;
 }
 
+int
+ods_log_setverbosity(int verbosity)
+{
+    log_level = verbosity + 2;
+}
+
 /**
  * Close logging.
  *

--- a/common/log.h
+++ b/common/log.h
@@ -67,6 +67,7 @@ void ods_log_init(const char *program_name, int use_syslog, const char *target_n
  * 
  */
 int ods_log_verbosity(void);
+int ods_log_setverbosity(int verbosity);
 
 /**
  * Close logging.

--- a/enforcer/src/daemon/verbosity_cmd.c
+++ b/enforcer/src/daemon/verbosity_cmd.c
@@ -113,7 +113,7 @@ run(int sockfd, engine_type* engine, const char *cmd, ssize_t n,
 		}
 		ods_log_assert(engine);
 		ods_log_assert(engine->config);
-		ods_log_init("ods-enforcerd", engine->config->use_syslog, engine->config->log_filename, val);
+		ods_log_setverbosity(val);
 		client_printf(sockfd, "Verbosity level set to %i.\n", val);
 		return 0;
 	} else {

--- a/signer/src/daemon/cmdhandler.c
+++ b/signer/src/daemon/cmdhandler.c
@@ -651,7 +651,7 @@ cmdhandler_handle_cmd_verbosity(int sockfd, cmdhandler_type* cmdc, int val)
     ods_log_assert(cmdc->engine);
     engine = (engine_type*) cmdc->engine;
     ods_log_assert(engine->config);
-    ods_log_init("ods-signerd", engine->config->use_syslog, engine->config->log_filename, val);
+    ods_log_setverbosity(val);
     (void)snprintf(buf, ODS_SE_MAXLINE, "Verbosity level set to %i.\n", val);
     ods_writen(sockfd, buf, strlen(buf));
 }

--- a/testing/test-cases.d/signer.adapters.input_basic/test.sh
+++ b/testing/test-cases.d/signer.adapters.input_basic/test.sh
@@ -23,17 +23,10 @@ ods_ldns_testns 15353 ods.datafile &&
 ## Start OpenDNSSEC
 ods_start_ods-control && 
 
-# increment verbosity to get the message in the signer caused by the
-# ldns-notify, this cannot be done too close to the ldns-notify, or
-# the signer seems not to have increased verbosity soon enough (or
-# something else is the case).
 ods-signer verbosity 5 &&
 
 ## Wait for signed zone file
 syslog_waitfor 300 'ods-signerd: .*\[STATS\] ods' &&
-
-# sleep a bit more to ensure the verbosity is really done
-sleep 30 &&
 
 ## Check signed zone file [when we decide on auditor tool]
 test -f "$INSTALL_ROOT/var/opendnssec/signed/ods" &&

--- a/testing/test-cases.d/signer.adapters.input_ixfr_notimpl/test.sh
+++ b/testing/test-cases.d/signer.adapters.input_ixfr_notimpl/test.sh
@@ -17,17 +17,10 @@ ods_ldns_testns 15353 ods.datafile &&
 ## Start OpenDNSSEC
 ods_start_ods-control && 
 
-# increment verbosity to get the message in the signer caused by the
-# ldns-notify, this cannot be done too close to the ldns-notify, or
-# the signer seems not to have increased verbosity soon enough (or
-# something else is the case).
 ods-signer verbosity 5 &&
 
 ## Wait for signed zone file
 syslog_waitfor 300 'ods-signerd: .*\[STATS\] ods' &&
-
-# sleep a bit more to ensure the verbosity is really done
-sleep 30 &&
 
 ## Check signed zone file [when we decide on auditor tool]
 test -f "$INSTALL_ROOT/var/opendnssec/signed/ods" &&


### PR DESCRIPTION
Avoid re-opening the syslog on just changing the verbosity level, this
seem to cause either a delay or missing the change in verbosity level
alltogether.  Re-opening syslog is a bad idea anyway.