### PR TITLE
conf/conf.rn*: fix AllowExtraction

### DIFF
--- a/conf/conf.rnc
+++ b/conf/conf.rnc
@@ -53,7 +53,7 @@ start = element Configuration {
 			element SkipPublicKey { empty }? &
 
 			# Generate extractable keys (CKA_EXTRACTABLE = TRUE) (optional)
-			element AllowExtract { empty }?
+			element AllowExtraction { empty }?
 
 		}*
 	} &

--- a/conf/conf.rng
+++ b/conf/conf.rng
@@ -75,7 +75,7 @@
                 </optional>
                 <optional>
                   <!-- Generate extractable keys (CKA_EXTRACTABLE = TRUE) (optional) -->
-                  <element name="AllowExtract">
+                  <element name="AllowExtraction">
                     <empty/>
                   </element>
                 </optional>


### PR DESCRIPTION
A trivial naming mistake in the conf/conf.rn[cg] files breaks the
AllowExtraction configuration option. Patch upstreamed from Debian,
bug #928021.