### PR TITLE
OPENDNSSEC-890: Set TTLs or RRs to ORIG TTL in signature.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ OpenDNSSEC 2.2 - 2017-xx-xx
 
 * OPENDNSSEC-901: Enforcer would ignore <ManualKeyGeneration/> tag in conf.xml
 * OPENDNSSEC-890: Mismatching TTLs in record sets would cause bogus signatures.
+* OPENDNSSEC-908: Warn when TTL exceeds KASP's MaxZoneTTL instead of capping.
 
 OpenDNSSEC 2.1.1 - 2017-04-28
 

--- a/signer/src/adapter/adapi.c
+++ b/signer/src/adapter/adapi.c
@@ -322,28 +322,20 @@ adapi_process_rr(zone_type* zone, ldns_rr* rr, int add, int backup)
     }
     /* //MaxZoneTTL. Only set for RRtype != SOA && RRtype != DNSKEY */
     if (tmp && tmp < ldns_rr_ttl(rr)) {
-        /* YBS: NOTICE! We are correcting the TTLs here. While
-         * this works it is **NOT** the correct place to do so. We SHOULD
-         * only correcting the records for the outgoing zone (so only
-         * correct them while signing). However, the datastructure currently
-         * in use can not make a distinction between incoming and outgoing.
-         * As a result IXFR's might fail when trying to remove a record
-         * that has its TTL fixed. */
         char* str = ldns_rdf2str(ldns_rr_owner(rr));
         if (str) {
-            size_t i = 0;
             str[(strlen(str))-1] = '\0';
             /* replace tabs with white space */
-            for (i=0; i < strlen(str); i++) {
+            for (int i = 0; i < strlen(str); i++) {
                 if (str[i] == '\t') {
                     str[i] = ' ';
                 }
             }
-            ods_log_debug("[%s] capping ttl %u to MaxZoneTTL %u for rrset "
+            ods_log_warning("[%s] TTL %u exceeds MaxZoneTTL %u for rrset "
                 "<%s,%s>", adapi_str, ldns_rr_ttl(rr), tmp, str,
                 rrset_type2str(ldns_rr_get_type(rr)));
+            LDNS_FREE(str);
         }
-        ldns_rr_set_ttl(rr, tmp);
     }
 
     /* TODO: DNAME and CNAME checks */

--- a/signer/src/signer/zone.c
+++ b/signer/src/signer/zone.c
@@ -534,8 +534,6 @@ zone_add_rr(zone_type* zone, ldns_rr* rr, int do_stats)
     rrset_type* rrset = NULL;
     rr_type* record = NULL;
     ods_status status = ODS_STATUS_OK;
-    char* str = NULL;
-    int i;
 
     ods_log_assert(rr);
     ods_log_assert(zone);
@@ -587,24 +585,16 @@ zone_add_rr(zone_type* zone, ldns_rr* rr, int do_stats)
         ods_log_assert(record->rr);
         ods_log_assert(record->is_added);
         if (ttl_rr != ttl_rrset) {
-            /* YBS: NOTICE! We are correcting the TTLs to ensure every RR in the 
-             * RRSET has the same TTL. Otherwise signatures go BOGUS. While
-             * this works it is **NOT** the correct place to do so. We SHOULD
-             * only correcting the records for the outgoing zone (so only 
-             * correct them while signing). However, the datastructure currently 
-             * in use can not make a distinction between incoming and outgoing.
-             * As a result IXFR's might fail when trying to remove a record
-             * that has its TTL fixed. */
-            str = ldns_rr2str(rr);
+            char *str = ldns_rr2str(rr);
             str[(strlen(str)) - 1] = '\0';
-            for (i = 0; i < strlen(str); i++) {
+            for (int i = 0; i < strlen(str); i++) {
                 if (str[i] == '\t') {
                     str[i] = ' ';
                 }
             }
-            ods_log_error("In zone file %s: TTL for the record '%s' set to %d", zone->name, str, ttl_rrset);
+            ods_log_error("In zone file %s: TTL for the record '%s' (%d) not"
+                " equal to recordset TTL (%d)", zone->name, str, ttl_rr, ttl_rrset);
             LDNS_FREE(str);
-            ldns_rr_set_ttl(rr, ttl_rrset);
         }
     }
     /* update stats */

--- a/testing/test-cases.d/signer.zones.validate_many_zones/test.sh
+++ b/testing/test-cases.d/signer.zones.validate_many_zones/test.sh
@@ -25,20 +25,20 @@ ods_reset_env  &&
 ods_start_ods-control &&
 
 #########################################################################
-# Basic checks of signing test zones
+echo -n "LINE: ${LINENO} " && echo "\n############ Basic checks of signing test zones #########\n" &&
 
-syslog_waitfor 300 'ods-signerd: .*\[STATS\] example.com' &&
-test -f "$INSTALL_ROOT/var/opendnssec/signed/example.com" &&
+echo -n "LINE: ${LINENO} " && syslog_waitfor 300 'ods-signerd: .*\[STATS\] example.com' &&
+echo -n "LINE: ${LINENO} " && test -f "$INSTALL_ROOT/var/opendnssec/signed/example.com" &&
 
-syslog_waitfor 300 'ods-signerd: .*\[STATS\] all.rr.org' &&
-test -f "$INSTALL_ROOT/var/opendnssec/signed/all.rr.org" &&
+echo -n "LINE: ${LINENO} " && syslog_waitfor 300 'ods-signerd: .*\[STATS\] all.rr.org' &&
+echo -n "LINE: ${LINENO} " && test -f "$INSTALL_ROOT/var/opendnssec/signed/all.rr.org" &&
 
-syslog_waitfor 300 'ods-signerd: .*\[STATS\] all.rr.binary.org' &&
-test -f "$INSTALL_ROOT/var/opendnssec/signed/all.rr.binary.org" &&
+echo -n "LINE: ${LINENO} " && syslog_waitfor 300 'ods-signerd: .*\[STATS\] all.rr.binary.org' &&
+echo -n "LINE: ${LINENO} " && test -f "$INSTALL_ROOT/var/opendnssec/signed/all.rr.binary.org" &&
 
 # OPENDNSSEC-231: Make sure we can support reverse classless zones
-syslog_waitfor 300 'ods-signerd: .*\[STATS\] 64/1.0.168.192.IN-ADDR.ARPA' &&
-test -f "$INSTALL_ROOT/var/opendnssec/signed/64-1.0.168.192.in-addr.arpa" &&
+echo -n "LINE: ${LINENO} " && syslog_waitfor 300 'ods-signerd: .*\[STATS\] 64/1.0.168.192.IN-ADDR.ARPA' &&
+echo -n "LINE: ${LINENO} " && test -f "$INSTALL_ROOT/var/opendnssec/signed/64-1.0.168.192.in-addr.arpa" &&
 
 # Validate the output on redhat
 case "$DISTRIBUTION" in
@@ -58,9 +58,8 @@ esac &&
 # Tests to cover signing specific bugs
 
 #SUPPORT-40 - Double check that all records down to the forth level appear in the output
-# having TTL = 600 due to MaxZoneTTL in kasp.xml
-$GREP -q -- "^test.example.com..*600.*IN.*NS.*ns2.example.com." "$INSTALL_ROOT/var/opendnssec/signed/example.com" &&
-$GREP -q -- "^test1.test.example.com..*600.*IN.*NS.*ns2.example.com." "$INSTALL_ROOT/var/opendnssec/signed/example.com" &&
+echo -n "LINE: ${LINENO} " && $GREP -q -- "^test.example.com..*86400.*IN.*NS.*ns2.example.com." "$INSTALL_ROOT/var/opendnssec/signed/example.com" &&
+echo -n "LINE: ${LINENO} " && $GREP -q -- "^test1.test.example.com..*86400.*IN.*NS.*ns2.example.com." "$INSTALL_ROOT/var/opendnssec/signed/example.com" &&
 
 #OPENDSNSEC-290 - Update the zone by changing a CNAME record to an A record.
 ods_setup_zone test/all.rr.org &&


### PR DESCRIPTION
OPENDNSSEC-908: Capping to MaxZoneTTL breaks IXFR