### PR TITLE
OPENDNSSEC-890: bogus sigs on mismatching TTLs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+OpenDNSSEC 2.1.2 - 2017-xx-xx
+
+* OPENDNSSEC-901: Enforcer would ignore <ManualKeyGeneration/> tag in conf.xml
+* OPENDNSSEC-890: Mismatching TTLs in record sets would cause bogus signatures.
+
 OpenDNSSEC 2.1.1 - 2017-04-28
 
 * OPENDNSSEC-889: MySQL migration script didn't work for all database and

--- a/signer/src/adapter/adapi.c
+++ b/signer/src/adapter/adapi.c
@@ -322,6 +322,13 @@ adapi_process_rr(zone_type* zone, ldns_rr* rr, int add, int backup)
     }
     /* //MaxZoneTTL. Only set for RRtype != SOA && RRtype != DNSKEY */
     if (tmp && tmp < ldns_rr_ttl(rr)) {
+        /* YBS: NOTICE! We are correcting the TTLs here. While
+         * this works it is **NOT** the correct place to do so. We SHOULD
+         * only correcting the records for the outgoing zone (so only
+         * correct them while signing). However, the datastructure currently
+         * in use can not make a distinction between incoming and outgoing.
+         * As a result IXFR's might fail when trying to remove a record
+         * that has its TTL fixed. */
         char* str = ldns_rdf2str(ldns_rr_owner(rr));
         if (str) {
             size_t i = 0;

--- a/signer/src/signer/rrset.c
+++ b/signer/src/signer/rrset.c
@@ -256,6 +256,19 @@ rrset_lookup_rr(rrset_type* rrset, ldns_rr* rr)
     return NULL;
 }
 
+/**
+ * What TTL should new RR's in this RRS get?
+ */
+uint32_t
+rrset_lookup_ttl(rrset_type* rrset, uint32_t default_ttl)
+{
+    for (int i = 0; i < rrset->rr_count; i++) {
+        if (!rrset->rrs[i].is_added) continue;
+        return ldns_rr_ttl(rrset->rrs[i].rr);
+    }
+    return default_ttl;
+}
+
 
 /**
  * Count the number of RRs in this RRset that have is_added.

--- a/signer/src/signer/rrset.h
+++ b/signer/src/signer/rrset.h
@@ -113,6 +113,12 @@ rrset_type* rrset_create(zone_type* zone, ldns_rr_type type);
 rr_type* rrset_lookup_rr(rrset_type* rrset, ldns_rr* rr);
 
 /**
+ * What TTL should new RR's in this RRS get?
+ *
+ */
+uint32_t rrset_lookup_ttl(rrset_type* rrset, uint32_t default_ttl);
+
+/**
  * Count the number of RRs in this RRset that have is_added.
  * \param[in] rrset RRset
  * \return size_t number of RRs


### PR DESCRIPTION
Same as other 890 but PR against 2.1/develop