### PR TITLE
Fix the ods-enforcer man page

### DIFF
--- a/enforcer/man/ods-enforcer.8.in
+++ b/enforcer/man/ods-enforcer.8.in
@@ -12,12 +12,7 @@ help
 | running
 .br
 .B ods\-enforcer
-queue
-| flush
-| signconf
-| enforce
-| verbosity
-.R <number>
+queue | flush | signconf | enforce | verbosity <number>
 .br
 .B ods\-enforcer update 
 conf | repositorylist | all


### PR DESCRIPTION
The ".R" sequence is invalid in a man page.