### PR TITLE
Alternative patch for rollover issue

### DIFF
--- a/enforcer/src/db/dbw.h
+++ b/enforcer/src/db/dbw.h
@@ -57,11 +57,12 @@ enum dbw_ds_at_parent {
     DBW_DS_AT_PARENT_SUBMITTED   = 2,
     DBW_DS_AT_PARENT_SEEN        = 3,
     DBW_DS_AT_PARENT_RETRACT     = 4,
-    DBW_DS_AT_PARENT_RETRACTED   = 5
+    DBW_DS_AT_PARENT_RETRACTED   = 5,
+    DBW_DS_AT_PARENT_GONE        = 6
 };
 
 static const char * dbw_ds_at_parent_txt[] = {
-    "unsubmitted", "submit", "submitted", "seen", "retract", "retracted", NULL
+    "unsubmitted", "submit", "submitted", "seen", "retract", "retracted", "gone", NULL
 };
 
 enum dbw_hsmkey_state {

--- a/enforcer/src/db/key_data.c
+++ b/enforcer/src/db/key_data.c
@@ -47,6 +47,7 @@ const db_enum_t key_data_enum_set_ds_at_parent[] = {
     { "seen", (key_data_ds_at_parent_t)KEY_DATA_DS_AT_PARENT_SEEN },
     { "retract", (key_data_ds_at_parent_t)KEY_DATA_DS_AT_PARENT_RETRACT },
     { "retracted", (key_data_ds_at_parent_t)KEY_DATA_DS_AT_PARENT_RETRACTED },
+    { "gone", (key_data_ds_at_parent_t)KEY_DATA_DS_AT_PARENT_GONE },
     { NULL, 0 }
 };
 
@@ -542,6 +543,9 @@ int key_data_from_result(key_data_t* key_data, const db_result_t* result) {
     }
     else if (ds_at_parent == (key_data_ds_at_parent_t)KEY_DATA_DS_AT_PARENT_RETRACTED) {
         key_data->ds_at_parent = KEY_DATA_DS_AT_PARENT_RETRACTED;
+    }
+    else if (ds_at_parent == (key_data_ds_at_parent_t)KEY_DATA_DS_AT_PARENT_GONE) {
+        key_data->ds_at_parent = KEY_DATA_DS_AT_PARENT_GONE;
     }
     else {
         return DB_ERROR_UNKNOWN;

--- a/enforcer/src/db/key_data.h
+++ b/enforcer/src/db/key_data.h
@@ -52,7 +52,8 @@ typedef enum key_data_ds_at_parent {
     KEY_DATA_DS_AT_PARENT_SUBMITTED = 2,
     KEY_DATA_DS_AT_PARENT_SEEN = 3,
     KEY_DATA_DS_AT_PARENT_RETRACT = 4,
-    KEY_DATA_DS_AT_PARENT_RETRACTED = 5
+    KEY_DATA_DS_AT_PARENT_RETRACTED = 5,
+    KEY_DATA_DS_AT_PARENT_GONE = 6
 } key_data_ds_at_parent_t;
 extern const db_enum_t key_data_enum_set_ds_at_parent[];
 

--- a/enforcer/src/keystate/keystate_ds_gone_cmd.c
+++ b/enforcer/src/keystate/keystate_ds_gone_cmd.c
@@ -75,7 +75,7 @@ run(int sockfd, cmdhandler_ctx_type* context, char *cmd)
         db_connection_t* dbconn = getconnectioncontext(context);
         engine_type* engine = getglobalcontext(context);
 	return run_ds_cmd(sockfd, cmd, dbconn, DBW_DS_AT_PARENT_RETRACTED,
-		DBW_DS_AT_PARENT_UNSUBMITTED, engine);
+		DBW_DS_AT_PARENT_GONE, engine);
 }
 
 struct cmd_func_block key_ds_gone_funcblock = {


### PR DESCRIPTION
Add new state to ds_at_parent: DBW_DS_AT_PARENT_GONE. Now we can detect ds-gone key from unsubmitted one by looking at ds_at_parent