### PR TITLE
Use leap_to instead of 'time leap' to be sure keys are in expected st…

### DIFF
--- a/testing/test-cases-daily.d/enforcer.keys.algorithm_rollover/test.sh
+++ b/testing/test-cases-daily.d/enforcer.keys.algorithm_rollover/test.sh
@@ -25,8 +25,7 @@ echo -n "LINE: ${LINENO} " && KSK1=`ods-enforcer key list -v -p --all | grep "KS
 
 
 # Leap to the time that both KSK and ZSK are used for signing
-echo -n "LINE: ${LINENO} " && sleep 3 && ods-enforcer time leap && sleep 3 &&
-echo -n "LINE: ${LINENO} " && sleep 3 && ods-enforcer time leap && sleep 3 &&
+echo -n "LINE: ${LINENO} " && sleep 3 && ods_enforcer_leap_to 90000 && sleep 3 &&
 echo -n "LINE: ${LINENO} " && sleep 3 && ods-enforcer key ds-submit -z ods --cka_id $KSK1 && sleep 3 &&
 echo -n "LINE: ${LINENO} " && sleep 3 && ods-enforcer key ds-seen -z ods --cka_id $KSK1 && sleep 3 &&
 echo -n "LINE: ${LINENO} " && sleep 3 && ods-enforcer time leap && sleep 3 &&


### PR DESCRIPTION
…ates