### PR TITLE
zone and cofig need their own copy of rr for nsec3params

### DIFF
--- a/signer/src/signer/zone.c
+++ b/signer/src/signer/zone.c
@@ -350,17 +350,8 @@ zone_publish_nsec3param(zone_type* zone)
     (void) zone_del_nsec3params(zone);
 
     ods_log_assert(zone->signconf->nsec3params->rr);
-    status = zone_add_rr(zone, zone->signconf->nsec3params->rr, 0);
+    status = zone_add_rr(zone, ldns_rr_clone(zone->signconf->nsec3params->rr), 0);
     if (status == ODS_STATUS_UNCHANGED) {
-        /* rr already exists, adjust pointer */
-        rrset = zone_lookup_rrset(zone, zone->apex, LDNS_RR_TYPE_NSEC3PARAMS);
-        ods_log_assert(rrset);
-        n3prr = rrset_lookup_rr(rrset, zone->signconf->nsec3params->rr);
-        ods_log_assert(n3prr);
-        if (n3prr->rr != zone->signconf->nsec3params->rr) {
-            ldns_rr_free(zone->signconf->nsec3params->rr);
-        }
-        zone->signconf->nsec3params->rr = n3prr->rr;
         status = ODS_STATUS_OK;
     } else if (status != ODS_STATUS_OK) {
         ods_log_error("[%s] unable to publish nsec3params for zone %s: "

--- a/testing/test-cases-daily.d/enforcer.ods-enforcer.key_functions/test.sh
+++ b/testing/test-cases-daily.d/enforcer.ods-enforcer.key_functions/test.sh
@@ -63,7 +63,6 @@ log_this ods-enforcer-key-export  ods-enforcer key export --all --keytype ZSK --
 log_grep_count ods-enforcer-key-export stdout "DNSKEY	256" 3 &&
 # test --ds
 log_this ods-enforcer-key-export  ods-enforcer key export --ds --zone ods &&
-log_grep ods-enforcer-key-export stdout "KSK DS record (SHA1):" &&
 log_grep ods-enforcer-key-export stdout "KSK DS record (SHA256):" &&
 
 


### PR DESCRIPTION
do not need to change rr in config if the status isn't changed
test: by default key export doesn't show any sha1