### PR TITLE
Partial work on migration form previous backup files.

### DIFF
--- a/enforcer/src/db/test/Makefile.am
+++ b/enforcer/src/db/test/Makefile.am
@@ -64,8 +64,6 @@ test_LDFLAGS = -no-install \
 	@ENFORCER_DB_LIBS@ \
 	$(BACKEND_LDFLAGS_CUSTOM)
 
-check: regress-db
-
 regress-db: test
 if USE_SQLITE
 	rm -f test.db

--- a/signer/src/Makefile.am
+++ b/signer/src/Makefile.am
@@ -41,6 +41,7 @@ ods_signerd_SOURCES=		ods-signerd.c \
 				signer/tools.c signer/tools.h \
 				signer/zone.c signer/zone.h \
 				signer/zonelist.c signer/zonelist.h \
+				signer/backup.c \
 				wire/acl.c wire/acl.h \
 				wire/axfr.c wire/axfr.h \
 				wire/buffer.c wire/buffer.h \

--- a/signer/src/adapter/adapi.c
+++ b/signer/src/adapter/adapi.c
@@ -145,9 +145,9 @@ adapi_process_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int add, in
     /* TODO: NS and DS checks */
 
     if (add) {
-        return zone_add_rr(zone, view, rr, 1);
+        return zone_add_rr(zone, view, rr);
     } else {
-        return zone_del_rr(zone, view, rr, 1);
+        return zone_del_rr(zone, view, rr);
     }
     /* not reached */
     return ODS_STATUS_ERR;

--- a/signer/src/daemon/signertasks.c
+++ b/signer/src/daemon/signertasks.c
@@ -672,6 +672,7 @@ do_writezone(task_type* task, const char* zonename, void* zonearg, void *context
     if(zone->operatingconf->statefile_timer > 0) {
         if(--(zone->operatingconf->statefile_timer) == 0) {
             zone->operatingconf->statefile_timer = zone->operatingconf->statefile_freq;
+            do_purgezone(zone);
             do_outputstatefile(zone);
         }
     }

--- a/signer/src/signer/backup.c
+++ b/signer/src/signer/backup.c
@@ -1,0 +1,755 @@
+/*
+ * Copyright (c) 2006-2010 NLNet Labs. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * Recover from backup.
+ *
+ */
+
+#include "config.h"
+#include "signer/zone.h"
+#include "adapter/adapi.h"
+#include "adapter/adutil.h"
+#include "duration.h"
+#include "file.h"
+#include "log.h"
+#include "status.h"
+#include "util.h"
+#include "signer/signconf.h"
+
+#include <ldns/ldns.h>
+
+static const char* backup_str = "backup";
+static const char* sc_str = "signconf";
+static const char* zone_str = "zone";
+
+
+
+static recordset_type*
+lookupdenial(names_view_type view, ldns_rdf* dname)
+{
+    return NULL; // FIXME
+}
+
+
+/**
+ * Read token from backup file.
+ *
+ */
+char*
+backup_read_token(FILE* in)
+{
+    static char buf[4000];
+    buf[sizeof(buf)-1]=0;
+
+    while (1) {
+        if (fscanf(in, "%3990s", buf) != 1) {
+            return 0;
+        }
+        if (buf[0] != '#') {
+            return buf;
+        }
+        if (!fgets(buf, sizeof(buf), in)) {
+            return 0;
+        }
+    }
+    return 0;
+}
+
+/**
+ * Read and match a string from backup file.
+ *
+ */
+int
+backup_read_check_str(FILE* in, const char* str)
+{
+    char *p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read check string \'%s\'", backup_str, str);
+        return 0;
+    }
+    if (ods_strcmp(p, str) != 0) {
+        if (!strcmp(p, "rfc5011") && !strcmp(str, "keytag")) {
+            return 1;
+        }
+        if (!strcmp(p, "jitter") && !strcmp(str, "keyset")) {
+            return fseek(in, -7, SEEK_CUR) == 0;
+        }
+
+        ods_log_debug("[%s] \'%s\' does not match \'%s\'", backup_str, p, str);
+        return 0;
+    }
+    return 1;
+}
+
+
+/**
+ * Read a string from backup file.
+ *
+ */
+int
+backup_read_str(FILE* in, const char** str)
+{
+    char *p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read string", backup_str);
+        return 0;
+    }
+    *str = strdup(p);
+    return 1;
+}
+
+
+/**
+ * Read time from backup file.
+ *
+ */
+int
+backup_read_time_t(FILE* in, time_t* v)
+{
+    char* p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read time", backup_str);
+       return 0;
+    }
+    *v=atol(p);
+    return 1;
+}
+
+
+/**
+ * Read duration from backup file.
+ *
+ */
+int
+backup_read_duration(FILE* in, duration_type** v)
+{
+    char* p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read duration", backup_str);
+       return 0;
+    }
+    if (!strcmp(p, "jitter")) {
+        return fseek(in, -7, SEEK_CUR) == 0;
+    }
+    *v=duration_create_from_string((const char*) p);
+    return 1;
+}
+
+
+/**
+ * Read rr type from backup file.
+ *
+ */
+int
+backup_read_rr_type(FILE* in, ldns_rr_type* v)
+{
+    char* p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read rr type", backup_str);
+       return 0;
+    }
+    *v=(ldns_rr_type) atoi(p);
+    return 1;
+}
+
+
+/**
+ * Read integer from backup file.
+ *
+ */
+int
+backup_read_int(FILE* in, int* v)
+{
+    char* p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read integer", backup_str);
+       return 0;
+    }
+    *v=atoi(p);
+    return 1;
+}
+
+
+/**
+ * Read 8bit unsigned integer from backup file.
+ *
+ */
+int
+backup_read_uint8_t(FILE* in, uint8_t* v)
+{
+    char* p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read uint8_t", backup_str);
+       return 0;
+    }
+    *v= (uint8_t)atoi(p);
+    return 1;
+}
+
+
+/**
+ * Read 32bit unsigned integer from backup file.
+ *
+ */
+int
+backup_read_uint32_t(FILE* in, uint32_t* v)
+{
+    char* p = backup_read_token(in);
+    if (!p) {
+        ods_log_debug("[%s] cannot read uint32_t", backup_str);
+       return 0;
+    }
+    *v= (uint32_t)atol(p);
+    return 1;
+}
+
+
+/**
+ * Read the next RR from the backup file.
+ *
+ */
+static ldns_rr*
+backup_read_rr(FILE* in, zone_type* zone, char* line, ldns_rdf** orig,
+    ldns_rdf** prev, ldns_status* status, unsigned int* l)
+{
+    ldns_rr* rr = NULL;
+    int len = 0;
+backup_read_line:
+    len = adutil_readline_frm_file(in, line, l, 1);
+    if (len >= 0) {
+        switch (line[0]) {
+            case ';':
+                /* done */
+                *status = LDNS_STATUS_OK;
+                return NULL;
+                break;
+            case '\n':
+            case '\0':
+                goto backup_read_line; /* perhaps next line is rr */
+                break;
+            /* let's hope its a RR */
+            default:
+                *status = ldns_rr_new_frm_str(&rr, line, zone->default_ttl,
+                    *orig, prev);
+                if (*status == LDNS_STATUS_OK) {
+                    return rr;
+                } else if (*status == LDNS_STATUS_SYNTAX_EMPTY) {
+                    if (rr) {
+                        ldns_rr_free(rr);
+                        rr = NULL;
+                    }
+                    *status = LDNS_STATUS_OK;
+                    goto backup_read_line; /* perhaps next line is rr */
+                    break;
+                } else {
+                    ods_log_error("[%s] error parsing RR #%i (%s): %s",
+                        backup_str, l&&*l?*l:0,
+                        ldns_get_errorstr_by_id(*status), line);
+                    if (rr) {
+                        ldns_rr_free(rr);
+                        rr = NULL;
+                    }
+                    return NULL;
+                }
+                break;
+        }
+    }
+    /* -1, EOF */
+    *status = LDNS_STATUS_OK;
+    return NULL;
+}
+
+
+/**
+ * Get locator from string.
+ *
+ */
+static char*
+replace_space_with_nul(char* str)
+{
+    int i = 0;
+    if (!str) {
+        return NULL;
+    }
+    i = strlen(str);
+    while (i>0) {
+        --i;
+        if (str[i] == ' ') {
+            str[i] = '\0';
+        }
+    }
+    return strdup(str);
+}
+
+
+/**
+ * Read namedb from backup file.
+ *
+ */
+ods_status
+backup_read_namedb(FILE* in, zone_type* zone, names_view_type view)
+{
+    zone_type* z = (zone_type*) zone;
+    recordset_type record;
+    ldns_rr_list* rrset;
+    ods_status result = ODS_STATUS_OK;
+    ldns_rr_type type_covered;
+    ldns_rr* rr = NULL;
+    ldns_rdf* prev = NULL;
+    ldns_rdf* orig = NULL;
+    ldns_rdf* dname = NULL;
+    ldns_status status = LDNS_STATUS_OK;
+    char line[SE_ADFILE_MAXLINE];
+    char* str = NULL;
+    char* locator = NULL;
+    char* name;
+    uint32_t flags = 0;
+    unsigned int l = 0;
+
+    ods_log_assert(in);
+    ods_log_assert(z);
+
+    /* $ORIGIN <zone name> */
+    dname = zone->apex;
+    if (!dname) {
+        ods_log_error("[%s] error getting default value for $ORIGIN",
+            backup_str);
+        return ODS_STATUS_ERR;
+    }
+    orig = ldns_rdf_clone(dname);
+    if (!orig) {
+        ods_log_error("[%s] error setting default value for $ORIGIN",
+            backup_str);
+        return ODS_STATUS_ERR;
+    }
+    /* read RRs */
+    ods_log_debug("[%s] read RRs %s", backup_str, z->name);
+    while ((rr = backup_read_rr(in, z, line, &orig, &prev, &status, &l))
+        != NULL) {
+        /* check status */
+        if (status != LDNS_STATUS_OK) {
+            ods_log_error("[%s] error reading RR #%i (%s): %s",
+                backup_str, l, ldns_get_errorstr_by_id(status), line);
+            result = ODS_STATUS_ERR;
+            goto backup_namedb_done;
+        }
+        /* add to the database */
+        result = adapi_add_rr(z, view, rr, 1);
+        if (result == ODS_STATUS_UNCHANGED) {
+            ods_log_debug("[%s] skipping RR #%i (duplicate): %s",
+                backup_str, l, line);
+            ldns_rr_free(rr);
+            rr = NULL;
+            result = ODS_STATUS_OK;
+            continue;
+        } else if (result != ODS_STATUS_OK) {
+            ods_log_error("[%s] error adding RR #%i: %s",
+                backup_str, l, line);
+            ldns_rr_free(rr);
+            rr = NULL;
+            goto backup_namedb_done;
+        }
+    }
+    if (result == ODS_STATUS_OK && status != LDNS_STATUS_OK) {
+        ods_log_error("[%s] error reading RR #%i (%s): %s",
+            backup_str, l, ldns_get_errorstr_by_id(status), line);
+        result = ODS_STATUS_ERR;
+        goto backup_namedb_done;
+    }
+
+    /* read NSEC(3)s */
+    ods_log_debug("[%s] read NSEC(3)s %s", backup_str, z->name);
+    l = 0;
+    while ((rr = backup_read_rr(in, z, line, &orig, &prev, &status, &l))
+        != NULL) {
+        /* check status */
+        if (status != LDNS_STATUS_OK) {
+            ods_log_error("[%s] error reading NSEC(3) #%i (%s): %s",
+                backup_str, l, ldns_get_errorstr_by_id(status), line);
+            result = ODS_STATUS_ERR;
+            goto backup_namedb_done;
+        }
+        if (ldns_rr_get_type(rr) != LDNS_RR_TYPE_NSEC &&
+            ldns_rr_get_type(rr) != LDNS_RR_TYPE_NSEC3) {
+            ods_log_error("[%s] error NSEC(3) #%i is not NSEC(3): %s",
+                backup_str, l, line);
+            ldns_rr_free(rr);
+            rr = NULL;
+            result = ODS_STATUS_ERR;
+            goto backup_namedb_done;
+        }
+        /* add to the denial chain */
+        record = lookupdenial(view, ldns_rr_owner(rr));
+        if(record)
+            names_recordsetdenial(record, rr);
+    }
+    if (result == ODS_STATUS_OK && status != LDNS_STATUS_OK) {
+        ods_log_error("[%s] error reading NSEC(3) #%i (%s): %s",
+            backup_str, l, ldns_get_errorstr_by_id(status), line);
+        result = ODS_STATUS_ERR;
+        goto backup_namedb_done;
+    }
+
+    /* read RRSIGs */
+    ods_log_debug("[%s] read RRSIGs %s", backup_str, z->name);
+    l = 0;
+    while ((rr = backup_read_rr(in, z, line, &orig, &prev, &status, &l))
+        != NULL) {
+        /* check status */
+        if (status != LDNS_STATUS_OK) {
+            ods_log_error("[%s] error reading RRSIG #%i (%s): %s",
+                backup_str, l, ldns_get_errorstr_by_id(status), line);
+            result = ODS_STATUS_ERR;
+            goto backup_namedb_done;
+        }
+        if (ldns_rr_get_type(rr) != LDNS_RR_TYPE_RRSIG) {
+            ods_log_error("[%s] error RRSIG #%i is not RRSIG: %s",
+                backup_str, l, line);
+            ldns_rr_free(rr);
+            rr = NULL;
+            result = ODS_STATUS_ERR;
+            goto backup_namedb_done;
+        }
+        /* read locator and flags */
+        str = strstr(line, "flags");
+        if (str) {
+            flags = (uint32_t) atoi(str+6);
+        }
+        str = strstr(line, "locator");
+        if (str) {
+            locator = replace_space_with_nul(str+8);
+        }
+        /* add signatures */
+        type_covered = ldns_rdf2rr_type(ldns_rr_rrsig_typecovered(rr));
+#ifdef NOTDEFINED
+        if (type_covered == LDNS_RR_TYPE_NSEC ||
+            type_covered == LDNS_RR_TYPE_NSEC3) {
+            names_viewlookupall(view, ldns_rr_owner(rr), type_covered, NULL, &rrset);
+        } else {
+            names_viewlookupall(view, ldns_rr_owner(rr), type_covered, NULL, &rrset);
+        }
+        if (!rrset) {
+            ods_log_error("[%s] error restoring RRSIG #%i (%s): %s",
+                backup_str, l, ldns_get_errorstr_by_id(status), line);
+            ldns_rr_free(rr);
+            rr = NULL;
+            result = ODS_STATUS_ERR;
+            goto backup_namedb_done;
+        }
+#endif
+        name = ldns_rdf2str(ldns_rr_owner(rr));
+        record = names_place(view, name);
+        free(name);
+        names_recordaddsignature(record, type_covered, rr, locator, flags);
+        locator = NULL; /* Locator is owned by rrset now */
+    }
+    if (result == ODS_STATUS_OK && status != LDNS_STATUS_OK) {
+        ods_log_error("[%s] error reading RRSIG #%i (%s): %s",
+            backup_str, l, ldns_get_errorstr_by_id(status), line);
+        result = ODS_STATUS_ERR;
+    }
+
+backup_namedb_done:
+    if (orig) {
+        ldns_rdf_deep_free(orig);
+        orig = NULL;
+    }
+    if (prev) {
+        ldns_rdf_deep_free(prev);
+        prev = NULL;
+    }
+    free(locator); /* if everything went well this is NULL. otherwise
+                    clean up. */
+    return result;
+}
+
+
+/**
+ * Recover key from backup.
+ *
+ */
+key_type*
+key_recover2(FILE* fd, keylist_type* kl)
+{
+    const char* locator = NULL;
+    const char* resourcerecord = NULL;
+    uint8_t algorithm = 0;
+    uint32_t flags = 0;
+    int publish = 0;
+    int ksk = 0;
+    int zsk = 0;
+    int keytag = 0; /* We are not actually interested but we must
+        parse it to continue correctly in the stream.
+        When reading 1.4.8 or later version backup file, the real value of keytag is 
+        rfc5011, but not importat due to not using it.*/
+    ods_log_assert(fd);
+
+    if (!backup_read_check_str(fd, "locator") ||
+        !backup_read_str(fd, &locator) ||
+        !backup_read_check_str(fd, "algorithm") ||
+        !backup_read_uint8_t(fd, &algorithm) ||
+        !backup_read_check_str(fd, "flags") ||
+        !backup_read_uint32_t(fd, &flags) ||
+        !backup_read_check_str(fd, "publish") ||
+        !backup_read_int(fd, &publish) ||
+        !backup_read_check_str(fd, "ksk") ||
+        !backup_read_int(fd, &ksk) ||
+        !backup_read_check_str(fd, "zsk") ||
+        !backup_read_int(fd, &zsk) ||
+        !backup_read_check_str(fd, "keytag") ||
+        !backup_read_int(fd, &keytag)) {
+        if (locator) {
+           free((void*)locator);
+           locator = NULL;
+        }
+        return NULL;
+    }
+    /* key ok */
+    return keylist_push(kl, locator, resourcerecord, algorithm, flags, publish, ksk, zsk);
+}
+
+
+/**
+ * Backup duration.
+ *
+ */
+static void
+signconf_backup_duration(FILE* fd, const char* opt, duration_type* duration)
+{
+    char* str = (duration == NULL ? NULL : duration2string(duration));
+    fprintf(fd, "%s %s ", opt, (str?str:"0"));
+    free(str);
+}
+
+
+/**
+ * Recover zone from backup.
+ *
+ */
+ods_status
+zone_recover(zone_type* zone, names_view_type view)
+{
+    char* filename = NULL;
+    FILE* fd = NULL;
+    const char* token = NULL;
+    time_t when = 0;
+    ods_status status = ODS_STATUS_OK;
+    /* zone part */
+    int klass = 0;
+    uint32_t inbound = 0, internal = 0, outbound = 0;
+    /* signconf part */
+    time_t lastmod = 0;
+    /* nsec3params part */
+    const char* salt = NULL;
+
+    ods_log_assert(zone);
+    ods_log_assert(zone->name);
+    ods_log_assert(zone->signconf);
+
+    filename = ods_build_path(zone->name, ".backup2", 0, 1);
+    if (!filename) {
+        return ODS_STATUS_MALLOC_ERR;
+    }
+    fd = ods_fopen(filename, NULL, "r");
+    if (fd) {
+        /* start recovery */
+        if (!backup_read_check_str(fd, ODS_SE_FILE_MAGIC_V3)) {
+            ods_log_error("[%s] corrupted backup file zone %s: read magic "
+                "error", zone_str, zone->name);
+            goto recover_error2;
+        }
+        if (!backup_read_check_str(fd, ";;Time:") |
+            !backup_read_time_t(fd, &when)) {
+            ods_log_error("[%s] corrupted backup file zone %s: read time "
+                "error", zone_str, zone->name);
+            goto recover_error2;
+        }
+        /* zone stuff */
+        if (!backup_read_check_str(fd, ";;Zone:") |
+            !backup_read_check_str(fd, "name") |
+            !backup_read_check_str(fd, zone->name)) {
+            ods_log_error("[%s] corrupted backup file zone %s: read name "
+                "error", zone_str, zone->name);
+            goto recover_error2;
+        }
+        if (!backup_read_check_str(fd, "class") |
+            !backup_read_int(fd, &klass)) {
+            ods_log_error("[%s] corrupted backup file zone %s: read class "
+                "error", zone_str, zone->name);
+            goto recover_error2;
+        }
+        if (!backup_read_check_str(fd, "inbound") |
+            !backup_read_uint32_t(fd, &inbound) |
+            !backup_read_check_str(fd, "internal") |
+            !backup_read_uint32_t(fd, &internal) |
+            !backup_read_check_str(fd, "outbound") |
+            !backup_read_uint32_t(fd, &outbound)) {
+            ods_log_error("[%s] corrupted backup file zone %s: read serial "
+                "error", zone_str, zone->name);
+            goto recover_error2;
+        }
+        zone->klass = (ldns_rr_class) klass;
+        zone->inboundserial   = malloc(sizeof(uint32_t));
+        zone->nextserial      = malloc(sizeof(uint32_t));
+        zone->outboundserial  = malloc(sizeof(uint32_t));
+        *zone->inboundserial  = inbound;
+        *zone->nextserial     = internal;
+        *zone->outboundserial = outbound;
+        /* signconf part */
+        if (!backup_read_check_str(fd, ";;Signconf:") |
+            !backup_read_check_str(fd, "lastmod") |
+            !backup_read_time_t(fd, &lastmod) |
+            !backup_read_check_str(fd, "maxzonettl") |
+            !backup_read_check_str(fd, "0") |
+            !backup_read_check_str(fd, "resign") |
+            !backup_read_duration(fd, &zone->signconf->sig_resign_interval) |
+            !backup_read_check_str(fd, "refresh") |
+            !backup_read_duration(fd, &zone->signconf->sig_refresh_interval) |
+            !backup_read_check_str(fd, "valid") |
+            !backup_read_duration(fd, &zone->signconf->sig_validity_default) |
+            !backup_read_check_str(fd, "denial") |
+            !backup_read_duration(fd,&zone->signconf->sig_validity_denial) |
+            !backup_read_check_str(fd, "keyset") |
+            !backup_read_duration(fd,&zone->signconf->sig_validity_keyset) |
+            !backup_read_check_str(fd, "jitter") |
+            !backup_read_duration(fd, &zone->signconf->sig_jitter) |
+            !backup_read_check_str(fd, "offset") |
+            !backup_read_duration(fd, &zone->signconf->sig_inception_offset) |
+            !backup_read_check_str(fd, "nsec") |
+            !backup_read_rr_type(fd, &zone->signconf->nsec_type) |
+            !backup_read_check_str(fd, "dnskeyttl") |
+            !backup_read_duration(fd, &zone->signconf->dnskey_ttl) |
+            !backup_read_check_str(fd, "soattl") |
+            !backup_read_duration(fd, &zone->signconf->soa_ttl) |
+            !backup_read_check_str(fd, "soamin") |
+            !backup_read_duration(fd, &zone->signconf->soa_min) |
+            !backup_read_check_str(fd, "serial") |
+            !backup_read_str(fd, &zone->signconf->soa_serial)) {
+            ods_log_error("[%s] corrupted backup file zone %s: read signconf "
+                "error", zone_str, zone->name);
+            goto recover_error2;
+        }
+        /* nsec3params part */
+        if (zone->signconf->nsec_type == LDNS_RR_TYPE_NSEC3) {
+            if (!backup_read_check_str(fd, ";;Nsec3parameters:") |
+                !backup_read_check_str(fd, "salt") |
+                !backup_read_str(fd, &salt) |
+                !backup_read_check_str(fd, "algorithm") |
+                !backup_read_uint32_t(fd, &zone->signconf->nsec3_algo) |
+                !backup_read_check_str(fd, "optout") |
+                !backup_read_int(fd, &zone->signconf->nsec3_optout) |
+                !backup_read_check_str(fd, "iterations") |
+                !backup_read_uint32_t(fd, &zone->signconf->nsec3_iterations)) {
+                ods_log_error("[%s] corrupted backup file zone %s: read "
+                    "nsec3parameters error", zone_str, zone->name);
+                goto recover_error2;
+            }
+            zone->signconf->nsec3_salt = strdup(salt);
+            free((void*) salt);
+            salt = NULL;
+            zone->signconf->nsec3params = nsec3params_create(
+                zone->signconf,
+                (uint8_t) zone->signconf->nsec3_algo,
+                (uint8_t) zone->signconf->nsec3_optout,
+                (uint16_t) zone->signconf->nsec3_iterations,
+                zone->signconf->nsec3_salt);
+            if (!zone->signconf->nsec3params) {
+                ods_log_error("[%s] corrupted backup file zone %s: unable to "
+                    "create nsec3param", zone_str, zone->name);
+                goto recover_error2;
+            }
+        }
+        zone->signconf->last_modified = lastmod;
+        zone->zoneconfigvalid = 1;
+        zone->default_ttl = (uint32_t) duration2time(zone->signconf->soa_min);
+        /* keys part */
+        zone->signconf->keys = keylist_create((void*) zone->signconf);
+        while (backup_read_str(fd, &token)) {
+            if (ods_strcmp(token, ";;Key:") == 0) {
+                if (!key_recover2(fd, zone->signconf->keys)) {
+                    ods_log_error("[%s] corrupted backup file zone %s: read "
+                        "key error", zone_str, zone->name);
+                    goto recover_error2;
+                }
+            } else if (ods_strcmp(token, ";;") == 0) {
+                /* keylist done */
+                free((void*) token);
+                token = NULL;
+                break;
+            } else {
+                /* keylist corrupted */
+                goto recover_error2;
+            }
+            free((void*) token);
+            token = NULL;
+        }
+        /* publish dnskeys */
+        status = zone_publish_dnskeys(zone, view, 1);
+        if (status != ODS_STATUS_OK) {
+            ods_log_error("[%s] corrupted backup file zone %s: unable to "
+                "publish dnskeys (%s)", zone_str, zone->name,
+                ods_status2str(status));
+            goto recover_error2;
+        }
+        /* publish nsec3param */
+        if (!zone->signconf->passthrough)
+            status = zone_publish_nsec3param(zone, view);
+        if (status != ODS_STATUS_OK) {
+            ods_log_error("[%s] corrupted backup file zone %s: unable to "
+                "publish nsec3param (%s)", zone_str, zone->name,
+                ods_status2str(status));
+            goto recover_error2;
+        }
+        /* publish other records */
+        status = backup_read_namedb(fd, zone, view);
+        if (status != ODS_STATUS_OK) {
+            ods_log_error("[%s] corrupted backup file zone %s: unable to "
+                "read resource records (%s)", zone_str, zone->name,
+                ods_status2str(status));
+            goto recover_error2;
+        }
+        free((void*)filename);
+        ods_fclose(fd);
+
+        /* all ok */
+        free((void*)filename);
+        if (fd) {
+            ods_fclose(fd);
+        }
+        if (zone->stats) {
+            pthread_mutex_lock(&zone->stats->stats_lock);
+            stats_clear(zone->stats);
+            pthread_mutex_unlock(&zone->stats->stats_lock);
+        }
+        return ODS_STATUS_OK;
+    }
+    free(filename);
+    return ODS_STATUS_UNCHANGED;
+
+  recover_error2:
+    return -1;
+}

--- a/signer/src/signer/zone.h
+++ b/signer/src/signer/zone.h
@@ -196,7 +196,7 @@ ldns_rr* zone_lookup_apex_rrset(names_view_type view, ldns_rr_type type,ldns_rr*
  *         other: rr not added to zone, error occurred
  *
  */
-ods_status zone_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int do_stats);
+ods_status zone_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr);
 
 /**
  * Delete RR.
@@ -209,7 +209,7 @@ ods_status zone_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int d
  *         other: rr not removed from zone, error occurred
  *
  */
-ods_status zone_del_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int do_stats);
+ods_status zone_del_rr(zone_type* zone, names_view_type view, ldns_rr* rr);
 
 /**
  * Remove all NSEC3PARAM RRs from the zone
@@ -243,5 +243,14 @@ void zone_cleanup(zone_type* zone);
  *
  */
 void zone_start(zone_type* zone);
+
+/**
+ * recover from old-style backup file format.
+ * @param zone the zone to cover
+ * @param view the input view of the zone
+ * @return returns whether the recvering was successfull
+ */
+ods_status
+zone_recover(zone_type* zone, names_view_type view);
 
 #endif /* SIGNER_ZONE_H */

--- a/signer/src/test/Makefile.am
+++ b/signer/src/test/Makefile.am
@@ -46,6 +46,7 @@ signertest_LDADD = \
 	../signer/tools.o \
 	../signer/zone.o \
 	../signer/zonelist.o \
+	../signer/backup.o \
 	../wire/acl.o \
 	../wire/axfr.o \
 	../wire/buffer.o \

--- a/signer/src/views/recordset.c
+++ b/signer/src/views/recordset.c
@@ -592,7 +592,6 @@ void
 names_recordsetdenial(recordset_type record, ldns_rr* denial)
 {
     assert(denial != NULL);
-    assert(record->spansignatures == NULL);
     record->spanhashrr = denial;
 }
 


### PR DESCRIPTION
- added missing files from distribution related to unit testing in dist
- disabled non-functional unit testing of enforcer
- Partial support for reading old-style backup files
  - will read the contents and signatures
  - will not preserve the signatures yet, because they immediately expire
  - will not preserve NSEC chain and will be rebuild
  in effect most will will be redone, but is a step towards reusing backup files