### PR TITLE
Don't call xmlCleanupThreads() directly, because xmlCleanupParser() has already done so.

### DIFF
--- a/enforcer/src/enforcer/update_all_cmd.c
+++ b/enforcer/src/enforcer/update_all_cmd.c
@@ -72,7 +72,8 @@ check_all(int sockfd, engine_type* engine)
 	int error = 1;
 
 	if (check_conf(engine->config->cfg_filename, &kasp, 
-			&zonelist, &replist, &repcount, 0))
+			&zonelist, &replist, &repcount,
+			(ods_log_verbosity() >= 3)))
 		ods_log_error_and_printf(sockfd, module_str, 
 			"Unable to validate '%s' consistency.", 
 			engine->config->cfg_filename);

--- a/enforcer/src/enforcer/update_conf_cmd.c
+++ b/enforcer/src/enforcer/update_conf_cmd.c
@@ -69,7 +69,7 @@ run(int sockfd, cmdhandler_ctx_type* context, const char *cmd)
 
 	ods_log_debug("[%s] %s command", module_str, update_conf_funcblock.cmdname);
 
-    if (check_conf(engine->config->cfg_filename, &kasp, &zonelist, &repositories, &repository_count, 0)) {
+    if (check_conf(engine->config->cfg_filename, &kasp, &zonelist, &repositories, &repository_count, (ods_log_verbosity() >= 3))) {
         client_printf_err(sockfd, "Unable to validate '%s' consistency.",
             engine->config->cfg_filename);
 

--- a/enforcer/src/ods-enforcerd.c
+++ b/enforcer/src/ods-enforcerd.c
@@ -114,7 +114,6 @@ program_teardown()
 
     xmlCleanupParser();
     xmlCleanupGlobals();
-    xmlCleanupThreads();
 }
 
 /**

--- a/enforcer/src/ods-enforcerd.c
+++ b/enforcer/src/ods-enforcerd.c
@@ -114,6 +114,7 @@ program_teardown()
 
     xmlCleanupParser();
     xmlCleanupGlobals();
+    xmlCleanupThreads();
 }
 
 /**

--- a/enforcer/src/ods-migrate.c
+++ b/enforcer/src/ods-migrate.c
@@ -419,6 +419,7 @@ main(int argc, char* argv[])
 
     xmlCleanupParser();
     xmlCleanupGlobals();
+    xmlCleanupThreads();
 
     return 0;
 }

--- a/enforcer/src/ods-migrate.c
+++ b/enforcer/src/ods-migrate.c
@@ -419,7 +419,6 @@ main(int argc, char* argv[])
 
     xmlCleanupParser();
     xmlCleanupGlobals();
-    xmlCleanupThreads();
 
     return 0;
 }

--- a/signer/src/daemon/engine.c
+++ b/signer/src/daemon/engine.c
@@ -407,7 +407,6 @@ engine_setup(void)
                 engine = NULL;
                 xmlCleanupParser();
                 xmlCleanupGlobals();
-                xmlCleanupThreads();
                 close(pipefd[1]);
                 while (read(pipefd[0], &buff, 1) != -1) {
                     if (buff <= 1) break;

--- a/signer/src/daemon/engine.c
+++ b/signer/src/daemon/engine.c
@@ -407,6 +407,7 @@ engine_setup(void)
                 engine = NULL;
                 xmlCleanupParser();
                 xmlCleanupGlobals();
+                xmlCleanupThreads();
                 close(pipefd[1]);
                 while (read(pipefd[0], &buff, 1) != -1) {
                     if (buff <= 1) break;

--- a/signer/src/ods-signerd.c
+++ b/signer/src/ods-signerd.c
@@ -107,7 +107,6 @@ program_teardown()
 {
     xmlCleanupParser();
     xmlCleanupGlobals();
-    xmlCleanupThreads();
     ods_log_close();
 }
 

--- a/signer/src/ods-signerd.c
+++ b/signer/src/ods-signerd.c
@@ -107,6 +107,7 @@ program_teardown()
 {
     xmlCleanupParser();
     xmlCleanupGlobals();
+    xmlCleanupThreads();
     ods_log_close();
 }
 


### PR DESCRIPTION
Doing otherwise by default triggers an assertion in the NetBSD/7.0 pthread library,
and therefore results in a core dump.
