### PR TITLE
Added a regression test case which attempts to reproduce SUPPORT-229.

### DIFF
--- a/testing/test-cases.d/signer.support_229/conf-mysql.xml
+++ b/testing/test-cases.d/signer.support_229/conf-mysql.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration>
+	<RepositoryList>
+		<Repository name="SoftHSM">
+			<Module>@SOFTHSM_MODULE@</Module>
+			<TokenLabel>OpenDNSSEC</TokenLabel>
+			<PIN>1234</PIN>
+		</Repository>
+	</RepositoryList>
+	<Common>
+		<Logging>
+			<Verbosity>6</Verbosity>
+			<Syslog><Facility>local0</Facility></Syslog>
+		</Logging>
+		<PolicyFile>@INSTALL_ROOT@/etc/opendnssec/kasp.xml</PolicyFile>
+		<ZoneListFile>@INSTALL_ROOT@/etc/opendnssec/zonelist.xml</ZoneListFile>
+	</Common>
+	<Enforcer>
+		<Datastore><MySQL><Host>localhost</Host><Database>test</Database><Username>test</Username><Password>test</Password></MySQL></Datastore>
+		<AutomaticKeyGenerationPeriod>PT3600S</AutomaticKeyGenerationPeriod>
+	</Enforcer>
+	<Signer>
+		<WorkingDirectory>@INSTALL_ROOT@/var/opendnssec/signer</WorkingDirectory>
+		<WorkerThreads>4</WorkerThreads>
+	</Signer>
+</Configuration>

--- a/testing/test-cases.d/signer.support_229/conf.xml
+++ b/testing/test-cases.d/signer.support_229/conf.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration>
+	<RepositoryList>
+		<Repository name="SoftHSM">
+			<Module>@SOFTHSM_MODULE@</Module>
+			<TokenLabel>OpenDNSSEC</TokenLabel>
+			<PIN>1234</PIN>
+		</Repository>
+	</RepositoryList>
+	<Common>
+		<Logging>
+			<Verbosity>6</Verbosity>
+			<Syslog><Facility>local0</Facility></Syslog>
+		</Logging>
+		<PolicyFile>@INSTALL_ROOT@/etc/opendnssec/kasp.xml</PolicyFile>
+		<ZoneListFile>@INSTALL_ROOT@/etc/opendnssec/zonelist.xml</ZoneListFile>
+	</Common>
+	<Enforcer>
+		<Datastore><SQLite>@INSTALL_ROOT@/var/opendnssec/kasp.db</SQLite></Datastore>
+		<AutomaticKeyGenerationPeriod>PT3600S</AutomaticKeyGenerationPeriod>
+	</Enforcer>
+	<Signer>
+		<WorkingDirectory>@INSTALL_ROOT@/var/opendnssec/signer</WorkingDirectory>
+		<WorkerThreads>4</WorkerThreads>
+	</Signer>
+</Configuration>

--- a/testing/test-cases.d/signer.support_229/kasp.xml
+++ b/testing/test-cases.d/signer.support_229/kasp.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<KASP>
+       <Policy name="default">
+                <Description>SUPPORT-229 kasp.xml file (with changed algorithm to avoid error CKR_MECHANISM_INVALID)</Description>
+                <Signatures>
+                        <Resign>PT1H</Resign>
+                        <Refresh>P15D</Refresh>
+                        <Validity>
+                                <Default>P21D</Default>
+                                <Denial>P21D</Denial>
+                        </Validity>
+                        <Jitter>P1D</Jitter>
+                        <InceptionOffset>PT1H</InceptionOffset>
+                </Signatures>
+
+                <Denial>
+                        <NSEC3>
+                                <!-- <TTL>PT0S</TTL> -->
+                                <!-- <OptOut/> -->
+                                <Resalt>P28D</Resalt>
+                                <Hash>
+                                        <Algorithm>1</Algorithm>
+                                        <Iterations>5</Iterations>
+                                        <Salt length="8"/>
+                                </Hash>
+                        </NSEC3>
+                </Denial>
+
+                <Keys>
+                        <!-- Parameters for both KSK and ZSK -->
+                        <TTL>PT3600S</TTL>
+                        <RetireSafety>PT3600S</RetireSafety>
+                        <PublishSafety>PT3600S</PublishSafety>
+                        <!-- <ShareKeys/> -->
+                        <!-- <Purge>P14D</Purge> -->
+
+                        <!-- Parameters for KSK only -->
+                        <KSK>
+                                <Algorithm length="2048">7</Algorithm>
+                                <Lifetime>P366D</Lifetime>
+                                <Repository>SoftHSM</Repository>
+                        </KSK>
+
+                        <!-- Parameters for ZSK only -->
+                        <ZSK>
+                                <Algorithm length="1024">7</Algorithm>
+                                <Lifetime>P30D</Lifetime>
+                                <Repository>SoftHSM</Repository>
+                                <!-- <ManualRollover/> -->
+                        </ZSK>
+                </Keys>
+
+                <Zone>
+                        <PropagationDelay>PT43200S</PropagationDelay>
+                        <SOA>
+                                <TTL>PT3600S</TTL>
+                                <Minimum>PT3600S</Minimum>
+                                <Serial>unixtime</Serial>
+                        </SOA>
+                </Zone>
+
+                <Parent>
+                        <PropagationDelay>PT9999S</PropagationDelay>
+                        <DS>
+                                <TTL>PT86400S</TTL>
+                        </DS>
+                        <SOA>
+                                <TTL>PT172800S</TTL>
+                                <Minimum>PT10800S</Minimum>
+                        </SOA>
+                </Parent>
+        </Policy>
+
+</KASP>

--- a/testing/test-cases.d/signer.support_229/test result observations.txt
+++ b/testing/test-cases.d/signer.support_229/test result observations.txt
@@ -1,0 +1,89 @@
+Test output observations:
+
+Test start time:
+./_syslog.:1:Mar 13 08:55:20 ade9827fd3a4 ods-enforcerd: [log] switching log to syslog verbosity 6 (log level 8)
+
+Key events:
+./_syslog.: 220:Mar 13 08:55:22 ade9827fd3a4 ods-enforcerd: 1 new ZSK(s) (1024 bits) need to be created.
+./_syslog.: 399:Mar 13 08:55:22 ade9827fd3a4 ods-enforcerd: 1 new ZSK(s) (1024 bits) need to be created.
+./_syslog.: 405:Mar 13 08:55:22 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com == FAILED DUE TO 'unable to notify signer'
+./_syslog.: 416:Mar 13 08:55:22 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com == FAILED DUE TO 'unable to notify signer'
+./_syslog.: 461:Mar 13 08:55:25 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com == FAILED DUE TO 'unable to notify signer'
+== MAIN TEST LOGIC STARTS HERE ==
+./_syslog.: 757:Mar 13 08:55:28 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 7e7908ff454f4f504fc597f40dd59819 == KEYTAG:32829 K_SK
+./_syslog.: 761:Mar 13 08:55:28 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 950a40cc0c0c152101787094310e3629 == KEYTAG:24335 ZSK
+
+./_syslog.: 966:Mar 13 08:55:33 ade9827fd3a4 ods-enforcerd: Time leap: Leaping to time Wed Mar 13 22:55:22 2019
+./_syslog.:1044:Mar 13 08:55:33 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com
+./_syslog.:1097:Mar 13 08:55:33 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 7e7908ff454f4f504fc597f40dd59819 == KEYTAG:32829 K_SK
+./_syslog.:1098:Mar 13 08:55:33 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 950a40cc0c0c152101787094310e3629 == KEYTAG:24335 ZSK
+
+./_syslog.:1228:Mar 13 08:55:40 ade9827fd3a4 ods-enforcerd: Time leap: Leaping to time Thu Mar 14 20:55:22 2019
+./_syslog.:1297:Mar 13 08:55:40 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com
+./_syslog.:1359:Mar 13 08:55:40 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 7e7908ff454f4f504fc597f40dd59819 == KEYTAG:32829 K_SK
+./_syslog.:1360:Mar 13 08:55:40 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 950a40cc0c0c152101787094310e3629 == KEYTAG:24335 ZSK
+
+./_syslog.:1527:Mar 13 08:55:47 ade9827fd3a4 ods-enforcerd: Time leap: Leaping to time Wed Apr 10 08:55:22 2019
+./_syslog.:1550:Mar 13 08:55:47 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com
+./_syslog.:1604:Mar 13 08:55:47 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 7e7908ff454f4f504fc597f40dd59819 == KEYTAG:32829 K_SK
+./_syslog.:1605:Mar 13 08:55:47 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 950a40cc0c0c152101787094310e3629 == KEYTAG:24335 ZSK
+
+./_syslog.:1760:Mar 13 08:55:54 ade9827fd3a4 ods-enforcerd: Time leap: Leaping to time Fri Apr 12 08:55:22 2019
+./_syslog.:1853:Mar 13 08:55:55 ade9827fd3a4 ods-enforcerd: 1 new ZSK(s) (1024 bits) need to be created.
+== date -d "Apr 12 08:55:55 2019" +'%s': 1555052155
+== date -d "Mar 13 08:55:20" +'%s':      1552463720
+== difference in seconds:                   2588435
+== difference in days: 2588435/60/60/24 =   29.9587 days
+./_syslog.:1859:Mar 13 08:55:55 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com
+./_syslog.:1912:Mar 13 08:55:55 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 7e7908ff454f4f504fc597f40dd59819 == KEYTAG:32829 K_SK
+./_syslog.:1913:Mar 13 08:55:55 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 950a40cc0c0c152101787094310e3629 == KEYTAG:24335 ZSK
+./_syslog.:1914:Mar 13 08:55:55 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 4e5814dcffa33cda817695a4c7d0eae9 == KEYTAG:4235  ZSK         <== NEW!
+
+./_syslog.:2070:Mar 13 08:56:02 ade9827fd3a4 ods-enforcerd: Time leap: Leaping to time Fri Apr 12 22:55:22 2019
+./_syslog.:2160:Mar 13 08:56:02 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com
+./_syslog.:2214:Mar 13 08:56:02 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 7e7908ff454f4f504fc597f40dd59819 == KEYTAG:32829 K_SK
+./_syslog.:2215:Mar 13 08:56:02 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 950a40cc0c0c152101787094310e3629 == KEYTAG:24335 ZSK
+./_syslog.:2216:Mar 13 08:56:02 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 4e5814dcffa33cda817695a4c7d0eae9 == KEYTAG:4235  NEW ZSK
+
+./_syslog.:2395:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: Time leap: Leaping to time Sun Apr 21 11:55:22 2019
+./_syslog.:2424:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: processing key 950a40cc0c0c152101787094310e3629 1
+./_syslog.:2425:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: May ZSK 950a40cc0c0c152101787094310e3629 DNSKEY in state omnipresent transition to unretentive?
+./_syslog.:2426:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Policy says we can (1/3)
+./_syslog.:2427:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: May ZSK 950a40cc0c0c152101787094310e3629 RRSIG in state unretentive transition to hidden?
+./_syslog.:2428:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Policy says we can (1/3)
+
+== ONLY 1/3 POLICY CHECKS PASSED, SO WHAT CHANGES NEXT SUCH THAT ALL THREE POLICY CHECKS ARE PASSED? TRANSITION OF NEW ZSK TO 'OMNIPRESENT'?
+
+./_syslog.:2429:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: processing key 4e5814dcffa33cda817695a4c7d0eae9 1   == KEYTAG:4235  NEW ZSK
+./_syslog.:2430:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: May ZSK 4e5814dcffa33cda817695a4c7d0eae9 RRSIG in state rumoured transition to omnipresent?
+./_syslog.:2431:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Policy says we can (1/3)
+./_syslog.:2432:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone DNSSEC says we can (2/3)
+./_syslog.:2433:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Timing says we can (3/3) now: 1555847722 key: 1555847722
+./_syslog.:2434:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: Transitioning ZSK 4e5814dcffa33cda817695a4c7d0eae9 RRSIG from rumoured to omnipresent
+
+./_syslog.:2440:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: processing key 950a40cc0c0c152101787094310e3629 1
+./_syslog.:2441:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: May ZSK 950a40cc0c0c152101787094310e3629 DNSKEY in state omnipresent transition to unretentive?
+./_syslog.:2442:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Policy says we can (1/3)
+./_syslog.:2443:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone DNSSEC says we can (2/3)
+./_syslog.:2444:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Timing says we can (3/3) now: 1555847722 key: 1552517722
+./_syslog.:2445:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: Transitioning ZSK 950a40cc0c0c152101787094310e3629 DNSKEY from omnipresent to unretentive
+./_syslog.:2449:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: May ZSK 950a40cc0c0c152101787094310e3629 RRSIG in state unretentive transition to hidden?
+./_syslog.:2450:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Policy says we can (1/3)
+./_syslog.:2451:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone DNSSEC says we can (2/3)
+./_syslog.:2452:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone Timing says we can (3/3) now: 1555847722 key: 1555239322
+./_syslog.:2453:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [enforcer] updateZone: Transitioning ZSK 950a40cc0c0c152101787094310e3629 RRSIG from unretentive to hidden
+
+== NOW THAT THE ZSK IS HIDDEN, IN THE NEXT STEP IT IS NOT INCLUDED IN THE PUBLISHED KEY SET AND SO DISAPPEARS FROM THE ZONE
+== THIS WOULD BE FINE IF THE RRSIGs WERE REPLACED WITH ONES SIGNED BY THE NEW ZSK BUT THEY ARE NOT ... WHY NOT?
+
+== KEY QUESTION:
+== WAS IT WRONG TO REMOVE THE ZSK, OR WRONG TO NOT REPLACE THE RRSIGs?
+
+./_syslog.:2475:Mar 13 08:56:09 ade9827fd3a4 ods-enforcerd: [signconf_cmd] performing signconf for zone example.com
+./_syslog.:2517:Mar 13 08:56:09 ade9827fd3a4 ods-signerd: [signconf] zone example.com signconf: RESIGN[PT1H] REFRESH[P15D] VALIDITY[P21D] DENIAL[P21D] KEYSET[PT0S] JITTER[P1D] OFFSET[PT1H] NSEC[50] DNSKEYTTL[PT1H] SOATTL[PT1H] MINIMUM[PT1H] SERIAL[unixtime]
+./_syslog.:2518:Mar 13 08:56:09 ade9827fd3a4 ods-signerd: [signconf] zone example.com nsec3: PARAMTTL[PT0S] OPTOUT[0] ALGORITHM[1] ITERATIONS[5] SALT[90d4953c16af8754]
+./_syslog.:2519:Mar 13 08:56:09 ade9827fd3a4 ods-signerd: [keys] zone example.com key: LOCATOR[7e7908ff454f4f504fc597f40dd59819] FLAGS[257] ALGORITHM[7] KSK[1] ZSK[0] PUBLISH[1]
+./_syslog.:2520:Mar 13 08:56:09 ade9827fd3a4 ods-signerd: [keys] zone example.com key: LOCATOR[950a40cc0c0c152101787094310e3629] FLAGS[256] ALGORITHM[7] KSK[0] ZSK[0] PUBLISH[0] <== OLD ZSK: NOT PUBLISHED!
+./_syslog.:2521:Mar 13 08:56:09 ade9827fd3a4 ods-signerd: [keys] zone example.com key: LOCATOR[4e5814dcffa33cda817695a4c7d0eae9] FLAGS[256] ALGORITHM[7] KSK[0] ZSK[1] PUBLISH[1] <== NEW ZSK: PUBLISHED
+./_syslog.:2530:Mar 13 08:56:09 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 7e7908ff454f4f504fc597f40dd59819 == KEYTAG:32829 K_SK
+./_syslog.:2531:Mar 13 08:56:09 ade9827fd3a4 ods-signerd:   [zone] publish example.com DNSKEY locator 4e5814dcffa33cda817695a4c7d0eae9 == KEYTAG:4235  ZSK

--- a/testing/test-cases.d/signer.support_229/test.sh
+++ b/testing/test-cases.d/signer.support_229/test.sh
@@ -19,77 +19,72 @@ THIRTY_ONE_DAYS_IN_SECONDS=$((31*24*60*60))
 LIGHT_GREEN='\033[0;92m'
 NO_COLOUR='\033[0m'
 
-# helper functions
-l() {
-    echo -en "${LIGHT_GREEN}$(date -u +'%b %d %H:%M:%S') UTC: LINE $1: ${NO_COLOUR}"
-}
-
 # entrypoint
 [ -n "$HAVE_MYSQL" ] && ods_setup_conf conf.xml conf-mysql.xml
 
 # ensure we start from a clean setup
-l $LINENO && ods_reset_env &&
+ods_reset_env &&
 
 # start both enforcer and signer
-l $LINENO && ods_start_ods-control &&
+ods_start_ods-control &&
 
 #########################################################################
 # wait for creation and signing of a single simple signed zone
 # assumes that the input zone file is present in test subdir unsigned/example.com
 # and is mentioned in file zonelist.xml in the test dir
-l $LINENO && syslog_waitfor 5 'ods-signerd: .*\[STATS\] example.com' &&
-l $LINENO && test -f "${SIGNED_ZONES}/example.com" &&
+syslog_waitfor 5 'ods-signerd: .*\[STATS\] example.com' &&
+test -f "${SIGNED_ZONES}/example.com" &&
 #########################################################################
 
 #########################################################################
 # check that DNSKEY "id" and RRSIG KEYTAG values (11324 and 52667 here) match, otherwise the zone is broken
 # example.com.     3600   IN      DNSKEY  256 3 7 <BASE64> ;{id = 11324 (zsk), size = 1024b}
 # example.com.    86400   IN      RRSIG   A 7 2 [0-9]+ 20190403012345 20190312213351 52667 example.com. <BASE64>
-l $LINENO && log_this cat-example.com-before cat "${SIGNED_ZONES}/example.com" &&
-l $LINENO && log_this key-status-before ods-enforcer key list --all --verbose &&
-l $LINENO && echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
-l $LINENO && echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
-l $LINENO && echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
-l $LINENO && echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
-l $LINENO && echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
-l $LINENO && echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
-l $LINENO && echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKSTATUS}" &&
-l $LINENO && echo "Checking ZSK ${KEYTAG} is ready.." && [ "${ZSKSTATUS}" == "ZSK ready ${KEYTAG}" ] &&
-l $LINENO && echo "Testing KEYTAG equality (DNSKEYID: $DNSKEYID == KEYTAG: $KEYTAG ?).." && [ "${DNSKEYID}" == "${KEYTAG}" ] &&
+log_this cat-example.com-before cat "${SIGNED_ZONES}/example.com" &&
+log_this key-status-before ods-enforcer key list --all --verbose &&
+echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
+echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
+echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
+echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
+echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
+echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
+echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKSTATUS}" &&
+echo "Checking ZSK ${KEYTAG} is ready.." && [ "${ZSKSTATUS}" == "ZSK ready ${KEYTAG}" ] &&
+echo "Testing KEYTAG equality (DNSKEYID: $DNSKEYID == KEYTAG: $KEYTAG ?).." && [ "${DNSKEYID}" == "${KEYTAG}" ] &&
 #########################################################################
 
 #########################################################################
 # leap to the time of the next key generation.
 # kasp.xml says the ZSK should be regenerated every 30 days.
-l $LINENO && log_this ods-enforcer-leap ods_enforcer_leap_over ${THIRTY_ONE_DAYS_IN_SECONDS} &&
+log_this ods-enforcer-leap ods_enforcer_leap_over ${THIRTY_ONE_DAYS_IN_SECONDS} &&
 #########################################################################
 
 #########################################################################
 # as above check for mismatched DNSKEY "id" and RRSIG.
 # if the bug is present this will fail.
-l $LINENO && log_this cat-example.com.xml-after cat "${SIGNCONF_FILE}" &&
-l $LINENO && log_this cat-example.com-after cat "${SIGNED_ZONES}/example.com" &&
-l $LINENO && log_this key-status-after ods-enforcer key list --all --verbose &&
-l $LINENO && echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
-l $LINENO && echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
-l $LINENO && echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
-l $LINENO && echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
-l $LINENO && echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
-l $LINENO && echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
-l $LINENO && echo -n "Capturing DNSKEY ${DNSKEYID} status.." && ZSKDNSKEYSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${DNSKEYID}) && echo " ${ZSKDNSKEYSTATUS}" &&
-l $LINENO && echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKKEYTAGSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKKEYTAGSTATUS}" &&
-l $LINENO && echo "Checking ZSK ${DNSKEYID} is active.." && [ "${ZSKDNSKEYSTATUS}" == "ZSK active ${DNSKEYID}" ] &&
-l $LINENO && echo "Checking ZSK ${KEYTAG} is retire.." && [ "${ZSKKEYTAGSTATUS}" == "ZSK retire ${KEYTAG}" ] &&
-l $LINENO && echo "Testing KEYTAG equality (DNSKEYID: $DNSKEYID == KEYTAG: $KEYTAG ?).." && [ "${DNSKEYID}" == "${KEYTAG}" ] &&
+log_this cat-example.com.xml-after cat "${SIGNCONF_FILE}" &&
+log_this cat-example.com-after cat "${SIGNED_ZONES}/example.com" &&
+log_this key-status-after ods-enforcer key list --all --verbose &&
+echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
+echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
+echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
+echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
+echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
+echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
+echo -n "Capturing DNSKEY ${DNSKEYID} status.." && ZSKDNSKEYSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${DNSKEYID}) && echo " ${ZSKDNSKEYSTATUS}" &&
+echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKKEYTAGSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKKEYTAGSTATUS}" &&
+echo "Checking ZSK ${DNSKEYID} is active.." && [ "${ZSKDNSKEYSTATUS}" == "ZSK active ${DNSKEYID}" ] &&
+echo "Checking ZSK ${KEYTAG} is retire.." && [ "${ZSKKEYTAGSTATUS}" == "ZSK retire ${KEYTAG}" ] &&
+echo "Testing KEYTAG equality (DNSKEYID: $DNSKEYID == KEYTAG: $KEYTAG ?).." && [ "${DNSKEYID}" == "${KEYTAG}" ] &&
 #########################################################################
 
 # Shutdown
-l $LINENO && ods_stop_ods-control &&
+ods_stop_ods-control &&
 
 # NOTE: You can change this to "return 1" to prevent testdir/_xxx log files being cleaned up
 return 0
 
 # One of the statements above failed, abort.
-l $LINENO && echo '*********** ERROR **********'
-l $LINENO && ods_kill
+echo '*********** ERROR **********'
+ods_kill
 return 1

--- a/testing/test-cases.d/signer.support_229/test.sh
+++ b/testing/test-cases.d/signer.support_229/test.sh
@@ -42,12 +42,12 @@ test -f "${SIGNED_ZONES}/example.com" &&
 # example.com.    86400   IN      RRSIG   A 7 2 [0-9]+ 20190403012345 20190312213351 52667 example.com. <BASE64>
 log_this cat-example.com-before cat "${SIGNED_ZONES}/example.com" &&
 log_this key-status-before ods-enforcer key list --all --verbose &&
-echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
+echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+RRSIG[[:space:]]+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
 echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
-echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
+echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+DNSKEY[[:space:]]+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
 echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
-echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
-echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
+echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+DNSKEY[[:space:]]+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
+echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+RRSIG[[:space:]]+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
 echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKSTATUS}" &&
 echo "Checking ZSK ${KEYTAG} is ready.." && [ "${ZSKSTATUS}" == "ZSK ready ${KEYTAG}" ] &&
 echo "Testing KEYTAG equality (DNSKEYID: $DNSKEYID == KEYTAG: $KEYTAG ?).." && [ "${DNSKEYID}" == "${KEYTAG}" ] &&
@@ -65,12 +65,12 @@ log_this ods-enforcer-leap ods_enforcer_leap_over ${THIRTY_ONE_DAYS_IN_SECONDS} 
 log_this cat-example.com.xml-after cat "${SIGNCONF_FILE}" &&
 log_this cat-example.com-after cat "${SIGNED_ZONES}/example.com" &&
 log_this key-status-after ods-enforcer key list --all --verbose &&
-echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
+echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+RRSIG[[:space:]]+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
 echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
-echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
+echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+DNSKEY[[:space:]]+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
 echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
-echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
-echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
+echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+DNSKEY[[:space:]]+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
+echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+RRSIG[[:space:]]+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
 echo -n "Capturing DNSKEY ${DNSKEYID} status.." && ZSKDNSKEYSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${DNSKEYID}) && echo " ${ZSKDNSKEYSTATUS}" &&
 echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKKEYTAGSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKKEYTAGSTATUS}" &&
 echo "Checking ZSK ${DNSKEYID} is active.." && [ "${ZSKDNSKEYSTATUS}" == "ZSK active ${DNSKEYID}" ] &&

--- a/testing/test-cases.d/signer.support_229/test.sh
+++ b/testing/test-cases.d/signer.support_229/test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Regression test case for SUPPORT-229: Broken zone when ODS replaces the DNSKEY but does not re-sign RRsets using the new DNSKEY.
+# Specifically, after the ZSK <Lifetime> period but before the <Refresh> period, with the customers kasp.xml settings ODS replaces
+# the only ZSK DNSKEY (used to create the RRSIGs in the zone) with a new one but does NOT replace the RRSIGs, so the RRSIG records
+# are unusable because the DNSKEY they must be verified against no longer exists in the zone.
+#
+# TO DO: Is the missing DNSKEY lacking the <Publish/> stanza in the signconf? YES it is - augment the test to check this?
+# TO DO: Match RRSIGs against DNSKEYs using something better than relying on zone comments?
+# TO DO: Base the leap time on the actual kasp.xml ZSK <Lifetime> value, not a hard-coded leap time.
+# TO DO: Understand why it breaks after 31 days but not after 30 days.
+# TO DO: Refactor into more helper functions?
+# TO DO: Reduce to the simplest reproduction scenario, e.g. without enforcer(d) but only with signer(d) using constructed signconf.
+#
+SIGNED_ZONES="$INSTALL_ROOT/var/opendnssec/signed"
+SIGNCONF_FILE="${INSTALL_ROOT}/var/opendnssec/signconf/example.com.xml"
+TESTDIR=$(dirname $0)
+THIRTY_ONE_DAYS_IN_SECONDS=$((31*24*60*60))
+LIGHT_GREEN='\033[0;92m'
+NO_COLOUR='\033[0m'
+
+# helper functions
+l() {
+    echo -en "${LIGHT_GREEN}$(date -u +'%b %d %H:%M:%S') UTC: LINE $1: ${NO_COLOUR}"
+}
+
+# entrypoint
+[ -n "$HAVE_MYSQL" ] && ods_setup_conf conf.xml conf-mysql.xml
+
+# ensure we start from a clean setup
+l $LINENO && ods_reset_env &&
+
+# start both enforcer and signer
+l $LINENO && ods_start_ods-control &&
+
+#########################################################################
+# wait for creation and signing of a single simple signed zone
+# assumes that the input zone file is present in test subdir unsigned/example.com
+# and is mentioned in file zonelist.xml in the test dir
+l $LINENO && syslog_waitfor 5 'ods-signerd: .*\[STATS\] example.com' &&
+l $LINENO && test -f "${SIGNED_ZONES}/example.com" &&
+#########################################################################
+
+#########################################################################
+# check that DNSKEY "id" and RRSIG KEYTAG values (11324 and 52667 here) match, otherwise the zone is broken
+# example.com.     3600   IN      DNSKEY  256 3 7 <BASE64> ;{id = 11324 (zsk), size = 1024b}
+# example.com.    86400   IN      RRSIG   A 7 2 [0-9]+ 20190403012345 20190312213351 52667 example.com. <BASE64>
+l $LINENO && log_this cat-example.com-before cat "${SIGNED_ZONES}/example.com" &&
+l $LINENO && log_this key-status-before ods-enforcer key list --all --verbose &&
+l $LINENO && echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
+l $LINENO && echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
+l $LINENO && echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
+l $LINENO && echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
+l $LINENO && echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
+l $LINENO && echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
+l $LINENO && echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKSTATUS}" &&
+l $LINENO && echo "Checking ZSK ${KEYTAG} is ready.." && [ "${ZSKSTATUS}" == "ZSK ready ${KEYTAG}" ] &&
+l $LINENO && echo "Testing KEYTAG equality (DNSKEYID: $DNSKEYID == KEYTAG: $KEYTAG ?).." && [ "${DNSKEYID}" == "${KEYTAG}" ] &&
+#########################################################################
+
+#########################################################################
+# leap to the time of the next key generation.
+# kasp.xml says the ZSK should be regenerated every 30 days.
+l $LINENO && log_this ods-enforcer-leap ods_enforcer_leap_over ${THIRTY_ONE_DAYS_IN_SECONDS} &&
+#########################################################################
+
+#########################################################################
+# as above check for mismatched DNSKEY "id" and RRSIG.
+# if the bug is present this will fail.
+l $LINENO && log_this cat-example.com.xml-after cat "${SIGNCONF_FILE}" &&
+l $LINENO && log_this cat-example.com-after cat "${SIGNED_ZONES}/example.com" &&
+l $LINENO && log_this key-status-after ods-enforcer key list --all --verbose &&
+l $LINENO && echo -n "Capturing RRSIG A count.." && RRSIG_A_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${RRSIG_A_COUNT}" &&
+l $LINENO && echo "Checking RRSIG A count ${RRSIG_A_COUNT} == 1.." && [ "${RRSIG_A_COUNT}" -eq "1" ] &&
+l $LINENO && echo -n "Capturing ZSK count.." && ZSK_COUNT=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | wc -l) && echo " ${ZSK_COUNT}" &&
+l $LINENO && echo "Checking ZSK count ${ZSK_COUNT} == 1.." && [ "${ZSK_COUNT}" -eq "1" ] &&
+l $LINENO && echo -n "Capturing ZSK KEYTAG (id).." && DNSKEYID=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+DNSKEY\s+256" "${SIGNED_ZONES}/example.com" | grep -Eo 'id = [0-9]+ \(zsk\)' | grep -Eo '[0-9]+') && echo " ${DNSKEYID}" &&
+l $LINENO && echo -n "Capturing RRSIG A KEYTAG.." && KEYTAG=$(grep -E -- "^example.com.\s+[0-9]+\s+IN\s+RRSIG\s+A" "${SIGNED_ZONES}/example.com" | awk '{print $11}') && echo " ${KEYTAG}" &&
+l $LINENO && echo -n "Capturing DNSKEY ${DNSKEYID} status.." && ZSKDNSKEYSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${DNSKEYID}) && echo " ${ZSKDNSKEYSTATUS}" &&
+l $LINENO && echo -n "Capturing DNSKEY ${KEYTAG} status.." && ZSKKEYTAGSTATUS=$(ods-enforcer key list --all --verbose | awk '{print $2,$3,$10}' | grep ${KEYTAG}) && echo " ${ZSKKEYTAGSTATUS}" &&
+l $LINENO && echo "Checking ZSK ${DNSKEYID} is active.." && [ "${ZSKDNSKEYSTATUS}" == "ZSK active ${DNSKEYID}" ] &&
+l $LINENO && echo "Checking ZSK ${KEYTAG} is retire.." && [ "${ZSKKEYTAGSTATUS}" == "ZSK retire ${KEYTAG}" ] &&
+l $LINENO && echo "Testing KEYTAG equality (DNSKEYID: $DNSKEYID == KEYTAG: $KEYTAG ?).." && [ "${DNSKEYID}" == "${KEYTAG}" ] &&
+#########################################################################
+
+# Shutdown
+l $LINENO && ods_stop_ods-control &&
+
+# NOTE: You can change this to "return 1" to prevent testdir/_xxx log files being cleaned up
+return 0
+
+# One of the statements above failed, abort.
+l $LINENO && echo '*********** ERROR **********'
+l $LINENO && ods_kill
+return 1

--- a/testing/test-cases.d/signer.support_229/unsigned/example.com
+++ b/testing/test-cases.d/signer.support_229/unsigned/example.com
@@ -1,0 +1,4 @@
+example.com.	86400	IN	SOA	ns1.example.com. postmaster.example.com. 2009060301 10800 3600 604800 86400
+example.com.	86400	IN	NS	ns1.example.com.
+example.com.	86400	IN	NS	ns2.example.com.
+example.com.	86400	IN	A	192.0.2.1

--- a/testing/test-cases.d/signer.support_229/zonelist.xml
+++ b/testing/test-cases.d/signer.support_229/zonelist.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ZoneList>
+	<Zone name="example.com">
+		<Policy>default</Policy>
+		<SignerConfiguration>@INSTALL_ROOT@/var/opendnssec/signconf/example.com.xml</SignerConfiguration>
+		<Adapters>
+			<Input>
+				<File>@INSTALL_ROOT@/var/opendnssec/unsigned/example.com</File>
+			</Input>
+			<Output>
+				<File>@INSTALL_ROOT@/var/opendnssec/signed/example.com</File>
+			</Output>
+		</Adapters>
+	</Zone>
+</ZoneList>


### PR DESCRIPTION
The test currently fails for the same reason as SUPPORT-229, namely that the zone ends up broken because the RRSIGs were created by a ZSK which ceases to exist thus orphaning the RRSIGs meaning that they cannot be verified.