### PR TITLE
Compilation problems under Ubuntu

### DIFF
--- a/common/utilities.c
+++ b/common/utilities.c
@@ -37,17 +37,3 @@ functioncast(void*generic) {
     functioncast_t* function = (functioncast_t*)&generic;
     return *function;
 }
-
-unsigned long long int
-rnd(void)
-{
-  unsigned long long int foo;
-  int cf_error_status;
-
-  asm("rdrand %%rax; \
-        mov $1,%%edx; \
-        cmovae %%rax,%%rdx; \
-        mov %%edx,%1; \
-        mov %%rax, %0;":"=r"(foo),"=r"(cf_error_status)::"%rax","%rdx");
-  return  (!cf_error_status ? 0 : foo);
-}

--- a/common/utilities.h
+++ b/common/utilities.h
@@ -84,6 +84,4 @@ extern char* argv0;
 typedef void (*functioncast_t)(void);
 extern functioncast_t functioncast(void*generic);
 
-unsigned long long int rnd(void);
-
 #endif

--- a/signer/src/daemon/signeroperation.c
+++ b/signer/src/daemon/signeroperation.c
@@ -26,6 +26,8 @@
 
 #include "config.h"
 
+#pragma GCC optimize ("O0")
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,8 +40,6 @@
 #include "util.h"
 #include "compat.h"
 #include "hsm.h"
-
-#pragma GCC optimize ("O0")
 
 static logger_cls_type cls = LOGGER_INITIALIZE("signing");
 

--- a/signer/src/test/signertest.c
+++ b/signer/src/test/signertest.c
@@ -25,7 +25,10 @@
  */
 
 #define _GNU_SOURCE
+
 #include "config.h"
+
+#pragma GCC optimize ("O0")
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -62,8 +65,6 @@ static char* workdir;
 static engine_type* engine;
 static janitor_threadclass_t debugthreadclass;
 static janitor_thread_t debugthread;
-
-#pragma GCC optimize ("O0")
 
 static void
 initialize(int argc, char* argv[])

--- a/signer/src/views/commitlog.c
+++ b/signer/src/views/commitlog.c
@@ -25,9 +25,12 @@
  */
 
 #define _LARGEFILE64_SOURCE
+#define _LARGEFILE_SOURCE
 #define _GNU_SOURCE
 
 #include "config.h"
+
+#pragma GCC optimize ("O0")
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,8 +45,6 @@
 #include "uthash.h"
 #include "utilities.h"
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 struct names_table_struct {
     ldns_rbtree_t* tree;

--- a/signer/src/views/httpd.c
+++ b/signer/src/views/httpd.c
@@ -25,6 +25,7 @@
  */
 
 #define _LARGEFILE64_SOURCE
+#define _LARGEFILE_SOURCE
 #define _GNU_SOURCE
 
 #include "config.h"

--- a/signer/src/views/index.c
+++ b/signer/src/views/index.c
@@ -26,6 +26,8 @@
 
 #include "config.h"
 
+#pragma GCC optimize ("O0")
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,8 +35,6 @@
 #include <ldns/ldns.h>
 #include "uthash.h"
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 typedef int (*comparefunction)(const void *, const void *);
 typedef int (*acceptfunction)(recordset_type newitem, recordset_type currentitem, int* cmp);

--- a/signer/src/views/iteratorgeneric.c
+++ b/signer/src/views/iteratorgeneric.c
@@ -26,13 +26,13 @@
 
 #include "config.h"
 
+#pragma GCC optimize ("O0")
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ldns/ldns.h>
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 struct names_iterator_struct {
     int (*iterate)(names_iterator*iter, void*);

--- a/signer/src/views/marshalling.c
+++ b/signer/src/views/marshalling.c
@@ -26,6 +26,8 @@
 
 #include "config.h"
 
+#pragma GCC optimize ("O0")
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -34,8 +36,6 @@
 #include <assert.h>
 #include <ldns/ldns.h>
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 enum marshall_mode { COPY, FREE, READ, WRITE, PRINT, COUNT };
 enum marshall_func { BASIC, OBJECT, SELF };

--- a/signer/src/views/recordset.c
+++ b/signer/src/views/recordset.c
@@ -26,6 +26,8 @@
 
 #include "config.h"
 
+#pragma GCC optimize ("O0")
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -35,8 +37,6 @@
 #include "utilities.h"
 #include "logging.h"
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 struct item {
     ldns_rr* rr;

--- a/signer/src/views/table.c
+++ b/signer/src/views/table.c
@@ -25,9 +25,12 @@
  */
 
 #define _LARGEFILE64_SOURCE
+#define _LARGEFILE_SOURCE
 #define _GNU_SOURCE
 
 #include "config.h"
+
+#pragma GCC optimize ("O0")
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,8 +44,6 @@
 #include <ldns/ldns.h>
 #include "uthash.h"
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 struct names_table_struct {
     ldns_rbtree_t* tree;

--- a/signer/src/views/views.c
+++ b/signer/src/views/views.c
@@ -25,9 +25,12 @@
  */
 
 #define _LARGEFILE64_SOURCE
+#define _LARGEFILE_SOURCE
 #define _GNU_SOURCE
 
 #include "config.h"
+
+#pragma GCC optimize ("O0")
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,8 +45,6 @@
 #include "utilities.h"
 #include "logging.h"
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 const char* names_view_BASE[]    = { "base",    "namerevision", "outdated" };
 const char* names_view_INPUT[]   = { "input",   "nameupcoming", "namehierarchy", NULL };

--- a/signer/src/views/zoneinput.c
+++ b/signer/src/views/zoneinput.c
@@ -25,9 +25,12 @@
  */
 
 #define _LARGEFILE64_SOURCE
+#define _LARGEFILE_SOURCE
 #define _GNU_SOURCE
 
 #include "config.h"
+
+#pragma GCC optimize ("O0")
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,8 +44,6 @@
 #include <ldns/host2str.h>
 #include "uthash.h"
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 #define HASH_FIND_OPAQUE(head,findptr,findlen,out) \
     HASH_FIND(hh,head,findptr,(unsigned)findlen,out)

--- a/signer/src/views/zoneoutput.c
+++ b/signer/src/views/zoneoutput.c
@@ -25,9 +25,12 @@
  */
 
 #define _LARGEFILE64_SOURCE
+#define _LARGEFILE_SOURCE
 #define _GNU_SOURCE
 
 #include "config.h"
+
+#pragma GCC optimize ("O0")
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,8 +43,6 @@
 #include <ldns/ldns.h>
 #include "uthash.h"
 #include "proto.h"
-
-#pragma GCC optimize ("O0")
 
 void
 writerecordcontent(recordset_type domainitem, FILE* fp)


### PR DESCRIPTION
Compilation problems under Ubuntu because header files have macros which cannot handle optimization being turned off after the header file has been loaded.