### PR TITLE
OPENDNSSEC-886: Improper time calculation on 32 bits machine causes purge time to be skipped

### DIFF
--- a/enforcer/src/enforcer/enforcer.c
+++ b/enforcer/src/enforcer/enforcer.c
@@ -2611,7 +2611,7 @@ removeDeadKeys(db_connection_t *dbconn, key_data_t** keylist,
 				key_purgable = 0;
 				break;
 			}
-			if (key_state_last_change(state) > key_time) {
+			if (key_time == -1 || key_state_last_change(state) > (unsigned int)key_time) {
 				key_time = key_state_last_change(state);
 			}
 		}


### PR DESCRIPTION
The 32 and 64 bit machines sometimes get different results for this comparison
Let's cast time_t to unsigned int to have the same type, also always set time when the value is not already set.