### PR TITLE
OPENDNSSEC-858 Don't print how long it took to execute command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ UNRELEASED:
   start quicker and earlier available for user input.
 * OPENDNSSEC-479: Transferring zones and sending notifies through a bound socket, using the same interface as listener
 * Key cache is now shared between threads.
+* OPENDNSSEC-858: Don't print "completed in x seconds" to stderr for enforcer
+  commands.
 * Various memory leaks
 * OPENDNSSEC-601: signer and enforcer working dir would not properly fallback to
   default when not specified.

--- a/enforcer/src/daemon/cmdhandler.c
+++ b/enforcer/src/daemon/cmdhandler.c
@@ -198,7 +198,6 @@ static int
 cmdhandler_perform_command(cmdhandler_type* cmdc, const char *cmd,
     ssize_t n)
 {
-    time_t tstart = time(NULL);
     struct cmd_func_block* fb;
     int ret;
     int sockfd = cmdc->client_fd;
@@ -212,13 +211,9 @@ cmdhandler_perform_command(cmdhandler_type* cmdc, const char *cmd,
         ret = fb->run(sockfd, cmdc->engine, cmd, n, cmdc->dbconn);
         if (ret == -1) {
             /* Syntax error, print usage for cmd */
-            client_printf_err(sockfd, "Error parsing arguments\n",
-                fb->cmdname, time(NULL) - tstart);
+            client_printf_err(sockfd, "Error parsing arguments\n");
             client_printf(sockfd, "Usage:\n\n");
             fb->usage(sockfd);
-        } else if (ret == 0) { /* success */
-            client_printf_err(sockfd, "%s completed in %ld seconds.\n",
-                fb->cmdname, time(NULL) - tstart);
         }
         ods_log_debug("[%s] done handling command %s[%ld]", module_str, cmd, (long)n);
         return ret;

--- a/enforcer/src/ods-enforcer.c
+++ b/enforcer/src/ods-enforcer.c
@@ -339,7 +339,7 @@ interface_start(const char* cmd, const char* servsock_filename)
                     else if (strlen(userbuf) != 0)
                         /* we are interactive so print response.
                          * But also suppress when no command is given. */
-                        fprintf(stderr, "Daemon exit code: %d\n", exitcode);
+                        fprintf(stderr, "Command exit code: %d\n", exitcode);
                     break;
                 }
             }


### PR DESCRIPTION
also rephrase "Daemon exit code" to "Command exit code" as not to give
the impression the daemon has exit.