### PR TITLE
Memory leak

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ OpenDNSSEC 2.1.5 - 2019-11-05
 * SUPPORT-244: Don't require Host and Port to be specified in conf.xml
   when migrating with a MySQL-based enforcer database backend.
 * Allow for MySQL database to be pre-generated when running the migration.
+* Full list of key states, that combined the -d and -v without trying to 
+  be backwards compatible.
 
 OpenDNSSEC 2.1.4 - 2019-05-16
 

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ OpenDNSSEC 2.1.5 - 2019-11-05
 * Allow for MySQL database to be pre-generated when running the migration.
 * Full list of key states, that combined the -d and -v without trying to 
   be backwards compatible.
+* SUPPORT-242: Skip over EDNS cookie option (thanks to Ha¥vard Eidne and
+  Ulrich-Lorenz Schlueter).
 
 OpenDNSSEC 2.1.4 - 2019-05-16
 

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,9 @@
-OpenDNSSEC 2.1.5 - unplanned
+OpenDNSSEC 2.1.5 - 2019-11-05
+
+* SUPPORT-245: Resolve memory leak in signer since 2.1.4.
+* SUPPORT-244: Don't require Host and Port to be specified in conf.xml
+  when migrating with a MySQL-based enforcer database backend.
+* Allow for MySQL database to be pre-generated when running the migration.
 
 OpenDNSSEC 2.1.4 - 2019-05-16
 

--- a/common/scheduler/task.c
+++ b/common/scheduler/task.c
@@ -201,7 +201,7 @@ task_compare_time_then_ttuple(const void* a, const void* b)
 
     if (x->due_date != schedule_WHENEVER && y->due_date != schedule_WHENEVER) {
         if (x->due_date != y->due_date) {
-            return (int) x->due_date - y->due_date;
+            return x->due_date - y->due_date;
         }
     }
     return cmp_ttuple(x, y);

--- a/enforcer/src/keystate/keystate_list_cmd.c
+++ b/enforcer/src/keystate/keystate_list_cmd.c
@@ -54,9 +54,9 @@ static const char *module_str = "keystate_list_task";
 #define UNR KEY_STATE_STATE_UNRETENTIVE
 #define NAV KEY_STATE_STATE_NA
 
-enum {KS_GEN = 0, KS_PUB, KS_RDY, KS_ACT, KS_RET, KS_UNK, KS_MIX};
+enum {KS_GEN = 0, KS_PUB, KS_RDY, KS_ACT, KS_RET, KS_UNK, KS_MIX, KS_DEAD};
 const char* statenames[] = {"generate", "publish", "ready",
-		"active", "retire", "unknown", "mixed"};
+		"active", "retire", "unknown", "mixed", "dead"};
 
 /** Map 2.0 states to 1.x states
  * @param p: state of RR higher in the chain (e.g. DS)
@@ -148,7 +148,10 @@ map_keytime(const zone_db_t *zone, const key_data_t *key)
 			return strdup("waiting for ds-retract");
 		case KEY_DATA_DS_AT_PARENT_RETRACTED:
 			return strdup("waiting for ds-gone");
-		default:
+            case KEY_DATA_DS_AT_PARENT_INVALID: return strdup("ds-invalid");
+            case KEY_DATA_DS_AT_PARENT_UNSUBMITTED: return strdup("ds-unsubmitted");
+            case KEY_DATA_DS_AT_PARENT_SEEN: return strdup("ds-seen");
+            default:
 			break;
 	}
 	if (zone_db_next_change(zone) < 0)
@@ -280,6 +283,25 @@ printverbosekey(int sockfd, zone_db_t* zone, key_data_t* key, char* tchange, hsm
 }
 
 static void
+printFullkey(int sockfd, zone_db_t* zone, key_data_t* key, char* tchange, hsm_key_t* hsmkey) {
+    (void)tchange;
+    client_printf(sockfd,
+            "%-31s %-8s %-9s %d %s %-12s %-12s %-12s %-12s %d %4d    %s\n",
+            zone_db_name(zone),
+            key_data_role_text(key),
+            map_keystate(key),
+            key_data_keytag(key),
+            hsm_key_locator(hsmkey),
+            key_state_state_text(key_data_cached_ds(key)),
+            key_state_state_text(key_data_cached_dnskey(key)),
+            key_state_state_text(key_data_cached_rrsigdnskey(key)),
+            key_state_state_text(key_data_cached_rrsig(key)),
+            key_data_publish(key),
+            key_data_active_ksk(key) | key_data_active_zsk(key),
+            tchange);
+}
+
+static void
 printverboseparsablekey(int sockfd, zone_db_t* zone, key_data_t* key, char* tchange, hsm_key_t* hsmkey) {
     client_printf(sockfd,
             "%s;%s;%s;%s;%d;%d;%s;%s;%d\n",
@@ -341,7 +363,7 @@ run(int sockfd, cmdhandler_ctx_type* context, const char *cmd)
     #define NARGV 12
     const char *argv[NARGV];
     int success, argIndex;
-    int argc = 0, bVerbose = 0, bDebug = 0, bParsable = 0, bAll = 0;
+    int argc = 0, bVerbose = 0, bDebug = 0, bFull = 0, bParsable = 0, bAll = 0;
     int long_index = 0, opt = 0;
     const char* keytype = NULL;
     const char* keystate = NULL;
@@ -351,6 +373,7 @@ run(int sockfd, cmdhandler_ctx_type* context, const char *cmd)
     static struct option long_options[] = {
         {"verbose", no_argument, 0, 'v'},
         {"debug", no_argument, 0, 'd'},
+        {"full", no_argument, 0, 'f'},
         {"parsable", no_argument, 0, 'p'},
         {"zone", required_argument, 0, 'z'},
         {"keytype", required_argument, 0, 't'},
@@ -374,13 +397,16 @@ run(int sockfd, cmdhandler_ctx_type* context, const char *cmd)
         return -1;
     }
     optind = 0;
-    while ((opt = getopt_long(argc, (char* const*)argv, "vdpz:t:e:a", long_options, &long_index) ) != -1) {
+    while ((opt = getopt_long(argc, (char* const*)argv, "vdfpz:t:e:a", long_options, &long_index) ) != -1) {
         switch (opt) {
             case 'v':
                 bVerbose = 1;
                 break;
             case 'd':
                 bDebug = 1;
+                break;
+            case 'f':
+                bFull = 1;
                 break;
             case 'p':
                 bParsable = 1;
@@ -410,7 +436,9 @@ run(int sockfd, cmdhandler_ctx_type* context, const char *cmd)
         return -1;
     }
 
-    if (bDebug) {
+    if (bFull) {
+        success = perform_keystate_list(sockfd, dbconn, zonename, keytype, keystate, NULL, &printFullkey);
+    } else if (bDebug) {
         if (bParsable) {
             success = perform_keystate_list(sockfd, dbconn, zonename, keytype, keystate, NULL, &printdebugparsablekey);
         } else {

--- a/enforcer/src/ods-migrate.c
+++ b/enforcer/src/ods-migrate.c
@@ -372,7 +372,8 @@ main(int argc, char* argv[])
     cfg->verbosity = verbosity;
     /* does it make sense? */
     if (engine_config_check(cfg) != ODS_STATUS_OK) {
-        abort(); /* TODO give some error, abort */
+        fprintf(stderr,"Configuration error.\n");
+        exit(1);
     }
 
     status = hsm_open2(parse_conf_repositories(cfgfile), hsm_prompt_pin);
@@ -381,7 +382,6 @@ main(int argc, char* argv[])
         if (errorstr != NULL) {
             fprintf(stderr, "%s", errorstr);
             free(errorstr);
-            abort(); /* FIXME */
         } else {
             fprintf(stderr,"error opening libhsm (errno %i)\n", status);
         }
@@ -395,6 +395,7 @@ main(int argc, char* argv[])
             dblayer_sqlite3_open(cfg->datastore);
 #else
             fprintf(stderr, "Database SQLite3 not available during compile-time.\n");
+            exit(1);
 #endif
             break;
         case ENFORCER_DATABASE_TYPE_MYSQL:
@@ -402,11 +403,14 @@ main(int argc, char* argv[])
             dblayer_mysql_open(cfg->db_host, cfg->db_username, cfg->db_password, cfg->datastore, cfg->db_port, NULL);
 #else
     fprintf(stderr, "Database MySQL not available during compile-time.\n");
+    exit(1);
 #endif
             break;
         case ENFORCER_DATABASE_TYPE_NONE:
         default:
-            fprintf(stderr, "No database defined\n");
+            fprintf(stderr, "No database defined, possible mismatch build\n");
+            fprintf(stderr, "and configuration for SQLite3 or MySQL.\n");
+            exit(1);
     }
 
     dblayer_foreach(listQueryStr, updateQueryStr, &compute);

--- a/enforcer/src/parser/confparser.c
+++ b/enforcer/src/parser/confparser.c
@@ -680,7 +680,7 @@ engineconfig_database_type_t parse_conf_db_type(const char *cfgfile) {
 
     if ((str = parse_conf_string(
         cfgfile,
-        "//Configuration/Enforcer/Datastore/MySQL/Host",
+        "//Configuration/Enforcer/Datastore/MySQL/Database",
         0)))
     {
         free((void*)str);

--- a/enforcer/utils/1.4-2.0_db_convert/convert_mysql
+++ b/enforcer/utils/1.4-2.0_db_convert/convert_mysql
@@ -52,7 +52,7 @@ if [[ $Z = *[![:space:]]* ]]; then
 fi
 
 echo "Creating database $DB_OUT (as user $DB_USR)"
-echo "DROP DATABASE IF EXISTS $DB_OUT;CREATE DATABASE $DB_OUT;" | 
+echo "CREATE DATABASE IF NOT EXISTS $DB_OUT;" | 
 	mysql -u $DB_USR -p$DB_PWD -h $DB_HOST
 
 echo "Creating tables in $DB_OUT (as user $DB_USR)"

--- a/signer/src/wire/edns.c
+++ b/signer/src/wire/edns.c
@@ -112,6 +112,7 @@ edns_rr_parse(edns_rr_type* err, buffer_type* buffer)
     uint16_t opt_class;
     uint8_t  opt_version;
     uint16_t opt_flags;
+    uint16_t opt_rdlen;
 
     if (!err || !buffer) {
         ods_log_debug("[%s] parse: no edns rr or no packet buffer available",
@@ -137,7 +138,8 @@ edns_rr_parse(edns_rr_type* err, buffer_type* buffer)
     (void)buffer_read_u8(buffer); /* opt_extended_rcode */
     opt_version = buffer_read_u8(buffer);
     opt_flags = buffer_read_u16(buffer);
-    (void)buffer_read_u16(buffer); /* opt_rdlen */
+    opt_rdlen = buffer_read_u16(buffer);
+    buffer_skip(buffer, opt_rdlen);
 
     if (opt_version != 0) {
         /* The only error is VERSION not implemented */

--- a/version.m4
+++ b/version.m4
@@ -1,3 +1,3 @@
 # this file contains the current OpenDNSSEC version
 
-define([OPENDNSSEC_VERSION], [2.1.5-dev])
+define([OPENDNSSEC_VERSION], [2.1.5])


### PR DESCRIPTION
SUPPORT-245, SUPPORT-244:
Resolve memory leak in signer since 2.1.4.
Don't require Host and Port to be specified in conf.xml   when migrating with a MySQL-based enforcer database backend.
Allow for MySQL database to be pre-generated when running the migration.
Full list of key states, that combined the -d and -v without trying to  be backwards compatible.
