### PR TITLE
OPENDNSSEC-879 --suspend option wasn't working since 2.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 OpenDNSSEC 2.2 - 2017-xx-xx
 
+* OPENDNSSEC-879: --suspend option for 'zone add' was broken.
+
 OpenDNSSEC 2.1.0 - 2017-02-22
 
 * If listening port for signer is not set in conf file, the default value

--- a/enforcer/src/keystate/zone_add_cmd.c
+++ b/enforcer/src/keystate/zone_add_cmd.c
@@ -396,9 +396,11 @@ run(int sockfd, cmdhandler_ctx_type* context, const char *cmd)
     /*
      * On successful generate HSM keys and add/flush enforce task.
      */
-    (void)hsm_key_factory_generate_policy(engine, dbconn, policy, 0);
-    ods_log_debug("[%s] Flushing enforce task", module_str);
-    (void)schedule_task(engine->taskq, enforce_task(engine, zone->name), 1, 0);
+    if (!suspend) {
+        (void)hsm_key_factory_generate_policy(engine, dbconn, policy, 0);
+        ods_log_debug("[%s] Flushing enforce task", module_str);
+        (void)schedule_task(engine->taskq, enforce_task(engine, zone->name), 1, 0);
+    }
 
     policy_free(policy);
 


### PR DESCRIPTION
OPENDNSSEC-879 --suspend option wasn't working since 2.1 due individual scheduling of zones.
