### PR TITLE
Strip the build directory from the doxygen docs

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -114,7 +114,7 @@ FULL_PATH_NAMES        = YES
 # If left blank the directory from which doxygen is run is used as the 
 # path to strip.
 
-STRIP_FROM_PATH        = 
+STRIP_FROM_PATH        = $(SRCDIR)
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of 
 # the path mentioned in the documentation of a class, which tells 


### PR DESCRIPTION
This makes the various paths relative to the project root directory
instead of being absolute.