### PR TITLE
Fix 'select' declaration warning on OpenBSD.

### DIFF
--- a/enforcer/ksm/database_access_lite.c
+++ b/enforcer/ksm/database_access_lite.c
@@ -41,6 +41,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <sys/select.h>
+
 #include <sqlite3.h>
 
 #include "ksm/dbsdef.h"


### PR DESCRIPTION
Warning message thrown during build:
```
database_access_lite.c:67: warning: implicit declaration of function 'select'
```