### PR TITLE
OPENDNSSEC-906 forward port of AllowExtract (2.1)

### DIFF
--- a/conf/conf.rnc
+++ b/conf/conf.rnc
@@ -50,7 +50,11 @@ start = element Configuration {
 			element RequireBackup { empty }? &
 
 			# Do not maintain public keys in the repository (optional)
-			element SkipPublicKey { empty }?
+			element SkipPublicKey { empty }? &
+
+			# Generate extractable keys (CKA_EXTRACTABLE = TRUE) (optional)
+			element AllowExtract { empty }?
+
 		}*
 	} &
 

--- a/conf/conf.xml.in
+++ b/conf/conf.xml.in
@@ -9,6 +9,9 @@
 			<TokenLabel>OpenDNSSEC</TokenLabel>
 			<PIN>1234</PIN>
 			<SkipPublicKey/>
+			<!--
+			<AllowExtraction/>
+			-->
 		</Repository>
 
 <!--

--- a/enforcer/src/parser/confparser.c
+++ b/enforcer/src/parser/confparser.c
@@ -216,6 +216,7 @@ parse_conf_repositories(const char* cfgfile)
     char* tokenlabel;
     char* pin;
     uint8_t use_pubkey;
+    uint8_t allowextract;
     int require_backup;
     hsm_repository_t* rlist = NULL;
     hsm_repository_t* repo  = NULL;
@@ -254,6 +255,7 @@ parse_conf_repositories(const char* cfgfile)
             tokenlabel = NULL;
             pin = NULL;
             use_pubkey = 1;
+            allowextract = 0;
             require_backup = 0;
 
             curNode = xpathObj->nodesetval->nodeTab[i]->xmlChildrenNode;
@@ -270,12 +272,14 @@ parse_conf_repositories(const char* cfgfile)
                     pin = (char *) xmlNodeGetContent(curNode);
                 if (xmlStrEqual(curNode->name, (const xmlChar *)"SkipPublicKey"))
                     use_pubkey = 0;
+                if (xmlStrEqual(curNode->name, (const xmlChar *)"AllowExtraction"))
+                    allowextract = 1;
 
                 curNode = curNode->next;
             }
             if (name && module && tokenlabel) {
                 repo = hsm_repository_new(name, module, tokenlabel, pin,
-                    use_pubkey, require_backup);
+                    use_pubkey, allowextract, require_backup);
             }
             if (!repo) {
                ods_log_error("[%s] unable to add %s repository: "

--- a/libhsm/checks/confparser.c
+++ b/libhsm/checks/confparser.c
@@ -62,6 +62,7 @@ parse_conf_repositories(const char* cfgfile)
     char* tokenlabel;
     char* pin;
     uint8_t use_pubkey;
+    uint8_t allowextract;
     int require_backup;
     hsm_repository_t* rlist = NULL;
     hsm_repository_t* repo  = NULL;
@@ -100,6 +101,7 @@ parse_conf_repositories(const char* cfgfile)
             tokenlabel = NULL;
             pin = NULL;
             use_pubkey = 1;
+            allowextract = 0;
             require_backup = 0;
 
             curNode = xpathObj->nodesetval->nodeTab[i]->xmlChildrenNode;
@@ -116,12 +118,14 @@ parse_conf_repositories(const char* cfgfile)
                     pin = (char *) xmlNodeGetContent(curNode);
                 if (xmlStrEqual(curNode->name, (const xmlChar *)"SkipPublicKey"))
                     use_pubkey = 0;
+                if (xmlStrEqual(curNode->name, (const xmlChar *)"AllowExtraction"))
+                    allowextract = 1;
 
                 curNode = curNode->next;
             }
             if (name && module && tokenlabel) {
                 repo = hsm_repository_new(name, module, tokenlabel, pin,
-                    use_pubkey, require_backup);
+                    use_pubkey, allowextract, require_backup);
             }
             if (!repo) {
                ods_log_error("[%s] unable to add %s repository: "

--- a/libhsm/src/bin/confparser.c
+++ b/libhsm/src/bin/confparser.c
@@ -62,6 +62,7 @@ parse_conf_repositories(const char* cfgfile)
     char* tokenlabel;
     char* pin;
     uint8_t use_pubkey;
+    uint8_t allowextract;
     int require_backup;
     hsm_repository_t* rlist = NULL;
     hsm_repository_t* repo  = NULL;
@@ -100,6 +101,7 @@ parse_conf_repositories(const char* cfgfile)
             tokenlabel = NULL;
             pin = NULL;
             use_pubkey = 1;
+            allowextract = 0;
             require_backup = 0;
 
             curNode = xpathObj->nodesetval->nodeTab[i]->xmlChildrenNode;
@@ -116,12 +118,14 @@ parse_conf_repositories(const char* cfgfile)
                     pin = (char *) xmlNodeGetContent(curNode);
                 if (xmlStrEqual(curNode->name, (const xmlChar *)"SkipPublicKey"))
                     use_pubkey = 0;
+                if (xmlStrEqual(curNode->name, (const xmlChar *)"AllowExtraction"))
+                    allowextract = 1;
 
                 curNode = curNode->next;
             }
             if (name && module && tokenlabel) {
                 repo = hsm_repository_new(name, module, tokenlabel, pin,
-                    use_pubkey, require_backup);
+                    use_pubkey, allowextract, require_backup);
             }
             if (!repo) {
                ods_log_error("[%s] unable to add %s repository: "

--- a/libhsm/src/lib/libhsm.h
+++ b/libhsm/src/lib/libhsm.h
@@ -79,6 +79,7 @@
 /*! HSM configuration */
 typedef struct {
     unsigned int use_pubkey;     /*!< Maintain public keys in HSM */
+    unsigned int allow_extract;  /*!< Generate CKA_EXTRACTABLE private keys */
 } hsm_config_t;
 
 /*! Data type to describe an HSM */
@@ -123,6 +124,7 @@ struct hsm_repository_struct {
     char    *pin;           /*!< PKCS#11 login credentials */
     uint8_t require_backup; /*!< require a backup of keys before using new keys */
     uint8_t use_pubkey;     /*!< use public keys in repository? */
+    unsigned int allow_extract;  /*!< Generate CKA_EXTRACTABLE private keys */
 };
 
 /*! HSM context to keep track of sessions */
@@ -191,7 +193,7 @@ hsm_open2(hsm_repository_t* rlist,
 */
 hsm_repository_t *
 hsm_repository_new(char* name, char* module, char* tokenlabel, char* pin,
-    uint8_t use_pubkey, uint8_t require_backup);
+    uint8_t use_pubkey, uint8_t allowextract, uint8_t require_backup);
 
 /*! Free configured repositories.
 

--- a/signer/src/parser/confparser.c
+++ b/signer/src/parser/confparser.c
@@ -154,6 +154,7 @@ parse_conf_repositories(const char* cfgfile)
     char* tokenlabel;
     char* pin;
     uint8_t use_pubkey;
+    uint8_t allowextract;
     int require_backup;
     hsm_repository_t* rlist = NULL;
     hsm_repository_t* repo  = NULL;
@@ -192,6 +193,7 @@ parse_conf_repositories(const char* cfgfile)
             tokenlabel = NULL;
             pin = NULL;
             use_pubkey = 1;
+            allowextract = 0;
             require_backup = 0;
 
             curNode = xpathObj->nodesetval->nodeTab[i]->xmlChildrenNode;
@@ -208,12 +210,14 @@ parse_conf_repositories(const char* cfgfile)
                     pin = (char *) xmlNodeGetContent(curNode);
                 if (xmlStrEqual(curNode->name, (const xmlChar *)"SkipPublicKey"))
                     use_pubkey = 0;
+                if (xmlStrEqual(curNode->name, (const xmlChar *)"AllowExtraction"))
+                    allowextract = 1;
 
                 curNode = curNode->next;
             }
             if (name && module && tokenlabel) {
                 repo = hsm_repository_new(name, module, tokenlabel, pin,
-                    use_pubkey, require_backup);
+                    use_pubkey, allowextract, require_backup);
             }
             if (!repo) {
                ods_log_error("[%s] unable to add %s repository: "


### PR DESCRIPTION
Forward port AllowExtraction option that was missing in 2.1 from late
development in 1.4.
In addition the public key configuration option wasn't passed properly.
This passing is still quite ugly, but at least now consistent.