### PR TITLE
OPENDNSSEC-752: The 1.4 enforcer calculates the keys it requires in a

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+OpenDNSSEC 1.4.14 - TBD
+
+* OPENDNSSEC-752: Incorrect calculated number of KSKs needed when KSK and ZSK
+  have exactly the same paramaters.
+
 OpenDNSSEC 1.4.13 - 2017-01-20
 
 * OPENDNSSEC-778: Double NSEC3PARAM record after resalt.

--- a/enforcer/enforcerd/enforcer.c
+++ b/enforcer/enforcerd/enforcer.c
@@ -356,7 +356,6 @@ int do_keygen(DAEMONCONFIG *config, KSM_POLICY* policy, hsm_ctx_t *ctx)
     int new_keys = 0;       /* number of keys required */
     unsigned int current_count = 0;  /* number of keys already in HSM */
 
-    int same_keys = 0;      /* Do ksks and zsks look the same ? */
     int ksks_created = 0;   /* Were any KSKs created? */
     
     DB_RESULT result; 
@@ -374,13 +373,6 @@ int do_keygen(DAEMONCONFIG *config, KSM_POLICY* policy, hsm_ctx_t *ctx)
     if (rightnow == NULL) {
         log_msg(config, LOG_ERR, "Couldn't turn \"now\" into a date, quitting...");
         exit(1);
-    }
-
-    /* See if our ZSKs and KSKs look the same */
-    if (policy->ksk->sm == policy->zsk->sm && policy->ksk->bits == policy->zsk->bits && policy->ksk->algorithm == policy->zsk->algorithm) {
-        same_keys = 1;
-    } else {
-        same_keys = 0;
     }
 
     /* How many zones on this policy */ 
@@ -496,11 +488,6 @@ int do_keygen(DAEMONCONFIG *config, KSM_POLICY* policy, hsm_ctx_t *ctx)
     if (status != 0) {
         log_msg(NULL, LOG_ERR, "Could not count current zsk numbers for policy %s", policy->name);
         /* TODO exit? continue with next policy? */
-    }
-    /* Don't have to adjust the queue for shared keys as the prediction has already taken care of that.*/
-    /* Might have to account for ksks */
-    if (same_keys) {
-        keys_in_queue -= ksks_needed;
     }
 
     new_keys = zsks_needed - keys_in_queue;

--- a/enforcer/ksm/ksm_key.c
+++ b/enforcer/ksm/ksm_key.c
@@ -810,6 +810,7 @@ int KsmKeyCountStillGood(int policy_id, int sm, int bits, int algorithm, int int
     if (bits != -1) {
         DqsConditionInt(&sql, "size", DQS_COMPARE_EQ, bits, where++);
     }
+    DqsConditionInt(&sql, "keytype", DQS_COMPARE_EQ, keytype, where++);
     if (algorithm != -1) {
         DqsConditionInt(&sql, "algorithm", DQS_COMPARE_EQ, algorithm, where++);
     }


### PR DESCRIPTION
way which is mostly but not entirely correct. Which in some cases (when
the KSK and ZSK have exactly the same parameters) causes a problem for
generating KSKs. Paired with a slightly incorrect database (extraneous
keys for a policy, caused by changing policies for zones) would have the
enforcer conclude there are in fact enough keys available.