### PR TITLE
Finally wrapped head around handlers. Turns out not all handlers are

### DIFF
--- a/signer/src/daemon/dnshandler.h
+++ b/signer/src/daemon/dnshandler.h
@@ -57,6 +57,7 @@ struct dnshandler_struct {
     query_type* query;
     netio_handler_type xfrhandler;
     unsigned need_to_exit;
+    netio_handler_type *tcp_accept_handlers;
 };
 
 /**

--- a/signer/src/daemon/xfrhandler.c
+++ b/signer/src/daemon/xfrhandler.c
@@ -97,6 +97,7 @@ xfrhandler_create()
     xfrh->dnshandler.timeout = 0;
     xfrh->dnshandler.event_types = NETIO_EVENT_READ;
     xfrh->dnshandler.event_handler = xfrhandler_handle_dns;
+    xfrh->dnshandler.free_handler = 0;
     return xfrh;
 }
 

--- a/signer/src/wire/netio.c
+++ b/signer/src/wire/netio.c
@@ -335,15 +335,14 @@ netio_dispatch(netio_type* netio, const struct timespec* timeout,
 void
 netio_cleanup(netio_type* netio)
 {
-    netio_handler_list_type* handler;
-
     ods_log_assert(netio);
-
     while (netio->handlers) {
-        handler = netio->handlers;
-        netio->handlers = netio->handlers->next;
-        free(handler->handler->user_data);
-        /*free(handler->handler);*/
+        netio_handler_list_type* handler = netio->handlers;
+        netio->handlers = handler->next;
+        if (handler->handler->free_handler) {
+            free(handler->handler->user_data);
+            free(handler->handler);
+        }
         free(handler);
     }
     free(netio);

--- a/signer/src/wire/netio.h
+++ b/signer/src/wire/netio.h
@@ -129,6 +129,7 @@ struct netio_handler_struct {
      * The event handler SHOULD NOT block.
      */
     netio_event_handler_type event_handler;
+    int free_handler;
 };
 
 /**


### PR DESCRIPTION
created equally. UDP handlers must be freed individually where as TCP
handlers are all allocated in one big block.