### PR TITLE
Fix build failure on gcc10

### DIFF
--- a/enforcer/src/daemon/ctrl_cmd.h
+++ b/enforcer/src/daemon/ctrl_cmd.h
@@ -29,6 +29,6 @@
 #ifndef _CTRL_CMD_H_
 #define _CTRL_CMD_H_
 
-struct cmd_func_block ctrl_funcblock;
+extern struct cmd_func_block ctrl_funcblock;
 
 #endif /* _CTRL_CMD_H_ */

--- a/enforcer/src/daemon/enforcercommands.h
+++ b/enforcer/src/daemon/enforcercommands.h
@@ -37,9 +37,9 @@
 #include "engine.h"
 #include "db/dbw.h"
 
-struct cmd_func_block** enforcercommands;
+extern struct cmd_func_block** enforcercommands;
 
-engine_type* getglobalcontext(cmdhandler_ctx_type*);
-db_connection_t* getconnectioncontext(cmdhandler_ctx_type*);
+extern engine_type* getglobalcontext(cmdhandler_ctx_type*);
+extern db_connection_t* getconnectioncontext(cmdhandler_ctx_type*);
 
 #endif

--- a/enforcer/src/daemon/engine.h
+++ b/enforcer/src/daemon/engine.h
@@ -72,7 +72,7 @@ struct engine_struct {
  * \param engine, the engine containing database configuration
  * \return connection on success, NULL on failure.
  */
-db_connection_t* get_database_connection(engine_type* engine);
+extern db_connection_t* get_database_connection(engine_type* engine);
 
 
 /**
@@ -84,16 +84,16 @@ db_connection_t* get_database_connection(engine_type* engine);
  *            for the command to a socket.
  */
 
-ods_status engine_setup(void);
+extern ods_status engine_setup(void);
 
 /**
  * Clean up engine.
  * \param[in] engine engine
  *
  */
-void engine_teardown(engine_type* engine);
+extern void engine_teardown(engine_type* engine);
 
-void engine_init(engine_type* engine, int daemonize);
+extern void engine_init(engine_type* engine, int daemonize);
 
 typedef void (*start_cb_t)(engine_type* engine);
 
@@ -106,29 +106,29 @@ typedef void (*start_cb_t)(engine_type* engine);
  * \return 0 if terminated normally, 1 on unrecoverable error.
  *
  */
-int engine_run(engine_type* engine, start_cb_t start, int single_run);
+extern int engine_run(engine_type* engine, start_cb_t start, int single_run);
 
 /**
  * Stop the engine after engine_runloop returns.
  * \param[in] engine engine
  *
  */
-void engine_stop(engine_type* engine);
+extern void engine_stop(engine_type* engine);
 
 /**
  * Wake up workers.
  * \param[in] engine engine
  *
  */
-void engine_wakeup_workers(engine_type* engine);
+extern void engine_wakeup_workers(engine_type* engine);
 /** signal all workers to stop. Blocks until all workers are joined.
  * \param[in] engine engine */
-void engine_stop_workers(engine_type* engine);
+extern void engine_stop_workers(engine_type* engine);
 /** start all workers.
  * \param[in] engine engine */
-void engine_start_workers(engine_type* engine);
+extern void engine_start_workers(engine_type* engine);
 
-engine_type* engine_alloc(void);
-void engine_dealloc(engine_type* engine);
+extern engine_type* engine_alloc(void);
+extern void engine_dealloc(engine_type* engine);
 
 #endif /* DAEMON_ENGINE_H */

--- a/enforcer/src/daemon/help_cmd.h
+++ b/enforcer/src/daemon/help_cmd.h
@@ -29,6 +29,6 @@
 #ifndef _HELP_CMD_H_
 #define _HELP_CMD_H_
 
-struct cmd_func_block help_funcblock;
+extern struct cmd_func_block help_funcblock;
 
 #endif /* _HELP_CMD_H_ */

--- a/enforcer/src/daemon/queue_cmd.h
+++ b/enforcer/src/daemon/queue_cmd.h
@@ -29,7 +29,7 @@
 #ifndef _QUEUE_CMD_H_
 #define _QUEUE_CMD_H_
 
-struct cmd_func_block queue_funcblock;
-struct cmd_func_block flush_funcblock;
+extern struct cmd_func_block queue_funcblock;
+extern struct cmd_func_block flush_funcblock;
 
 #endif /* _QUEUE_CMD_H_ */

--- a/enforcer/src/daemon/time_leap_cmd.h
+++ b/enforcer/src/daemon/time_leap_cmd.h
@@ -29,6 +29,6 @@
 #ifndef _TIME_LEAP_CMD_H_
 #define _TIME_LEAP_CMD_H_
 
-struct cmd_func_block time_leap_funcblock;
+extern struct cmd_func_block time_leap_funcblock;
 
 #endif /* _TIME_LEAP_CMD_H_ */

--- a/enforcer/src/daemon/verbosity_cmd.h
+++ b/enforcer/src/daemon/verbosity_cmd.h
@@ -29,6 +29,6 @@
 #ifndef _VERBOSITY_CMD_H_
 #define _VERBOSITY_CMD_H_
 
-struct cmd_func_block verbosity_funcblock;
+extern struct cmd_func_block verbosity_funcblock;
 
 #endif /* _VERBOSITY_CMD_H_ */

--- a/enforcer/src/db/database_version.h
+++ b/enforcer/src/db/database_version.h
@@ -54,13 +54,13 @@ struct database_version {
  * \param[in] connection a db_connection_t pointer.
  * \return a database_version_t pointer or NULL on error.
  */
-database_version_t* database_version_new(const db_connection_t* connection);
+extern database_version_t* database_version_new(const db_connection_t* connection);
 
 /**
  * Delete a database version object, this does not delete it from the database.
  * \param[in] database_version a database_version_t pointer.
  */
-void database_version_free(database_version_t* database_version);
+extern void database_version_free(database_version_t* database_version);
 
 /**
  * Set the content of a database version object based on a database result.
@@ -68,14 +68,14 @@ void database_version_free(database_version_t* database_version);
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int database_version_from_result(database_version_t* database_version, const db_result_t* result);
+extern int database_version_from_result(database_version_t* database_version, const db_result_t* result);
 
 /**
  * Get the version of a database version object. Undefined behavior if `database_version` is NULL.
  * \param[in] database_version a database_version_t pointer.
  * \return an unsigned integer.
  */
-unsigned int database_version_version(const database_version_t* database_version);
+extern unsigned int database_version_version(const database_version_t* database_version);
 
 /**
  * A list of database version objects.
@@ -98,27 +98,27 @@ struct database_version_list {
  * \param[in] connection a db_connection_t pointer.
  * \return a database_version_list_t pointer or NULL on error.
  */
-database_version_list_t* database_version_list_new(const db_connection_t* connection);
+extern database_version_list_t* database_version_list_new(const db_connection_t* connection);
 
 /**
  * Delete a database version object list.
  * \param[in] database_version_list a database_version_list_t pointer.
  */
-void database_version_list_free(database_version_list_t* database_version_list);
+extern void database_version_list_free(database_version_list_t* database_version_list);
 
 /**
  * Get all database version objects.
  * \param[in] database_version_list a database_version_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int database_version_list_get(database_version_list_t* database_version_list);
+extern int database_version_list_get(database_version_list_t* database_version_list);
 
 /**
  * Get a new list with all database version objects.
  * \param[in] connection a db_connection_t pointer.
  * \return a database_version_list_t pointer or NULL on error.
  */
-database_version_list_t* database_version_list_new_get(const db_connection_t* connection);
+extern database_version_list_t* database_version_list_new_get(const db_connection_t* connection);
 
 /**
  * Get the next database version object in a database version object list.
@@ -128,6 +128,6 @@ database_version_list_t* database_version_list_new_get(const db_connection_t* co
  * \return a database_version_t pointer or NULL on error or if there are no more
  * database version objects in the database version object list.
  */
-const database_version_t* database_version_list_next(database_version_list_t* database_version_list);
+extern const database_version_t* database_version_list_next(database_version_list_t* database_version_list);
 
 #endif

--- a/enforcer/src/db/database_version_ext.h
+++ b/enforcer/src/db/database_version_ext.h
@@ -37,6 +37,6 @@
  * \param[in] a db_connection_t pointer.
  * \return an integer with the database version or zero on error.
  */
-int database_version_get_version(db_connection_t* connection);
+extern int database_version_get_version(db_connection_t* connection);
 
 #endif

--- a/enforcer/src/db/db_backend.h
+++ b/enforcer/src/db/db_backend.h
@@ -190,21 +190,21 @@ struct db_backend_handle {
  * Create a new database backend handle.
  * \return a db_backend_handle_t pointer or NULL on error.
  */
-db_backend_handle_t* db_backend_handle_new(void);
+extern db_backend_handle_t* db_backend_handle_new(void);
 
 /**
  * Delete a database backend handle, disconnecting the backend and freeing the
  * backend specific data.
  * \param[in] backend_handle a db_backend_handle_t pointer.
  */
-void db_backend_handle_free(db_backend_handle_t* backend_handle);
+extern void db_backend_handle_free(db_backend_handle_t* backend_handle);
 
 /**
  * Initiate the backend of a database backend.
  * \param[in] backend_handle a db_backend_handle_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_initialize(const db_backend_handle_t* backend_handle);
+extern int db_backend_handle_initialize(const db_backend_handle_t* backend_handle);
 
 /**
  * Connect to the database of a database backend, the connection specific
@@ -213,7 +213,7 @@ int db_backend_handle_initialize(const db_backend_handle_t* backend_handle);
  * \param[in] configuration_list a db_configuration_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_connect(const db_backend_handle_t* backend_handle, const db_configuration_list_t* configuration_list);
+extern int db_backend_handle_connect(const db_backend_handle_t* backend_handle, const db_configuration_list_t* configuration_list);
 
 /**
  * Create an object in the database. The `object` refer to the database object
@@ -225,7 +225,7 @@ int db_backend_handle_connect(const db_backend_handle_t* backend_handle, const d
  * \param[in] value_set a db_value_set_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_create(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set);
+extern int db_backend_handle_create(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set);
 
 /**
  * Read an object or objects from the database.
@@ -236,7 +236,7 @@ int db_backend_handle_create(const db_backend_handle_t* backend_handle, const db
  * \return a db_result_list_t pointer or NULL on error or if no objects where
  * read.
  */
-db_result_list_t* db_backend_handle_read(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
+extern db_result_list_t* db_backend_handle_read(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
 
 /**
  * Update an object or objects in the database.
@@ -247,7 +247,7 @@ db_result_list_t* db_backend_handle_read(const db_backend_handle_t* backend_hand
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_update(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
+extern int db_backend_handle_update(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
 
 /**
  * Delete an object or objects from the database.
@@ -256,7 +256,7 @@ int db_backend_handle_update(const db_backend_handle_t* backend_handle, const db
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_delete(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_clause_list_t* clause_list);
+extern int db_backend_handle_delete(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_clause_list_t* clause_list);
 
 /**
  * Count objects from the database. Return the count in `count`.
@@ -267,7 +267,7 @@ int db_backend_handle_delete(const db_backend_handle_t* backend_handle, const db
  * \param[out] count a size_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_count(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
+extern int db_backend_handle_count(const db_backend_handle_t* backend_handle, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
 
 /**
  * Set the initialize function of a database backend handle.
@@ -275,7 +275,7 @@ int db_backend_handle_count(const db_backend_handle_t* backend_handle, const db_
  * \param[in] initialize_function a db_backend_handle_initialize_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_initialize(db_backend_handle_t* backend_handle, db_backend_handle_initialize_t initialize_function);
+extern int db_backend_handle_set_initialize(db_backend_handle_t* backend_handle, db_backend_handle_initialize_t initialize_function);
 
 /**
  * Set the shutdown function of a database backend handle.
@@ -283,7 +283,7 @@ int db_backend_handle_set_initialize(db_backend_handle_t* backend_handle, db_bac
  * \param[in] shutdown_function a db_backend_handle_shutdown_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_shutdown(db_backend_handle_t* backend_handle, db_backend_handle_shutdown_t shutdown_function);
+extern int db_backend_handle_set_shutdown(db_backend_handle_t* backend_handle, db_backend_handle_shutdown_t shutdown_function);
 
 /**
  * Set the connect function of a database backend handle.
@@ -291,7 +291,7 @@ int db_backend_handle_set_shutdown(db_backend_handle_t* backend_handle, db_backe
  * \param[in] connect_function a db_backend_handle_connect_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_connect(db_backend_handle_t* backend_handle, db_backend_handle_connect_t connect_function);
+extern int db_backend_handle_set_connect(db_backend_handle_t* backend_handle, db_backend_handle_connect_t connect_function);
 
 /**
  * Set the disconnect function of a database backend handle.
@@ -299,7 +299,7 @@ int db_backend_handle_set_connect(db_backend_handle_t* backend_handle, db_backen
  * \param[in] disconnect_function a db_backend_handle_disconnect_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_disconnect(db_backend_handle_t* backend_handle, db_backend_handle_disconnect_t disconnect_function);
+extern int db_backend_handle_set_disconnect(db_backend_handle_t* backend_handle, db_backend_handle_disconnect_t disconnect_function);
 
 int db_backend_handle_set_last_id(db_backend_handle_t* backend_handle, db_backend_handle_last_id_t last_id_function);
 
@@ -309,7 +309,7 @@ int db_backend_handle_set_last_id(db_backend_handle_t* backend_handle, db_backen
  * \param[in] create_function a db_backend_handle_create_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_create(db_backend_handle_t* backend_handle, db_backend_handle_create_t create_function);
+extern int db_backend_handle_set_create(db_backend_handle_t* backend_handle, db_backend_handle_create_t create_function);
 
 /**
  * Set the read function of a database backend handle.
@@ -317,7 +317,7 @@ int db_backend_handle_set_create(db_backend_handle_t* backend_handle, db_backend
  * \param[in] read_function a db_backend_handle_read_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_read(db_backend_handle_t* backend_handle, db_backend_handle_read_t read_function);
+extern int db_backend_handle_set_read(db_backend_handle_t* backend_handle, db_backend_handle_read_t read_function);
 
 /**
  * Set the update function of a database backend handle.
@@ -325,7 +325,7 @@ int db_backend_handle_set_read(db_backend_handle_t* backend_handle, db_backend_h
  * \param[in] update_function a db_backend_handle_update_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_update(db_backend_handle_t* backend_handle, db_backend_handle_update_t update_function);
+extern int db_backend_handle_set_update(db_backend_handle_t* backend_handle, db_backend_handle_update_t update_function);
 
 /**
  * Set the delete function of a database backend handle.
@@ -333,7 +333,7 @@ int db_backend_handle_set_update(db_backend_handle_t* backend_handle, db_backend
  * \param[in] delete_function a db_backend_handle_delete_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_delete(db_backend_handle_t* backend_handle, db_backend_handle_delete_t delete_function);
+extern int db_backend_handle_set_delete(db_backend_handle_t* backend_handle, db_backend_handle_delete_t delete_function);
 
 /**
  * Set the count function of a database backend handle.
@@ -341,7 +341,7 @@ int db_backend_handle_set_delete(db_backend_handle_t* backend_handle, db_backend
  * \param[in] count_function a db_backend_handle_count_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_count(db_backend_handle_t* backend_handle, db_backend_handle_count_t count_function);
+extern int db_backend_handle_set_count(db_backend_handle_t* backend_handle, db_backend_handle_count_t count_function);
 
 /**
  * Set the free function of a database backend handle.
@@ -349,7 +349,7 @@ int db_backend_handle_set_count(db_backend_handle_t* backend_handle, db_backend_
  * \param[in] free_function a db_backend_handle_free_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_free(db_backend_handle_t* backend_handle, db_backend_handle_free_t free_function);
+extern int db_backend_handle_set_free(db_backend_handle_t* backend_handle, db_backend_handle_free_t free_function);
 
 /**
  * Set the transaction begin function of a database backend handle.
@@ -357,7 +357,7 @@ int db_backend_handle_set_free(db_backend_handle_t* backend_handle, db_backend_h
  * \param[in] transaction_begin_function a db_backend_handle_transaction_begin_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_transaction_begin(db_backend_handle_t* backend_handle, db_backend_handle_transaction_begin_t transaction_begin_function);
+extern int db_backend_handle_set_transaction_begin(db_backend_handle_t* backend_handle, db_backend_handle_transaction_begin_t transaction_begin_function);
 
 /**
  * Set the transaction commit function of a database backend handle.
@@ -365,7 +365,7 @@ int db_backend_handle_set_transaction_begin(db_backend_handle_t* backend_handle,
  * \param[in] transaction_commit_function a db_backend_handle_transaction_commit_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_transaction_commit(db_backend_handle_t* backend_handle, db_backend_handle_transaction_commit_t transaction_commit_function);
+extern int db_backend_handle_set_transaction_commit(db_backend_handle_t* backend_handle, db_backend_handle_transaction_commit_t transaction_commit_function);
 
 /**
  * Set the transaction rollback function of a database backend handle.
@@ -373,7 +373,7 @@ int db_backend_handle_set_transaction_commit(db_backend_handle_t* backend_handle
  * \param[in] transaction_rollback_function a db_backend_handle_transaction_rollback_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_transaction_rollback(db_backend_handle_t* backend_handle, db_backend_handle_transaction_rollback_t transaction_rollback_function);
+extern int db_backend_handle_set_transaction_rollback(db_backend_handle_t* backend_handle, db_backend_handle_transaction_rollback_t transaction_rollback_function);
 
 /**
  * Set the backend specific data of a database backend handle.
@@ -381,7 +381,7 @@ int db_backend_handle_set_transaction_rollback(db_backend_handle_t* backend_hand
  * \param[in] data a void pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_handle_set_data(db_backend_handle_t* backend_handle, void* data);
+extern int db_backend_handle_set_data(db_backend_handle_t* backend_handle, void* data);
 
 /**
  * A database backend.
@@ -396,13 +396,13 @@ struct db_backend {
  * Create a new database backend.
  * \return a db_backend_t pointer or NULL on error.
  */
-db_backend_t* db_backend_new(void);
+extern db_backend_t* db_backend_new(void);
 
 /**
  * Delete a database backend.
  * \param[in] backend a db_backend_t pointer.
  */
-void db_backend_free(db_backend_t* backend);
+extern void db_backend_free(db_backend_t* backend);
 
 /**
  * Get the database backend handle of a database backend.
@@ -410,7 +410,7 @@ void db_backend_free(db_backend_t* backend);
  * \return a db_backend_handle_t pointer or NULL on error or if no database
  * backend handle has been set.
  */
-const db_backend_handle_t* db_backend_handle(const db_backend_t* backend);
+extern const db_backend_handle_t* db_backend_handle(const db_backend_t* backend);
 
 /**
  * Set the name of a database backend.
@@ -418,7 +418,7 @@ const db_backend_handle_t* db_backend_handle(const db_backend_t* backend);
  * \param[in] name a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_set_name(db_backend_t* backend, const char* name);
+extern int db_backend_set_name(db_backend_t* backend, const char* name);
 
 /**
  * Det the database backend handle of a database backend, this takes over the
@@ -427,14 +427,14 @@ int db_backend_set_name(db_backend_t* backend, const char* name);
  * \param[in] handle a db_backend_handle_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_set_handle(db_backend_t* backend, db_backend_handle_t* handle);
+extern int db_backend_set_handle(db_backend_t* backend, db_backend_handle_t* handle);
 
 /**
  * Initiate the backend of a database backend.
  * \param[in] backend a db_backend_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_initialize(const db_backend_t* backend);
+extern int db_backend_initialize(const db_backend_t* backend);
 
 /**
  * Connect to the database of a database backend, the connection specific
@@ -443,7 +443,7 @@ int db_backend_initialize(const db_backend_t* backend);
  * \param[in] configuration_list a db_configuration_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_connect(const db_backend_t* backend, const db_configuration_list_t* configuration_list);
+extern int db_backend_connect(const db_backend_t* backend, const db_configuration_list_t* configuration_list);
 
 int db_backend_last_id(const db_backend_t* backend, int *last_id);
 
@@ -457,7 +457,7 @@ int db_backend_last_id(const db_backend_t* backend, int *last_id);
  * \param[in] value_set a db_value_set_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_create(const db_backend_t* backend, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set);
+extern int db_backend_create(const db_backend_t* backend, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set);
 
 /**
  * Read an object or objects from the database.
@@ -468,7 +468,7 @@ int db_backend_create(const db_backend_t* backend, const db_object_t* object, co
  * \return a db_result_list_t pointer or NULL on error or if no objects where
  * read.
  */
-db_result_list_t* db_backend_read(const db_backend_t* backend, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
+extern db_result_list_t* db_backend_read(const db_backend_t* backend, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
 
 /**
  * Update an object or objects in the database.
@@ -479,7 +479,7 @@ db_result_list_t* db_backend_read(const db_backend_t* backend, const db_object_t
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_update(const db_backend_t* backend, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
+extern int db_backend_update(const db_backend_t* backend, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
 
 /**
  * Delete an object or objects from the database.
@@ -488,7 +488,7 @@ int db_backend_update(const db_backend_t* backend, const db_object_t* object, co
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_delete(const db_backend_t* backend, const db_object_t* object, const db_clause_list_t* clause_list);
+extern int db_backend_delete(const db_backend_t* backend, const db_object_t* object, const db_clause_list_t* clause_list);
 
 /**
  * Count objects from the database. Return the count in `count`.
@@ -499,7 +499,7 @@ int db_backend_delete(const db_backend_t* backend, const db_object_t* object, co
  * \param[out] count a size_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_backend_count(const db_backend_t* backend, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
+extern int db_backend_count(const db_backend_t* backend, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
 
 /**
  * Get a new database backend by the name supplied in `name`.
@@ -507,6 +507,6 @@ int db_backend_count(const db_backend_t* backend, const db_object_t* object, con
  * \return a db_backend_t pointer or NULL on error or if the database backend
  * does not exist.
  */
-db_backend_t* db_backend_factory_get_backend(const char* name);
+extern db_backend_t* db_backend_factory_get_backend(const char* name);
 
 #endif

--- a/enforcer/src/db/db_backend_mysql.h
+++ b/enforcer/src/db/db_backend_mysql.h
@@ -40,6 +40,6 @@
  * Create a new database backend handle for SQLite.
  * \return a db_backend_handle_t pointer or NULL on error.
  */
-db_backend_handle_t* db_backend_mysql_new_handle(void);
+extern db_backend_handle_t* db_backend_mysql_new_handle(void);
 
 #endif

--- a/enforcer/src/db/db_backend_sqlite.h
+++ b/enforcer/src/db/db_backend_sqlite.h
@@ -39,6 +39,6 @@
  * Create a new database backend handle for SQLite.
  * \return a db_backend_handle_t pointer or NULL on error.
  */
-db_backend_handle_t* db_backend_sqlite_new_handle(void);
+extern db_backend_handle_t* db_backend_sqlite_new_handle(void);
 
 #endif

--- a/enforcer/src/db/db_clause.h
+++ b/enforcer/src/db/db_clause.h
@@ -129,41 +129,41 @@ struct db_clause {
  * Create a new database clause.
  * \return a db_clause_t pointer or NULL on error.
  */
-db_clause_t* db_clause_new(void);
+extern db_clause_t* db_clause_new(void);
 
 /**
  * Delete a database clause.
  * \param[in] clause a db_clause_t pointer.
  */
-void db_clause_free(db_clause_t* clause);
+extern void db_clause_free(db_clause_t* clause);
 
 /**
  * Get the field name of a database clause.
  * \param[in] a db_clause_t pointer.
  * \return a character pointer or NULL on error or if no field name has been set.
  */
-const char* db_clause_field(const db_clause_t* clause);
+extern const char* db_clause_field(const db_clause_t* clause);
 
 /**
  * Get the database clause type of a database clause.
  * \param[in] a db_clause_t pointer.
  * \return a db_clause_type_t.
  */
-db_clause_type_t db_clause_type(const db_clause_t* clause);
+extern db_clause_type_t db_clause_type(const db_clause_t* clause);
 
 /**
  * Get the database value of a database value.
  * \param[in] a db_clause_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* db_clause_value(const db_clause_t* clause);
+extern const db_value_t* db_clause_value(const db_clause_t* clause);
 
 /**
  * Get the database clause operator of a database clause.
  * \param[in] a db_clause_t pointer.
  * \return a db_clause_operator_t.
  */
-db_clause_operator_t db_clause_operator(const db_clause_t* clause);
+extern db_clause_operator_t db_clause_operator(const db_clause_t* clause);
 
 /**
  * Get the database clause list of a database clause, this is used for nested
@@ -172,7 +172,7 @@ db_clause_operator_t db_clause_operator(const db_clause_t* clause);
  * \return a db_clause_list_t pointer or NULL on error or if no database clause
  * list has been set.
  */
-const db_clause_list_t* db_clause_list(const db_clause_t* clause);
+extern const db_clause_list_t* db_clause_list(const db_clause_t* clause);
 
 /**
  * Set the field name of a database clause.
@@ -180,7 +180,7 @@ const db_clause_list_t* db_clause_list(const db_clause_t* clause);
  * \param[in] field a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_clause_set_field(db_clause_t* clause, const char* field);
+extern int db_clause_set_field(db_clause_t* clause, const char* field);
 
 /**
  * Set the database clause type of a database clause.
@@ -188,7 +188,7 @@ int db_clause_set_field(db_clause_t* clause, const char* field);
  * \param[in] type a db_clause_type_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_clause_set_type(db_clause_t* clause, db_clause_type_t type);
+extern int db_clause_set_type(db_clause_t* clause, db_clause_type_t type);
 
 /**
  * Set the database clause operator of a database clause.
@@ -196,14 +196,14 @@ int db_clause_set_type(db_clause_t* clause, db_clause_type_t type);
  * \param[in] clause_operator a db_clause_operator_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_clause_set_operator(db_clause_t* clause, db_clause_operator_t clause_operator);
+extern int db_clause_set_operator(db_clause_t* clause, db_clause_operator_t clause_operator);
 
 /**
  * Check if the database clause is not empty.
  * \param[in] a db_clause_t pointer.
  * \return DB_ERROR_* if empty, otherwise DB_OK.
  */
-int db_clause_not_empty(const db_clause_t* clause);
+extern int db_clause_not_empty(const db_clause_t* clause);
 
 /**
  * Return the next database clause connected in a database clause list.
@@ -211,14 +211,14 @@ int db_clause_not_empty(const db_clause_t* clause);
  * \return a db_clause_t pointer or NULL on error or if there are no more
  * database clauses in the list.
  */
-const db_clause_t* db_clause_next(const db_clause_t* clause);
+extern const db_clause_t* db_clause_next(const db_clause_t* clause);
 
 /**
  * Get the writable database value of a database clause.
  * \param[in] a db_clause_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-db_value_t* db_clause_get_value(db_clause_t* clause);
+extern db_value_t* db_clause_get_value(db_clause_t* clause);
 
 /**
  * A list of database clauses.
@@ -232,13 +232,13 @@ struct db_clause_list {
  * Create a new database clause list.
  * \return a db_clause_list_t pointer or NULL on error.
  */
-db_clause_list_t* db_clause_list_new(void);
+extern db_clause_list_t* db_clause_list_new(void);
 
 /**
  * Delete a database clause list and all database clauses in the list.
  * \param[in] clause_list a db_clause_list_t pointer.
  */
-void db_clause_list_free(db_clause_list_t* clause_list);
+extern void db_clause_list_free(db_clause_list_t* clause_list);
 
 /**
  * Add a database clause to a database clause list, this takes over the
@@ -247,13 +247,13 @@ void db_clause_list_free(db_clause_list_t* clause_list);
  * \param[in] a db_clause_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_clause_list_add(db_clause_list_t* clause_list, db_clause_t* clause);
+extern int db_clause_list_add(db_clause_list_t* clause_list, db_clause_t* clause);
 
 /**
  * Return the first database clause of a database clause list.
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return a db_clause_t pointer or NULL on error or if the list is empty.
  */
-const db_clause_t* db_clause_list_begin(const db_clause_list_t* clause_list);
+extern const db_clause_t* db_clause_list_begin(const db_clause_list_t* clause_list);
 
 #endif

--- a/enforcer/src/db/db_configuration.h
+++ b/enforcer/src/db/db_configuration.h
@@ -48,13 +48,13 @@ struct db_configuration {
  * Create a new database configuration.
  * \return a db_configuration_t pointer or NULL on error.
  */
-db_configuration_t* db_configuration_new(void);
+extern db_configuration_t* db_configuration_new(void);
 
 /**
  * Delete a database configuration.
  * \param[in] configuration a db_configuration_t pointer.
  */
-void db_configuration_free(db_configuration_t* configuration);
+extern void db_configuration_free(db_configuration_t* configuration);
 
 /**
  * Get the value of a database configuration.
@@ -62,7 +62,7 @@ void db_configuration_free(db_configuration_t* configuration);
  * \return a character pointer or NULL on error or if no database configuration
  * value has been set.
  */
-const char* db_configuration_value(const db_configuration_t* configuration);
+extern const char* db_configuration_value(const db_configuration_t* configuration);
 
 /**
  * Set the name of a database configuration.
@@ -70,7 +70,7 @@ const char* db_configuration_value(const db_configuration_t* configuration);
  * \param[in] name a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_configuration_set_name(db_configuration_t* configuration, const char* name);
+extern int db_configuration_set_name(db_configuration_t* configuration, const char* name);
 
 /**
  * Set the value of a database configuration.
@@ -78,14 +78,14 @@ int db_configuration_set_name(db_configuration_t* configuration, const char* nam
  * \param[in] value a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_configuration_set_value(db_configuration_t* configuration, const char* value);
+extern int db_configuration_set_value(db_configuration_t* configuration, const char* value);
 
 /**
  * Check if the database configuration is not empty.
  * \param[in] configuration a db_configuration_t pointer.
  * \return DB_ERROR_* if empty, otherwise DB_OK.
  */
-int db_configuration_not_empty(const db_configuration_t* configuration);
+extern int db_configuration_not_empty(const db_configuration_t* configuration);
 
 /**
  * A list of database configurations.
@@ -99,14 +99,14 @@ struct db_configuration_list {
  * Create a new database configuration list.
  * \return a db_configuration_list_t pointer or NULL on error.
  */
-db_configuration_list_t* db_configuration_list_new(void);
+extern db_configuration_list_t* db_configuration_list_new(void);
 
 /**
  * Delete a database configuration list and all database configurations in the
  * list.
  * \param[in] configuration_list a db_configuration_list_t pointer.
  */
-void db_configuration_list_free(db_configuration_list_t* configuration_list);
+extern void db_configuration_list_free(db_configuration_list_t* configuration_list);
 
 /**
  * free global allocator. 
@@ -119,7 +119,7 @@ void db_configuration_list_free(db_configuration_list_t* configuration_list);
  * \param[in] configuration a db_configuration_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_configuration_list_add(db_configuration_list_t* configuration_list, db_configuration_t* configuration);
+extern int db_configuration_list_add(db_configuration_list_t* configuration_list, db_configuration_t* configuration);
 
 /**
  * Find a database configuration by name within a database configuration list.
@@ -128,6 +128,6 @@ int db_configuration_list_add(db_configuration_list_t* configuration_list, db_co
  * \return a db_configuration_t pointer or NULL on error or if the database
  * configuration does not exist.
  */
-const db_configuration_t* db_configuration_list_find(const db_configuration_list_t* configuration_list, const char* name);
+extern const db_configuration_t* db_configuration_list_find(const db_configuration_list_t* configuration_list, const char* name);
 
 #endif

--- a/enforcer/src/db/db_connection.h
+++ b/enforcer/src/db/db_connection.h
@@ -52,13 +52,13 @@ struct db_connection {
  * Create a new database connection.
  * \return a db_connection_t pointer or NULL on error.
  */
-db_connection_t* db_connection_new(void);
+extern db_connection_t* db_connection_new(void);
 
 /**
  * Delete a database connection and the database backend within.
  * \param[in] connection a db_connection_t pointer.
  */
-void db_connection_free(db_connection_t* connection);
+extern void db_connection_free(db_connection_t* connection);
 
 /**
  * Set the database configuration list for a database connection.
@@ -66,7 +66,7 @@ void db_connection_free(db_connection_t* connection);
  * \param[in] configuration_list a db_configuration_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_connection_set_configuration_list(db_connection_t* connection, const db_configuration_list_t* configuration_list);
+extern int db_connection_set_configuration_list(db_connection_t* connection, const db_configuration_list_t* configuration_list);
 
 /**
  * Setup the database connection, this verifies the information in the database
@@ -74,14 +74,14 @@ int db_connection_set_configuration_list(db_connection_t* connection, const db_c
  * \param[in] connection a db_connection_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_connection_setup(db_connection_t* connection);
+extern int db_connection_setup(db_connection_t* connection);
 
 /**
  * Connect to the database.
  * \param[in] connection a db_connection_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_connection_connect(const db_connection_t* connection);
+extern int db_connection_connect(const db_connection_t* connection);
 
 int db_connection_last_id(const db_connection_t* connection, int *last_id);
 
@@ -95,7 +95,7 @@ int db_connection_last_id(const db_connection_t* connection, int *last_id);
  * \param[in] value_set a db_value_set_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_connection_create(const db_connection_t* connection, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set);
+extern int db_connection_create(const db_connection_t* connection, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set);
 
 /**
  * Read an object or objects from the database.
@@ -106,7 +106,7 @@ int db_connection_create(const db_connection_t* connection, const db_object_t* o
  * \return a db_result_list_t pointer or NULL on error or if no objects where
  * read.
  */
-db_result_list_t* db_connection_read(const db_connection_t* connection, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
+extern db_result_list_t* db_connection_read(const db_connection_t* connection, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
 
 /**
  * Update an object or objects in the database.
@@ -117,7 +117,7 @@ db_result_list_t* db_connection_read(const db_connection_t* connection, const db
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_connection_update(const db_connection_t* connection, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
+extern int db_connection_update(const db_connection_t* connection, const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
 
 /**
  * Delete an object or objects from the database.
@@ -126,7 +126,7 @@ int db_connection_update(const db_connection_t* connection, const db_object_t* o
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_connection_delete(const db_connection_t* connection, const db_object_t* object, const db_clause_list_t* clause_list);
+extern int db_connection_delete(const db_connection_t* connection, const db_object_t* object, const db_clause_list_t* clause_list);
 
 /**
  * Count objects from the database. Return the count in `count`.
@@ -137,6 +137,6 @@ int db_connection_delete(const db_connection_t* connection, const db_object_t* o
  * \param[out] count a size_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_connection_count(const db_connection_t* connection, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
+extern int db_connection_count(const db_connection_t* connection, const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
 
 #endif

--- a/enforcer/src/db/db_join.h
+++ b/enforcer/src/db/db_join.h
@@ -54,7 +54,7 @@ struct db_join {
  * \return a character pointer or NULL on error or if no from table name has
  * been set.
  */
-const char* db_join_from_table(const db_join_t* join);
+extern const char* db_join_from_table(const db_join_t* join);
 
 /**
  * Get the from field name of a database join.
@@ -62,7 +62,7 @@ const char* db_join_from_table(const db_join_t* join);
  * \return a character pointer or NULL on error or if no from field name has
  * been set.
  */
-const char* db_join_from_field(const db_join_t* join);
+extern const char* db_join_from_field(const db_join_t* join);
 
 /**
  * Get the to table name of a database join.
@@ -70,7 +70,7 @@ const char* db_join_from_field(const db_join_t* join);
  * \return a character pointer or NULL on error or if no to table name has been
  * set.
  */
-const char* db_join_to_table(const db_join_t* join);
+extern const char* db_join_to_table(const db_join_t* join);
 
 /**
  * Get the to field name of a database join.
@@ -78,7 +78,7 @@ const char* db_join_to_table(const db_join_t* join);
  * \return a character pointer or NULL on error or if no to field name has been
  * set.
  */
-const char* db_join_to_field(const db_join_t* join);
+extern const char* db_join_to_field(const db_join_t* join);
 
 /**
  * Get the next database join connected in a database join list.
@@ -86,7 +86,7 @@ const char* db_join_to_field(const db_join_t* join);
  * \return a db_join_t pointer or NULL on error or if there are no more database
  * joins in the list.
  */
-const db_join_t* db_join_next(const db_join_t* join);
+extern const db_join_t* db_join_next(const db_join_t* join);
 
 /**
  * A list of database joins.
@@ -101,6 +101,6 @@ struct db_join_list {
  * \param[in] join_list a db_join_list_t pointer.
  * \return a db_join_t pointer or NULL on error or if the list is empty.
  */
-const db_join_t* db_join_list_begin(const db_join_list_t* join_list);
+extern const db_join_t* db_join_list_begin(const db_join_list_t* join_list);
 
 #endif

--- a/enforcer/src/db/db_object.h
+++ b/enforcer/src/db/db_object.h
@@ -60,20 +60,20 @@ struct db_object_field {
  * Create a database object field.
  * \return a db_object_field_t pointer or NULL on error.
  */
-db_object_field_t* db_object_field_new(void);
+extern db_object_field_t* db_object_field_new(void);
 
 /**
  * Create a database object field that is a copy of another.
  * \param[in] from_object_field a db_object_field_t pointer.
  * \return a db_object_field_t pointer or NULL on error.
  */
-db_object_field_t* db_object_field_new_copy(const db_object_field_t* from_object_field);
+extern db_object_field_t* db_object_field_new_copy(const db_object_field_t* from_object_field);
 
 /**
  * Delete a database object field.
  * \param[in] object_field a db_object_field_t pointer.
  */
-void db_object_field_free(db_object_field_t* object_field);
+extern void db_object_field_free(db_object_field_t* object_field);
 
 /**
  * Copy the content of a database object field.
@@ -81,21 +81,21 @@ void db_object_field_free(db_object_field_t* object_field);
  * \param[in] from_object_field a db_object_field_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_field_copy(db_object_field_t* object_field, const db_object_field_t* from_object_field);
+extern int db_object_field_copy(db_object_field_t* object_field, const db_object_field_t* from_object_field);
 
 /**
  * Get the name of a database object field.
  * \param[in] object_field a db_object_field_t pointer.
  * \return a character pointer or NULL on error or if no field name has been set.
  */
-const char* db_object_field_name(const db_object_field_t* object_field);
+extern const char* db_object_field_name(const db_object_field_t* object_field);
 
 /**
  * Get the type of a database object field.
  * \param[in] object_field a db_object_field_t pointer.
  * \return a db_type_t.
  */
-db_type_t db_object_field_type(const db_object_field_t* object_field);
+extern db_type_t db_object_field_type(const db_object_field_t* object_field);
 
 /**
  * Set the name of a database object field.
@@ -103,7 +103,7 @@ db_type_t db_object_field_type(const db_object_field_t* object_field);
  * \param[in] name a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_field_set_name(db_object_field_t* object_field, const char* name);
+extern int db_object_field_set_name(db_object_field_t* object_field, const char* name);
 
 /**
  * Set the type of a database object field.
@@ -111,7 +111,7 @@ int db_object_field_set_name(db_object_field_t* object_field, const char* name);
  * \param[in] type a db_type_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_field_set_type(db_object_field_t* object_field, db_type_t type);
+extern int db_object_field_set_type(db_object_field_t* object_field, db_type_t type);
 
 /**
  * Set the enumerate set of a database object field.
@@ -119,14 +119,14 @@ int db_object_field_set_type(db_object_field_t* object_field, db_type_t type);
  * \param[in] enum_set a NULL terminated db_enum_t list.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_field_set_enum_set(db_object_field_t* object_field, const db_enum_t* enum_set);
+extern int db_object_field_set_enum_set(db_object_field_t* object_field, const db_enum_t* enum_set);
 
 /**
  * Check if the object field is not empty.
  * \param[in] object_field a db_object_field_t pointer.
  * \return DB_ERROR_* if empty, otherwise DB_OK.
  */
-int db_object_field_not_empty(const db_object_field_t* object_field);
+extern int db_object_field_not_empty(const db_object_field_t* object_field);
 
 /**
  * Get the next object field connected in a database object field list.
@@ -134,7 +134,7 @@ int db_object_field_not_empty(const db_object_field_t* object_field);
  * \return a db_object_field_t pointer or NULL on error or if there are no more
  * object fields in the list.
  */
-const db_object_field_t* db_object_field_next(const db_object_field_t* object_field);
+extern const db_object_field_t* db_object_field_next(const db_object_field_t* object_field);
 
 /**
  * A list of object fields.
@@ -149,20 +149,20 @@ struct db_object_field_list {
  * Create a new object field list.
  * \return a db_object_field_list_t pointer or NULL on error.
  */
-db_object_field_list_t* db_object_field_list_new(void);
+extern db_object_field_list_t* db_object_field_list_new(void);
 
 /**
  * Create a new object field list that is a copy of another.
  * \param[in] from_object_field_list a db_object_field_list_t pointer.
  * \return a db_object_field_list_t pointer or NULL on error.
  */
-db_object_field_list_t* db_object_field_list_new_copy(const db_object_field_list_t* from_object_field_list);
+extern db_object_field_list_t* db_object_field_list_new_copy(const db_object_field_list_t* from_object_field_list);
 
 /**
  * Delete a object field list and all object fields within the list.
  * \param[in] object_field_list a db_object_field_list_t pointer.
  */
-void db_object_field_list_free(db_object_field_list_t* object_field_list);
+extern void db_object_field_list_free(db_object_field_list_t* object_field_list);
 
 /**
  * Copy the content of a database object field list.
@@ -170,7 +170,7 @@ void db_object_field_list_free(db_object_field_list_t* object_field_list);
  * \param[in] from_object_field_list a db_object_field_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_field_list_copy(db_object_field_list_t* object_field_list, const db_object_field_list_t* from_object_field_list);
+extern int db_object_field_list_copy(db_object_field_list_t* object_field_list, const db_object_field_list_t* from_object_field_list);
 
 /**
  * Add a database object field to a database object field list, this will takes
@@ -179,21 +179,21 @@ int db_object_field_list_copy(db_object_field_list_t* object_field_list, const d
  * \param[in] object_field a db_object_field_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_field_list_add(db_object_field_list_t* object_field_list, db_object_field_t* object_field);
+extern int db_object_field_list_add(db_object_field_list_t* object_field_list, db_object_field_t* object_field);
 
 /**
  * Return the first database object field in a database object field list.
  * \param[in] object_field_list a db_object_field_list_t pointer.
  * \return a db_object_field_t pointer or NULL on error or if the list is empty.
  */
-const db_object_field_t* db_object_field_list_begin(const db_object_field_list_t* object_field_list);
+extern const db_object_field_t* db_object_field_list_begin(const db_object_field_list_t* object_field_list);
 
 /**
  * Return the size of a object field list.
  * \param[in] object_field_list a db_object_field_list_t pointer.
  * \return a size_t, may be zero on error.
  */
-size_t db_object_field_list_size(const db_object_field_list_t* object_field_list);
+extern size_t db_object_field_list_size(const db_object_field_list_t* object_field_list);
 
 /**
  * A database object.
@@ -210,14 +210,14 @@ struct db_object {
  * Create a new database object.
  * \return a db_object_t pointer or NULL on error.
  */
-db_object_t* db_object_new(void);
+extern db_object_t* db_object_new(void);
 
 /**
  * Delete a database object and the object field list and backend meta data list
  * if set.
  * \param[in] object a db_object_t pointer.
  */
-void db_object_free(db_object_t* object);
+extern void db_object_free(db_object_t* object);
 
 /**
  * Get the database connection of a database object.
@@ -225,7 +225,7 @@ void db_object_free(db_object_t* object);
  * \return a db_connection_t pointer or NULL on error or if no connection has
  * been set.
  */
-const db_connection_t* db_object_connection(const db_object_t* object);
+extern const db_connection_t* db_object_connection(const db_object_t* object);
 
 /**
  * Get the table name of a database object.
@@ -233,7 +233,7 @@ const db_connection_t* db_object_connection(const db_object_t* object);
  * \return a character pointer or NULL on error or if no table name has been
  * set.
  */
-const char* db_object_table(const db_object_t* object);
+extern const char* db_object_table(const db_object_t* object);
 
 /**
  * Get the object field list of a database object.
@@ -241,7 +241,7 @@ const char* db_object_table(const db_object_t* object);
  * \return a db_object_field_list_t pointer or NULL on error or if no object
  * field list has been set.
  */
-const db_object_field_list_t* db_object_object_field_list(const db_object_t* object);
+extern const db_object_field_list_t* db_object_object_field_list(const db_object_t* object);
 
 /**
  * Set the database connection of a database object.
@@ -249,7 +249,7 @@ const db_object_field_list_t* db_object_object_field_list(const db_object_t* obj
  * \param[in] connection a db_connection_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_set_connection(db_object_t* object, const db_connection_t* connection);
+extern int db_object_set_connection(db_object_t* object, const db_connection_t* connection);
 
 /**
  * Set the table name of a database object.
@@ -257,7 +257,7 @@ int db_object_set_connection(db_object_t* object, const db_connection_t* connect
  * \param[in] table a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_set_table(db_object_t* object, const char* table);
+extern int db_object_set_table(db_object_t* object, const char* table);
 
 /**
  * Set the primary key name of a database object.
@@ -265,7 +265,7 @@ int db_object_set_table(db_object_t* object, const char* table);
  * \param[in] primary_key_name a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_set_primary_key_name(db_object_t* object, const char* primary_key_name);
+extern int db_object_set_primary_key_name(db_object_t* object, const char* primary_key_name);
 
 /**
  * Set the object field list of a database object, this takes over the ownership
@@ -274,7 +274,7 @@ int db_object_set_primary_key_name(db_object_t* object, const char* primary_key_
  * \param[in] object_field_list a db_object_field_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_set_object_field_list(db_object_t* object, db_object_field_list_t* object_field_list);
+extern int db_object_set_object_field_list(db_object_t* object, db_object_field_list_t* object_field_list);
 
 /**
  * Create an object in the database. The `object_field_list` describes the
@@ -295,7 +295,7 @@ int db_object_create(db_object_t* object, const db_object_field_list_t* object_f
  * \return a db_result_list_t pointer or NULL on error or if no objects where
  * read.
  */
-db_result_list_t* db_object_read(const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
+extern db_result_list_t* db_object_read(const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list);
 
 /**
  * Update an object or objects in the database.
@@ -305,7 +305,7 @@ db_result_list_t* db_object_read(const db_object_t* object, const db_join_list_t
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_update(const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
+extern int db_object_update(const db_object_t* object, const db_object_field_list_t* object_field_list, const db_value_set_t* value_set, const db_clause_list_t* clause_list);
 
 /**
  * Delete an object or objects from the database.
@@ -313,7 +313,7 @@ int db_object_update(const db_object_t* object, const db_object_field_list_t* ob
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_delete(const db_object_t* object, const db_clause_list_t* clause_list);
+extern int db_object_delete(const db_object_t* object, const db_clause_list_t* clause_list);
 
 /**
  * Count objects from the database. Return the count in `count`.
@@ -323,6 +323,6 @@ int db_object_delete(const db_object_t* object, const db_clause_list_t* clause_l
  * \param[out] count a size_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_object_count(const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
+extern int db_object_count(const db_object_t* object, const db_join_list_t* join_list, const db_clause_list_t* clause_list, size_t* count);
 
 #endif

--- a/enforcer/src/db/db_result.h
+++ b/enforcer/src/db/db_result.h
@@ -62,20 +62,20 @@ struct db_result {
  * Create a new database result.
  * \return a db_result_t pointer or NULL on error.
  */
-db_result_t* db_result_new(void);
+extern db_result_t* db_result_new(void);
 
 /**
  * Create a new database result that is a copy of another.
  * \param[in] from_result a db_result_t pointer.
  * \return a db_result_t pointer or NULL on error.
  */
-db_result_t* db_result_new_copy(const db_result_t* from_result);
+extern db_result_t* db_result_new_copy(const db_result_t* from_result);
 
 /**
  * Delete a database result and the backend meta data list if set.
  * \param[in] result a db_result_t pointer.
  */
-void db_result_free(db_result_t* result);
+extern void db_result_free(db_result_t* result);
 
 /**
  * Copy the content of another database result.
@@ -83,7 +83,7 @@ void db_result_free(db_result_t* result);
  * \param[in] from_result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_result_copy(db_result_t* result, const db_result_t* from_result);
+extern int db_result_copy(db_result_t* result, const db_result_t* from_result);
 
 /**
  * Get the value set of a database result.
@@ -91,7 +91,7 @@ int db_result_copy(db_result_t* result, const db_result_t* from_result);
  * \return a db_value_set_t pointer or NULL on error or if no value set has
  * been set.
  */
-const db_value_set_t* db_result_value_set(const db_result_t* result);
+extern const db_value_set_t* db_result_value_set(const db_result_t* result);
 
 /**
  * Set the value set of a database result.
@@ -99,14 +99,14 @@ const db_value_set_t* db_result_value_set(const db_result_t* result);
  * \param[in] value_set a db_value_set_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_result_set_value_set(db_result_t* result, db_value_set_t* value_set);
+extern int db_result_set_value_set(db_result_t* result, db_value_set_t* value_set);
 
 /**
  * Check if a database result is not empty.
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* if empty, otherwise DB_OK.
  */
-int db_result_not_empty(const db_result_t* result);
+extern int db_result_not_empty(const db_result_t* result);
 
 /**
  * A list of database results.
@@ -125,20 +125,20 @@ struct db_result_list {
  * Create a new database result list.
  * \return a db_result_list_t pointer or NULL on error.
  */
-db_result_list_t* db_result_list_new(void);
+extern db_result_list_t* db_result_list_new(void);
 
 /**
  * Create a new database result list that is a copy of another.
  * \param[in] from_result_list a db_result_list_t pointer.
  * \return a db_result_list_t pointer or NULL on error.
  */
-db_result_list_t* db_result_list_new_copy(const db_result_list_t* from_result_list);
+extern db_result_list_t* db_result_list_new_copy(const db_result_list_t* from_result_list);
 
 /**
  * Delete a database result list and all database results within the list.
  * \param[in] result_list a db_result_list_t pointer.
  */
-void db_result_list_free(db_result_list_t* result_list);
+extern void db_result_list_free(db_result_list_t* result_list);
 
 /**
  * free global allocator. 
@@ -149,7 +149,7 @@ void db_result_list_free(db_result_list_t* result_list);
  * \param[in] result_list a db_result_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_result_list_copy(db_result_list_t* result_list, const db_result_list_t* from_result_list);
+extern int db_result_list_copy(db_result_list_t* result_list, const db_result_list_t* from_result_list);
 
 /**
  * Set the function pointer for fetching the next database result for a database
@@ -161,7 +161,7 @@ int db_result_list_copy(db_result_list_t* result_list, const db_result_list_t* f
  * \param[in] size a size_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_result_list_set_next(db_result_list_t* result_list, db_result_list_next_t next_function, void* next_data, size_t size);
+extern int db_result_list_set_next(db_result_list_t* result_list, db_result_list_next_t next_function, void* next_data, size_t size);
 
 /**
  * Add a database result to a database result list, this will takes over the
@@ -170,7 +170,7 @@ int db_result_list_set_next(db_result_list_t* result_list, db_result_list_next_t
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_result_list_add(db_result_list_t* result_list, db_result_t* result);
+extern int db_result_list_add(db_result_list_t* result_list, db_result_t* result);
 
 /**
  * Return the first database result in a database result list and reset the
@@ -178,7 +178,7 @@ int db_result_list_add(db_result_list_t* result_list, db_result_t* result);
  * \param[in] result_list a db_result_list_t pointer.
  * \return a db_result_t pointer or NULL on error or if the list is empty.
  */
-const db_result_t* db_result_list_begin(db_result_list_t* result_list);
+extern const db_result_t* db_result_list_begin(db_result_list_t* result_list);
 
 /**
  * Return the next database result in a database result list.
@@ -186,7 +186,7 @@ const db_result_t* db_result_list_begin(db_result_list_t* result_list);
  * \return a db_result_t pointer or NULL on error or if the end of the list has
  * been reached.
  */
-const db_result_t* db_result_list_next(db_result_list_t* result_list);
+extern const db_result_t* db_result_list_next(db_result_list_t* result_list);
 
 /**
  * Return the size of the database result list.
@@ -195,7 +195,7 @@ const db_result_t* db_result_list_next(db_result_list_t* result_list);
  * , if the database result list is empty or if the backend does not support
  * returning the size.
  */
-size_t db_result_list_size(const db_result_list_t* result_list);
+extern size_t db_result_list_size(const db_result_list_t* result_list);
 
 /**
  * Make sure that all objects in this database result list is loaded into memory
@@ -204,6 +204,6 @@ size_t db_result_list_size(const db_result_list_t* result_list);
  * \param[in] result_list a db_result_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_result_list_fetch_all(db_result_list_t* result_list);
+extern int db_result_list_fetch_all(db_result_list_t* result_list);
 
 #endif

--- a/enforcer/src/db/db_value.h
+++ b/enforcer/src/db/db_value.h
@@ -63,19 +63,19 @@ struct db_value {
  * Create a new database value.
  * \return a db_value_t pointer or NULL on error.
  */
-db_value_t* db_value_new(void);
+extern db_value_t* db_value_new(void);
 
 /**
  * Delete a database value.
  * \param[in] value a db_value_t pointer.
  */
-void db_value_free(db_value_t* value);
+extern void db_value_free(db_value_t* value);
 
 /**
  * Reset a database value, releasing all interal resources and marking it empty.
  * \param[in] value a db_value_t pointer.
  */
-void db_value_reset(db_value_t* value);
+extern void db_value_reset(db_value_t* value);
 
 /**
  * Copy the contant from one database value into another.
@@ -83,7 +83,7 @@ void db_value_reset(db_value_t* value);
  * \param[in] from_value a db_value_t pointer to copy from.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_copy(db_value_t* value, const db_value_t* from_value);
+extern int db_value_copy(db_value_t* value, const db_value_t* from_value);
 
 /**
  * Compare two database values A and B. Sets `result` with less than, equal to,
@@ -94,14 +94,14 @@ int db_value_copy(db_value_t* value, const db_value_t* from_value);
  * \param[out] result an integer pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_cmp(const db_value_t* value_a, const db_value_t* value_b, int* result);
+extern int db_value_cmp(const db_value_t* value_a, const db_value_t* value_b, int* result);
 
 /**
  * Get the type of a database value.
  * \param[in] value a db_value_t pointer.
  * \return a db_type_t.
  */
-db_type_t db_value_type(const db_value_t* value);
+extern db_type_t db_value_type(const db_value_t* value);
 
 /**
  * Get a pointer for the 32bit integer in a database value.
@@ -110,7 +110,7 @@ db_type_t db_value_type(const db_value_t* value);
  * integer value.
  * TODO: unit test
  */
-const db_type_int32_t* db_value_int32(const db_value_t* value);
+extern const db_type_int32_t* db_value_int32(const db_value_t* value);
 
 /**
  * Get a pointer for the unsigned 32bit integer in a database value.
@@ -119,7 +119,7 @@ const db_type_int32_t* db_value_int32(const db_value_t* value);
  * unsigned 32bit integer value.
  * TODO: unit test
  */
-const db_type_uint32_t* db_value_uint32(const db_value_t* value);
+extern const db_type_uint32_t* db_value_uint32(const db_value_t* value);
 
 /**
  * Get a pointer for the 64bit integer in a database value.
@@ -128,7 +128,7 @@ const db_type_uint32_t* db_value_uint32(const db_value_t* value);
  * integer value.
  * TODO: unit test
  */
-const db_type_int64_t* db_value_int64(const db_value_t* value);
+extern const db_type_int64_t* db_value_int64(const db_value_t* value);
 
 /**
  * Get a pointer for the unsigned 64bit integer in a database value.
@@ -137,14 +137,14 @@ const db_type_int64_t* db_value_int64(const db_value_t* value);
  * unsigned 64bit integer value.
  * TODO: unit test
  */
-const db_type_uint64_t* db_value_uint64(const db_value_t* value);
+extern const db_type_uint64_t* db_value_uint64(const db_value_t* value);
 
 /**
  * Get a character pointer for the text in a database value.
  * \param[in] value a db_value_t pointer.
  * \return a character pointer or NULL on error, if empty or not a text value.
  */
-const char* db_value_text(const db_value_t* value);
+extern const char* db_value_text(const db_value_t* value);
 
 /**
  * Sets `enum_value` with the integer value of an enumeration database value.
@@ -152,14 +152,14 @@ const char* db_value_text(const db_value_t* value);
  * \param[out] enum_value an integer pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_enum_value(const db_value_t* value, int* enum_value);
+extern int db_value_enum_value(const db_value_t* value, int* enum_value);
 
 /**
  * Check if a database value is not empty.
  * \param[in] value a db_value_t pointer.
  * \return DB_ERROR_* if empty, otherwise DB_OK.
  */
-int db_value_not_empty(const db_value_t* value);
+extern int db_value_not_empty(const db_value_t* value);
 
 /**
  * Get the 32bit integer representation of the database value.
@@ -167,7 +167,7 @@ int db_value_not_empty(const db_value_t* value);
  * \param[out] to_int32 a db_type_int32_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_to_int32(const db_value_t* value, db_type_int32_t* to_int32);
+extern int db_value_to_int32(const db_value_t* value, db_type_int32_t* to_int32);
 
 /**
  * Get the unsigned 32bit integer representation of the database value.
@@ -175,7 +175,7 @@ int db_value_to_int32(const db_value_t* value, db_type_int32_t* to_int32);
  * \param[out] to_uint32 a db_type_uint32_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_to_uint32(const db_value_t* value, db_type_uint32_t* to_uint32);
+extern int db_value_to_uint32(const db_value_t* value, db_type_uint32_t* to_uint32);
 
 /**
  * Get the 64bit integer representation of the database value.
@@ -183,7 +183,7 @@ int db_value_to_uint32(const db_value_t* value, db_type_uint32_t* to_uint32);
  * \param[out] to_int64 a db_type_int64_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_to_int64(const db_value_t* value, db_type_int64_t* to_int64);
+extern int db_value_to_int64(const db_value_t* value, db_type_int64_t* to_int64);
 
 /**
  * Get the unsigned 64bit integer representation of the database value.
@@ -191,7 +191,7 @@ int db_value_to_int64(const db_value_t* value, db_type_int64_t* to_int64);
  * \param[out] to_uint64 a db_type_uint64_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_to_uint64(const db_value_t* value, db_type_uint64_t* to_uint64);
+extern int db_value_to_uint64(const db_value_t* value, db_type_uint64_t* to_uint64);
 
 /**
  * Get the character representation of the database value.
@@ -199,7 +199,7 @@ int db_value_to_uint64(const db_value_t* value, db_type_uint64_t* to_uint64);
  * \param[out] to_text a character pointer pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_to_text(const db_value_t* value, char** to_text);
+extern int db_value_to_text(const db_value_t* value, char** to_text);
 
 /**
  * Get the integer enumeration representation of the database value.
@@ -208,7 +208,7 @@ int db_value_to_text(const db_value_t* value, char** to_text);
  * \param[in] enum_set a db_enum_t array that MUST end with NULL.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_to_enum_value(const db_value_t* value, int* to_int, const db_enum_t* enum_set);
+extern int db_value_to_enum_value(const db_value_t* value, int* to_int, const db_enum_t* enum_set);
 
 /**
  * Set the database value to a 32bit integer value.
@@ -216,7 +216,7 @@ int db_value_to_enum_value(const db_value_t* value, int* to_int, const db_enum_t
  * \param[in] from_int32 a db_type_int32_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_from_int32(db_value_t* value, db_type_int32_t from_int32);
+extern int db_value_from_int32(db_value_t* value, db_type_int32_t from_int32);
 
 /**
  * Set the database value to an unsigned 32bit integer value.
@@ -224,7 +224,7 @@ int db_value_from_int32(db_value_t* value, db_type_int32_t from_int32);
  * \param[in] from_uint32 a db_type_uint32_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_from_uint32(db_value_t* value, db_type_uint32_t from_uint32);
+extern int db_value_from_uint32(db_value_t* value, db_type_uint32_t from_uint32);
 
 /**
  * Set the database value to a 64bit integer value.
@@ -232,7 +232,7 @@ int db_value_from_uint32(db_value_t* value, db_type_uint32_t from_uint32);
  * \param[in] from_int64 a db_type_int64_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_from_int64(db_value_t* value, db_type_int64_t from_int64);
+extern int db_value_from_int64(db_value_t* value, db_type_int64_t from_int64);
 
 /**
  * Set the database value to an unsigned 64bit integer value.
@@ -240,7 +240,7 @@ int db_value_from_int64(db_value_t* value, db_type_int64_t from_int64);
  * \param[in] from_uint64 a db_type_uint64_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_from_uint64(db_value_t* value, db_type_uint64_t from_uint64);
+extern int db_value_from_uint64(db_value_t* value, db_type_uint64_t from_uint64);
 
 /**
  * Set the database value to a text value.
@@ -248,7 +248,7 @@ int db_value_from_uint64(db_value_t* value, db_type_uint64_t from_uint64);
  * \param[in] from_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_from_text(db_value_t* value, const char* from_text);
+extern int db_value_from_text(db_value_t* value, const char* from_text);
 
 /**
  * Set the database value to a text value.
@@ -257,7 +257,7 @@ int db_value_from_text(db_value_t* value, const char* from_text);
  * \param[in] size a size_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_from_text2(db_value_t* value, const char* from_text, size_t size);
+extern int db_value_from_text2(db_value_t* value, const char* from_text, size_t size);
 
 /**
  * Set the database value to an enumeration value based on an integer value.
@@ -266,14 +266,14 @@ int db_value_from_text2(db_value_t* value, const char* from_text, size_t size);
  * \param[in] enum_set a db_enum_t array that MUST end with NULL.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_from_enum_value(db_value_t* value, int enum_value, const db_enum_t* enum_set);
+extern int db_value_from_enum_value(db_value_t* value, int enum_value, const db_enum_t* enum_set);
 
 /**
  * Mark the database as a primary key.
  * \param[in] value a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int db_value_set_primary_key(db_value_t* value);
+extern int db_value_set_primary_key(db_value_t* value);
 
 /**
  * A container for a fixed set of database values.
@@ -288,27 +288,27 @@ struct db_value_set {
  * \param[in] size a size_t.
  * \return a db_value_set_t pointer or NULL on error.
  */
-db_value_set_t* db_value_set_new(size_t size);
+extern db_value_set_t* db_value_set_new(size_t size);
 
 /**
  * Create a new set of database value that is a copy of another.
  * \param[in] from_value_set a db_value_set_t pointer.
  * \return a db_value_set_t pointer or NULL on error.
  */
-db_value_set_t* db_value_set_new_copy(const db_value_set_t* from_value_set);
+extern db_value_set_t* db_value_set_new_copy(const db_value_set_t* from_value_set);
 
 /**
  * Delete a database value set and all values within the set.
  * \param[in] value_set a db_value_set_t pointer.
  */
-void db_value_set_free(db_value_set_t* value_set);
+extern void db_value_set_free(db_value_set_t* value_set);
 
 /**
  * Get the size of database value set.
  * \param[in] value_set a db_value_set_t pointer.
  * \return a size_t.
  */
-size_t db_value_set_size(const db_value_set_t* value_set);
+extern size_t db_value_set_size(const db_value_set_t* value_set);
 
 /**
  * Get a read only database value at a position in a database value set.
@@ -316,7 +316,7 @@ size_t db_value_set_size(const db_value_set_t* value_set);
  * \param[in] at a size_t.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* db_value_set_at(const db_value_set_t* value_set, size_t at);
+extern const db_value_t* db_value_set_at(const db_value_set_t* value_set, size_t at);
 
 /**
  * Get a writable database value at a position in a database value set.
@@ -324,6 +324,6 @@ const db_value_t* db_value_set_at(const db_value_set_t* value_set, size_t at);
  * \param[in] at a size_t.
  * \return a db_value_t pointer or NULL on error.
  */
-db_value_t* db_value_set_get(db_value_set_t* value_set, size_t at);
+extern db_value_t* db_value_set_get(db_value_set_t* value_set, size_t at);
 
 #endif

--- a/enforcer/src/db/hsm_key.h
+++ b/enforcer/src/db/hsm_key.h
@@ -98,20 +98,20 @@ struct hsm_key {
  * \param[in] connection a db_connection_t pointer.
  * \return a hsm_key_t pointer or NULL on error.
  */
-hsm_key_t* hsm_key_new(const db_connection_t* connection);
+extern hsm_key_t* hsm_key_new(const db_connection_t* connection);
 
 /**
  * Create a new hsm key object that is a copy of another hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a hsm_key_t pointer or NULL on error.
  */
-hsm_key_t* hsm_key_new_copy(const hsm_key_t* hsm_key);
+extern hsm_key_t* hsm_key_new_copy(const hsm_key_t* hsm_key);
 
 /**
  * Delete a hsm key object, this does not delete it from the database.
  * \param[in] hsm_key a hsm_key_t pointer.
  */
-void hsm_key_free(hsm_key_t* hsm_key);
+extern void hsm_key_free(hsm_key_t* hsm_key);
 
 /**
  * Copy the content of a hsm key object.
@@ -119,7 +119,7 @@ void hsm_key_free(hsm_key_t* hsm_key);
  * \param[in] hsm_key_copy a hsm_key_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_copy(hsm_key_t* hsm_key, const hsm_key_t* hsm_key_copy);
+extern int hsm_key_copy(hsm_key_t* hsm_key, const hsm_key_t* hsm_key_copy);
 
 /**
  * Set the content of a hsm key object based on a database result.
@@ -127,77 +127,77 @@ int hsm_key_copy(hsm_key_t* hsm_key, const hsm_key_t* hsm_key_copy);
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_from_result(hsm_key_t* hsm_key, const db_result_t* result);
+extern int hsm_key_from_result(hsm_key_t* hsm_key, const db_result_t* result);
 
 /**
  * Get the id of a hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* hsm_key_id(const hsm_key_t* hsm_key);
+extern const db_value_t* hsm_key_id(const hsm_key_t* hsm_key);
 
 /**
  * Get the policy_id of a hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* hsm_key_policy_id(const hsm_key_t* hsm_key);
+extern const db_value_t* hsm_key_policy_id(const hsm_key_t* hsm_key);
 
 /**
  * Get the locator of a hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a character pointer or NULL on error or if no locator has been set.
  */
-const char* hsm_key_locator(const hsm_key_t* hsm_key);
+extern const char* hsm_key_locator(const hsm_key_t* hsm_key);
 
 /**
  * Get the state of a hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a hsm_key_state_t which may be HSM_KEY_STATE_INVALID on error or if no state has been set.
  */
-hsm_key_state_t hsm_key_state(const hsm_key_t* hsm_key);
+extern hsm_key_state_t hsm_key_state(const hsm_key_t* hsm_key);
 
 /**
  * Get the bits of a hsm key object. Undefined behavior if `hsm_key` is NULL.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int hsm_key_bits(const hsm_key_t* hsm_key);
+extern unsigned int hsm_key_bits(const hsm_key_t* hsm_key);
 
 /**
  * Get the algorithm of a hsm key object. Undefined behavior if `hsm_key` is NULL.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int hsm_key_algorithm(const hsm_key_t* hsm_key);
+extern unsigned int hsm_key_algorithm(const hsm_key_t* hsm_key);
 
 /**
  * Get the role of a hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a hsm_key_role_t which may be HSM_KEY_ROLE_INVALID on error or if no role has been set.
  */
-hsm_key_role_t hsm_key_role(const hsm_key_t* hsm_key);
+extern hsm_key_role_t hsm_key_role(const hsm_key_t* hsm_key);
 
 /**
  * Get the inception of a hsm key object. Undefined behavior if `hsm_key` is NULL.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int hsm_key_inception(const hsm_key_t* hsm_key);
+extern unsigned int hsm_key_inception(const hsm_key_t* hsm_key);
 
 /**
  * Get the repository of a hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a character pointer or NULL on error or if no repository has been set.
  */
-const char* hsm_key_repository(const hsm_key_t* hsm_key);
+extern const char* hsm_key_repository(const hsm_key_t* hsm_key);
 
 /**
  * Get the backup of a hsm key object.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return a hsm_key_backup_t which may be HSM_KEY_BACKUP_INVALID on error or if no backup has been set.
  */
-hsm_key_backup_t hsm_key_backup(const hsm_key_t* hsm_key);
+extern hsm_key_backup_t hsm_key_backup(const hsm_key_t* hsm_key);
 
 /**
  * Set the policy_id of a hsm key object. If this fails the original value may have been lost.
@@ -205,7 +205,7 @@ hsm_key_backup_t hsm_key_backup(const hsm_key_t* hsm_key);
  * \param[in] policy_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_policy_id(hsm_key_t* hsm_key, const db_value_t* policy_id);
+extern int hsm_key_set_policy_id(hsm_key_t* hsm_key, const db_value_t* policy_id);
 
 /**
  * Set the locator of a hsm key object.
@@ -213,7 +213,7 @@ int hsm_key_set_policy_id(hsm_key_t* hsm_key, const db_value_t* policy_id);
  * \param[in] locator_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_locator(hsm_key_t* hsm_key, const char* locator_text);
+extern int hsm_key_set_locator(hsm_key_t* hsm_key, const char* locator_text);
 
 /**
  * Set the state of a hsm key object.
@@ -221,7 +221,7 @@ int hsm_key_set_locator(hsm_key_t* hsm_key, const char* locator_text);
  * \param[in] state a hsm_key_state_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_state(hsm_key_t* hsm_key, hsm_key_state_t state);
+extern int hsm_key_set_state(hsm_key_t* hsm_key, hsm_key_state_t state);
 
 /**
  * Set the bits of a hsm key object.
@@ -229,7 +229,7 @@ int hsm_key_set_state(hsm_key_t* hsm_key, hsm_key_state_t state);
  * \param[in] bits an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_bits(hsm_key_t* hsm_key, unsigned int bits);
+extern int hsm_key_set_bits(hsm_key_t* hsm_key, unsigned int bits);
 
 /**
  * Set the algorithm of a hsm key object.
@@ -237,7 +237,7 @@ int hsm_key_set_bits(hsm_key_t* hsm_key, unsigned int bits);
  * \param[in] algorithm an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_algorithm(hsm_key_t* hsm_key, unsigned int algorithm);
+extern int hsm_key_set_algorithm(hsm_key_t* hsm_key, unsigned int algorithm);
 
 /**
  * Set the role of a hsm key object.
@@ -245,7 +245,7 @@ int hsm_key_set_algorithm(hsm_key_t* hsm_key, unsigned int algorithm);
  * \param[in] role a hsm_key_role_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_role(hsm_key_t* hsm_key, hsm_key_role_t role);
+extern int hsm_key_set_role(hsm_key_t* hsm_key, hsm_key_role_t role);
 
 /**
  * Set the inception of a hsm key object.
@@ -253,7 +253,7 @@ int hsm_key_set_role(hsm_key_t* hsm_key, hsm_key_role_t role);
  * \param[in] inception an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_inception(hsm_key_t* hsm_key, unsigned int inception);
+extern int hsm_key_set_inception(hsm_key_t* hsm_key, unsigned int inception);
 
 /**
  * Set the key_type of a hsm key object.
@@ -261,7 +261,7 @@ int hsm_key_set_inception(hsm_key_t* hsm_key, unsigned int inception);
  * \param[in] key_type a hsm_key_key_type_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_key_type(hsm_key_t* hsm_key, hsm_key_key_type_t key_type);
+extern int hsm_key_set_key_type(hsm_key_t* hsm_key, hsm_key_key_type_t key_type);
 
 /**
  * Set the repository of a hsm key object.
@@ -269,7 +269,7 @@ int hsm_key_set_key_type(hsm_key_t* hsm_key, hsm_key_key_type_t key_type);
  * \param[in] repository_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_repository(hsm_key_t* hsm_key, const char* repository_text);
+extern int hsm_key_set_repository(hsm_key_t* hsm_key, const char* repository_text);
 
 /**
  * Set the backup of a hsm key object.
@@ -277,7 +277,7 @@ int hsm_key_set_repository(hsm_key_t* hsm_key, const char* repository_text);
  * \param[in] backup a hsm_key_backup_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_set_backup(hsm_key_t* hsm_key, hsm_key_backup_t backup);
+extern int hsm_key_set_backup(hsm_key_t* hsm_key, hsm_key_backup_t backup);
 
 /**
  * Create a clause for policy_id of a hsm key object and add it to a database clause list.
@@ -288,7 +288,7 @@ int hsm_key_set_backup(hsm_key_t* hsm_key, hsm_key_backup_t backup);
  * \param[in] policy_id a db_value_t pointer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_policy_id_clause(db_clause_list_t* clause_list, const db_value_t* policy_id);
+extern db_clause_t* hsm_key_policy_id_clause(db_clause_list_t* clause_list, const db_value_t* policy_id);
 
 /**
  * Create a clause for state of a hsm key object and add it to a database clause list.
@@ -299,7 +299,7 @@ db_clause_t* hsm_key_policy_id_clause(db_clause_list_t* clause_list, const db_va
  * \param[in] state a hsm_key_state_t.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_state_clause(db_clause_list_t* clause_list, hsm_key_state_t state);
+extern db_clause_t* hsm_key_state_clause(db_clause_list_t* clause_list, hsm_key_state_t state);
 
 /**
  * Create a clause for bits of a hsm key object and add it to a database clause list.
@@ -310,7 +310,7 @@ db_clause_t* hsm_key_state_clause(db_clause_list_t* clause_list, hsm_key_state_t
  * \param[in] bits an unsigned integer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_bits_clause(db_clause_list_t* clause_list, unsigned int bits);
+extern db_clause_t* hsm_key_bits_clause(db_clause_list_t* clause_list, unsigned int bits);
 
 /**
  * Create a clause for algorithm of a hsm key object and add it to a database clause list.
@@ -321,7 +321,7 @@ db_clause_t* hsm_key_bits_clause(db_clause_list_t* clause_list, unsigned int bit
  * \param[in] algorithm an unsigned integer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_algorithm_clause(db_clause_list_t* clause_list, unsigned int algorithm);
+extern db_clause_t* hsm_key_algorithm_clause(db_clause_list_t* clause_list, unsigned int algorithm);
 
 /**
  * Create a clause for role of a hsm key object and add it to a database clause list.
@@ -332,7 +332,7 @@ db_clause_t* hsm_key_algorithm_clause(db_clause_list_t* clause_list, unsigned in
  * \param[in] role a hsm_key_role_t.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_role_clause(db_clause_list_t* clause_list, hsm_key_role_t role);
+extern db_clause_t* hsm_key_role_clause(db_clause_list_t* clause_list, hsm_key_role_t role);
 
 /**
  * Create a clause for is_revoked of a hsm key object and add it to a database clause list.
@@ -343,7 +343,7 @@ db_clause_t* hsm_key_role_clause(db_clause_list_t* clause_list, hsm_key_role_t r
  * \param[in] is_revoked an unsigned integer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_is_revoked_clause(db_clause_list_t* clause_list, unsigned int is_revoked);
+extern db_clause_t* hsm_key_is_revoked_clause(db_clause_list_t* clause_list, unsigned int is_revoked);
 
 /**
  * Create a clause for key_type of a hsm key object and add it to a database clause list.
@@ -354,7 +354,7 @@ db_clause_t* hsm_key_is_revoked_clause(db_clause_list_t* clause_list, unsigned i
  * \param[in] key_type a hsm_key_key_type_t.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_key_type_clause(db_clause_list_t* clause_list, hsm_key_key_type_t key_type);
+extern db_clause_t* hsm_key_key_type_clause(db_clause_list_t* clause_list, hsm_key_key_type_t key_type);
 
 /**
  * Create a clause for repository of a hsm key object and add it to a database clause list.
@@ -365,7 +365,7 @@ db_clause_t* hsm_key_key_type_clause(db_clause_list_t* clause_list, hsm_key_key_
  * \param[in] repository_text a character pointer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_repository_clause(db_clause_list_t* clause_list, const char* repository_text);
+extern db_clause_t* hsm_key_repository_clause(db_clause_list_t* clause_list, const char* repository_text);
 
 /**
  * Create a clause for backup of a hsm key object and add it to a database clause list.
@@ -376,14 +376,14 @@ db_clause_t* hsm_key_repository_clause(db_clause_list_t* clause_list, const char
  * \param[in] backup a hsm_key_backup_t.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* hsm_key_backup_clause(db_clause_list_t* clause_list, hsm_key_backup_t backup);
+extern db_clause_t* hsm_key_backup_clause(db_clause_list_t* clause_list, hsm_key_backup_t backup);
 
 /**
  * Create a hsm key object in the database.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_create(hsm_key_t* hsm_key);
+extern int hsm_key_create(hsm_key_t* hsm_key);
 
 /**
  * Get a hsm key object from the database by a id specified in `id`.
@@ -391,7 +391,7 @@ int hsm_key_create(hsm_key_t* hsm_key);
  * \param[in] id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_get_by_id(hsm_key_t* hsm_key, const db_value_t* id);
+extern int hsm_key_get_by_id(hsm_key_t* hsm_key, const db_value_t* id);
 
 /**
  * Get a hsm key object from the database by a locator specified in `locator`.
@@ -399,7 +399,7 @@ int hsm_key_get_by_id(hsm_key_t* hsm_key, const db_value_t* id);
  * \param[in] locator a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_get_by_locator(hsm_key_t* hsm_key, const char* locator);
+extern int hsm_key_get_by_locator(hsm_key_t* hsm_key, const char* locator);
 
 /**
  * Get a new hsm key object from the database by a locator specified in `locator`.
@@ -407,14 +407,14 @@ int hsm_key_get_by_locator(hsm_key_t* hsm_key, const char* locator);
  * \param[in] locator a character pointer.
  * \return a hsm_key_t pointer or NULL on error or if it does not exist.
  */
-hsm_key_t* hsm_key_new_get_by_locator(const db_connection_t* connection, const char* locator);
+extern hsm_key_t* hsm_key_new_get_by_locator(const db_connection_t* connection, const char* locator);
 
 /**
  * Update a hsm key object in the database.
  * \param[in] hsm_key a hsm_key_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_update(hsm_key_t* hsm_key);
+extern int hsm_key_update(hsm_key_t* hsm_key);
 
 int hsm_key_delete(hsm_key_t* hsmkey);
 
@@ -428,7 +428,7 @@ int hsm_key_delete(hsm_key_t* hsmkey);
  * should be counted.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_count(hsm_key_t* hsm_key, db_clause_list_t* clause_list, size_t* count);
+extern int hsm_key_count(hsm_key_t* hsm_key, db_clause_list_t* clause_list, size_t* count);
 
 /**
  * A list of hsm key objects.
@@ -452,7 +452,7 @@ struct hsm_key_list {
  * \param[in] connection a db_connection_t pointer.
  * \return a hsm_key_list_t pointer or NULL on error.
  */
-hsm_key_list_t* hsm_key_list_new(const db_connection_t* connection);
+extern hsm_key_list_t* hsm_key_list_new(const db_connection_t* connection);
 
 size_t
 hsm_key_list_size(hsm_key_list_t* hsm_key_list);
@@ -462,7 +462,7 @@ hsm_key_list_size(hsm_key_list_t* hsm_key_list);
  * \param[in] hsm_key_list a hsm_key_list_t pointer.
  * \return a hsm_key_list_t pointer or NULL on error.
  */
-hsm_key_list_t* hsm_key_list_new_copy(const hsm_key_list_t* hsm_key_copy);
+extern hsm_key_list_t* hsm_key_list_new_copy(const hsm_key_list_t* hsm_key_copy);
 
 /**
  * Specify that objects should be stored within the list as they are fetch,
@@ -470,13 +470,13 @@ hsm_key_list_t* hsm_key_list_new_copy(const hsm_key_list_t* hsm_key_copy);
  * \param[in] hsm_key_list a hsm_key_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_list_object_store(hsm_key_list_t* hsm_key_list);
+extern int hsm_key_list_object_store(hsm_key_list_t* hsm_key_list);
 
 /**
  * Delete a hsm key object list.
  * \param[in] hsm_key_list a hsm_key_list_t pointer.
  */
-void hsm_key_list_free(hsm_key_list_t* hsm_key_list);
+extern void hsm_key_list_free(hsm_key_list_t* hsm_key_list);
 
 /**
  * free global allocator.
@@ -488,7 +488,7 @@ void hsm_key_list_free(hsm_key_list_t* hsm_key_list);
  * \param[in] from_hsm_key_list a hsm_key_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_list_copy(hsm_key_list_t* hsm_key_list, const hsm_key_list_t* from_hsm_key_list);
+extern int hsm_key_list_copy(hsm_key_list_t* hsm_key_list, const hsm_key_list_t* from_hsm_key_list);
 
 /**
  * Get hsm key objects from the database by a clause list.
@@ -496,7 +496,7 @@ int hsm_key_list_copy(hsm_key_list_t* hsm_key_list, const hsm_key_list_t* from_h
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_list_get_by_clauses(hsm_key_list_t* hsm_key_list, const db_clause_list_t* clause_list);
+extern int hsm_key_list_get_by_clauses(hsm_key_list_t* hsm_key_list, const db_clause_list_t* clause_list);
 
 /**
  * Get a new list of hsm key objects from the database by a clause list.
@@ -504,7 +504,7 @@ int hsm_key_list_get_by_clauses(hsm_key_list_t* hsm_key_list, const db_clause_li
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return a hsm_key_list_t pointer or NULL on error.
  */
-hsm_key_list_t* hsm_key_list_new_get_by_clauses(const db_connection_t* connection, const db_clause_list_t* clause_list);
+extern hsm_key_list_t* hsm_key_list_new_get_by_clauses(const db_connection_t* connection, const db_clause_list_t* clause_list);
 
 /**
  * Get hsm key objects from the database by a policy_id specified in `policy_id`.
@@ -512,7 +512,7 @@ hsm_key_list_t* hsm_key_list_new_get_by_clauses(const db_connection_t* connectio
  * \param[in] policy_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int hsm_key_list_get_by_policy_id(hsm_key_list_t* hsm_key_list, const db_value_t* policy_id);
+extern int hsm_key_list_get_by_policy_id(hsm_key_list_t* hsm_key_list, const db_value_t* policy_id);
 
 /**
  * Get a new list of hsm key objects from the database by a policy_id specified in `policy_id`.
@@ -520,7 +520,7 @@ int hsm_key_list_get_by_policy_id(hsm_key_list_t* hsm_key_list, const db_value_t
  * \param[in] policy_id a db_value_t pointer.
  * \return a hsm_key_list_t pointer or NULL on error.
  */
-hsm_key_list_t* hsm_key_list_new_get_by_policy_id(const db_connection_t* connection, const db_value_t* policy_id);
+extern hsm_key_list_t* hsm_key_list_new_get_by_policy_id(const db_connection_t* connection, const db_value_t* policy_id);
 
 /**
  * Get the first hsm key object in a hsm key object list and reset the
@@ -529,7 +529,7 @@ hsm_key_list_t* hsm_key_list_new_get_by_policy_id(const db_connection_t* connect
  * \return a hsm_key_t pointer or NULL on error or if there are no
  * hsm key objects in the hsm key object list.
  */
-const hsm_key_t* hsm_key_list_begin(hsm_key_list_t* hsm_key_list);
+extern const hsm_key_t* hsm_key_list_begin(hsm_key_list_t* hsm_key_list);
 
 /**
  * Get the first hsm key object in a hsm key object list and reset the
@@ -539,7 +539,7 @@ const hsm_key_t* hsm_key_list_begin(hsm_key_list_t* hsm_key_list);
  * \return a hsm_key_t pointer or NULL on error or if there are no
  * hsm key objects in the hsm key object list.
  */
-hsm_key_t* hsm_key_list_get_begin(hsm_key_list_t* hsm_key_list);
+extern hsm_key_t* hsm_key_list_get_begin(hsm_key_list_t* hsm_key_list);
 
 /**
  * Get the next hsm key object in a hsm key object list.
@@ -549,7 +549,7 @@ hsm_key_t* hsm_key_list_get_begin(hsm_key_list_t* hsm_key_list);
  * \return a hsm_key_t pointer or NULL on error or if there are no more
  * hsm key objects in the hsm key object list.
  */
-const hsm_key_t* hsm_key_list_next(hsm_key_list_t* hsm_key_list);
+extern const hsm_key_t* hsm_key_list_next(hsm_key_list_t* hsm_key_list);
 
 /**
  * Get the next hsm key object in a hsm key object list.
@@ -559,6 +559,6 @@ const hsm_key_t* hsm_key_list_next(hsm_key_list_t* hsm_key_list);
  * \return a hsm_key_t pointer or NULL on error or if there are no more
  * hsm key objects in the hsm key object list.
  */
-hsm_key_t* hsm_key_list_get_next(hsm_key_list_t* hsm_key_list);
+extern hsm_key_t* hsm_key_list_get_next(hsm_key_list_t* hsm_key_list);
 
 #endif

--- a/enforcer/src/db/hsm_key_ext.h
+++ b/enforcer/src/db/hsm_key_ext.h
@@ -35,13 +35,13 @@
 /**
  * Return the human readable backup state of hsm_key as static string.
  */
-char const *
+extern char const *
 hsm_key_to_backup_state(hsm_key_t const *hsm_key);
 
 /**
  * Get all HSM keys for policy/algorithm/bits/repository.
  * NULL on failure
  */
-hsm_key_list_t* hsm_key_list_new_get_by_policy_key(const policy_key_t *pkey);
+extern hsm_key_list_t* hsm_key_list_new_get_by_policy_key(const policy_key_t *pkey);
 
 #endif

--- a/enforcer/src/db/key_data.h
+++ b/enforcer/src/db/key_data.h
@@ -94,20 +94,20 @@ struct key_data {
  * \param[in] connection a db_connection_t pointer.
  * \return a key_data_t pointer or NULL on error.
  */
-key_data_t* key_data_new(const db_connection_t* connection);
+extern key_data_t* key_data_new(const db_connection_t* connection);
 
 /**
  * Create a new key data object that is a copy of another key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a key_data_t pointer or NULL on error.
  */
-key_data_t* key_data_new_copy(const key_data_t* key_data);
+extern key_data_t* key_data_new_copy(const key_data_t* key_data);
 
 /**
  * Delete a key data object, this does not delete it from the database.
  * \param[in] key_data a key_data_t pointer.
  */
-void key_data_free(key_data_t* key_data);
+extern void key_data_free(key_data_t* key_data);
 
 /**
  * Copy the content of a key data object.
@@ -115,7 +115,7 @@ void key_data_free(key_data_t* key_data);
  * \param[in] key_data_copy a key_data_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_copy(key_data_t* key_data, const key_data_t* key_data_copy);
+extern int key_data_copy(key_data_t* key_data, const key_data_t* key_data_copy);
 
 /**
  * Compare two key data objects and return less than, equal to,
@@ -126,7 +126,7 @@ int key_data_copy(key_data_t* key_data, const key_data_t* key_data_copy);
  * \return less than, equal to, or greater than zero if A is found, respectively,
  * to be less than, to match, or be greater than B.
  */
-int key_data_cmp(const key_data_t* key_data_a, const key_data_t* key_data_b);
+extern int key_data_cmp(const key_data_t* key_data_a, const key_data_t* key_data_b);
 
 /**
  * Set the content of a key data object based on a database result.
@@ -134,21 +134,21 @@ int key_data_cmp(const key_data_t* key_data_a, const key_data_t* key_data_b);
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_from_result(key_data_t* key_data, const db_result_t* result);
+extern int key_data_from_result(key_data_t* key_data, const db_result_t* result);
 
 /**
  * Get the id of a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* key_data_id(const key_data_t* key_data);
+extern const db_value_t* key_data_id(const key_data_t* key_data);
 
 /**
  * Get the zone_id of a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* key_data_zone_id(const key_data_t* key_data);
+extern const db_value_t* key_data_zone_id(const key_data_t* key_data);
 
 /**
  * Get the zone_id object related to a key data object.
@@ -156,28 +156,28 @@ const db_value_t* key_data_zone_id(const key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a zone_db_t pointer or NULL on error or if no object could be found.
  */
-zone_db_t* key_data_get_zone(const key_data_t* key_data);
+extern zone_db_t* key_data_get_zone(const key_data_t* key_data);
 
 /**
  * Get the hsm_key_id of a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* key_data_hsm_key_id(const key_data_t* key_data);
+extern const db_value_t* key_data_hsm_key_id(const key_data_t* key_data);
 
 /**
  * Cache the hsm_key_id object related to a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_cache_hsm_key(key_data_t* key_data);
+extern int key_data_cache_hsm_key(key_data_t* key_data);
 
 /**
  * Get the hsm_key_id object related to a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a hsm_key_t pointer or NULL on error or if no object could be found.
  */
-const hsm_key_t* key_data_hsm_key(const key_data_t* key_data);
+extern const hsm_key_t* key_data_hsm_key(const key_data_t* key_data);
 
 /**
  * Get the hsm_key_id object related to a key data object.
@@ -185,91 +185,91 @@ const hsm_key_t* key_data_hsm_key(const key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a hsm_key_t pointer or NULL on error or if no object could be found.
  */
-hsm_key_t* key_data_get_hsm_key(const key_data_t* key_data);
+extern hsm_key_t* key_data_get_hsm_key(const key_data_t* key_data);
 
 /**
  * Get the algorithm of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_algorithm(const key_data_t* key_data);
+extern unsigned int key_data_algorithm(const key_data_t* key_data);
 
 /**
  * Get the inception of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_inception(const key_data_t* key_data);
+extern unsigned int key_data_inception(const key_data_t* key_data);
 
 /**
  * Get the role of a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a key_data_role_t which may be KEY_DATA_ROLE_INVALID on error or if no role has been set.
  */
-key_data_role_t key_data_role(const key_data_t* key_data);
+extern key_data_role_t key_data_role(const key_data_t* key_data);
 
 /**
  * Get the role as text of a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a character pointer or NULL on error or if no role has been set.
  */
-const char* key_data_role_text(const key_data_t* key_data);
+extern const char* key_data_role_text(const key_data_t* key_data);
 
 /**
  * Get the introducing of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_introducing(const key_data_t* key_data);
+extern unsigned int key_data_introducing(const key_data_t* key_data);
 
 /**
  * Get the active_zsk of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_active_zsk(const key_data_t* key_data);
+extern unsigned int key_data_active_zsk(const key_data_t* key_data);
 
 /**
  * Get the publish of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_publish(const key_data_t* key_data);
+extern unsigned int key_data_publish(const key_data_t* key_data);
 
 /**
  * Get the active_ksk of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_active_ksk(const key_data_t* key_data);
+extern unsigned int key_data_active_ksk(const key_data_t* key_data);
 
 /**
  * Get the ds_at_parent of a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a key_data_ds_at_parent_t which may be KEY_DATA_DS_AT_PARENT_INVALID on error or if no ds_at_parent has been set.
  */
-key_data_ds_at_parent_t key_data_ds_at_parent(const key_data_t* key_data);
+extern key_data_ds_at_parent_t key_data_ds_at_parent(const key_data_t* key_data);
 
 /**
  * Get the keytag of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_keytag(const key_data_t* key_data);
+extern unsigned int key_data_keytag(const key_data_t* key_data);
 
 /**
  * Get the minimize of a key data object. Undefined behavior if `key_data` is NULL.
  * \param[in] key_data a key_data_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_data_minimize(const key_data_t* key_data);
+extern unsigned int key_data_minimize(const key_data_t* key_data);
 
 /**
  * Get the key_state objects related to a key data object.
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_list_t pointer or NULL on error.
  */
-key_state_list_t* key_data_key_state_list(key_data_t* key_data);
+extern key_state_list_t* key_data_key_state_list(key_data_t* key_data);
 
 /**
  * Retrieve key_state objects related to a key data object.
@@ -278,7 +278,7 @@ key_state_list_t* key_data_key_state_list(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_retrieve_key_state_list(key_data_t* key_data);
+extern int key_data_retrieve_key_state_list(key_data_t* key_data);
 
 /**
  * Set the zone_id of a key data object. If this fails the original value may have been lost.
@@ -286,7 +286,7 @@ int key_data_retrieve_key_state_list(key_data_t* key_data);
  * \param[in] zone_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_zone_id(key_data_t* key_data, const db_value_t* zone_id);
+extern int key_data_set_zone_id(key_data_t* key_data, const db_value_t* zone_id);
 
 /**
  * Set the hsm_key_id of a key data object. If this fails the original value may have been lost.
@@ -294,7 +294,7 @@ int key_data_set_zone_id(key_data_t* key_data, const db_value_t* zone_id);
  * \param[in] hsm_key_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_hsm_key_id(key_data_t* key_data, const db_value_t* hsm_key_id);
+extern int key_data_set_hsm_key_id(key_data_t* key_data, const db_value_t* hsm_key_id);
 
 /**
  * Set the algorithm of a key data object.
@@ -302,7 +302,7 @@ int key_data_set_hsm_key_id(key_data_t* key_data, const db_value_t* hsm_key_id);
  * \param[in] algorithm an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_algorithm(key_data_t* key_data, unsigned int algorithm);
+extern int key_data_set_algorithm(key_data_t* key_data, unsigned int algorithm);
 
 /**
  * Set the inception of a key data object.
@@ -310,7 +310,7 @@ int key_data_set_algorithm(key_data_t* key_data, unsigned int algorithm);
  * \param[in] inception an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_inception(key_data_t* key_data, unsigned int inception);
+extern int key_data_set_inception(key_data_t* key_data, unsigned int inception);
 
 /**
  * Set the role of a key data object.
@@ -318,7 +318,7 @@ int key_data_set_inception(key_data_t* key_data, unsigned int inception);
  * \param[in] role a key_data_role_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_role(key_data_t* key_data, key_data_role_t role);
+extern int key_data_set_role(key_data_t* key_data, key_data_role_t role);
 
 /**
  * Set the introducing of a key data object.
@@ -326,7 +326,7 @@ int key_data_set_role(key_data_t* key_data, key_data_role_t role);
  * \param[in] introducing an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_introducing(key_data_t* key_data, unsigned int introducing);
+extern int key_data_set_introducing(key_data_t* key_data, unsigned int introducing);
 
 /**
  * Set the active_zsk of a key data object.
@@ -334,7 +334,7 @@ int key_data_set_introducing(key_data_t* key_data, unsigned int introducing);
  * \param[in] active_zsk an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_active_zsk(key_data_t* key_data, unsigned int active_zsk);
+extern int key_data_set_active_zsk(key_data_t* key_data, unsigned int active_zsk);
 
 /**
  * Set the publish of a key data object.
@@ -342,7 +342,7 @@ int key_data_set_active_zsk(key_data_t* key_data, unsigned int active_zsk);
  * \param[in] publish an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_publish(key_data_t* key_data, unsigned int publish);
+extern int key_data_set_publish(key_data_t* key_data, unsigned int publish);
 
 /**
  * Set the active_ksk of a key data object.
@@ -350,7 +350,7 @@ int key_data_set_publish(key_data_t* key_data, unsigned int publish);
  * \param[in] active_ksk an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_active_ksk(key_data_t* key_data, unsigned int active_ksk);
+extern int key_data_set_active_ksk(key_data_t* key_data, unsigned int active_ksk);
 
 /**
  * Set the ds_at_parent of a key data object.
@@ -358,7 +358,7 @@ int key_data_set_active_ksk(key_data_t* key_data, unsigned int active_ksk);
  * \param[in] ds_at_parent a key_data_ds_at_parent_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_ds_at_parent(key_data_t* key_data, key_data_ds_at_parent_t ds_at_parent);
+extern int key_data_set_ds_at_parent(key_data_t* key_data, key_data_ds_at_parent_t ds_at_parent);
 
 /**
  * Set the keytag of a key data object.
@@ -366,7 +366,7 @@ int key_data_set_ds_at_parent(key_data_t* key_data, key_data_ds_at_parent_t ds_a
  * \param[in] keytag an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_keytag(key_data_t* key_data, unsigned int keytag);
+extern int key_data_set_keytag(key_data_t* key_data, unsigned int keytag);
 
 /**
  * Set the minimize of a key data object.
@@ -374,7 +374,7 @@ int key_data_set_keytag(key_data_t* key_data, unsigned int keytag);
  * \param[in] minimize an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_set_minimize(key_data_t* key_data, unsigned int minimize);
+extern int key_data_set_minimize(key_data_t* key_data, unsigned int minimize);
 
 /**
  * Create a clause for zone_id of a key data object and add it to a database clause list.
@@ -385,7 +385,7 @@ int key_data_set_minimize(key_data_t* key_data, unsigned int minimize);
  * \param[in] zone_id a db_value_t pointer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* key_data_zone_id_clause(db_clause_list_t* clause_list, const db_value_t* zone_id);
+extern db_clause_t* key_data_zone_id_clause(db_clause_list_t* clause_list, const db_value_t* zone_id);
 
 /**
  * Create a clause for hsm_key_id of a key data object and add it to a database clause list.
@@ -396,7 +396,7 @@ db_clause_t* key_data_zone_id_clause(db_clause_list_t* clause_list, const db_val
  * \param[in] hsm_key_id a db_value_t pointer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* key_data_hsm_key_id_clause(db_clause_list_t* clause_list, const db_value_t* hsm_key_id);
+extern db_clause_t* key_data_hsm_key_id_clause(db_clause_list_t* clause_list, const db_value_t* hsm_key_id);
 
 /**
  * Create a clause for role of a key data object and add it to a database clause list.
@@ -407,7 +407,7 @@ db_clause_t* key_data_hsm_key_id_clause(db_clause_list_t* clause_list, const db_
  * \param[in] role a key_data_role_t.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* key_data_role_clause(db_clause_list_t* clause_list, key_data_role_t role);
+extern db_clause_t* key_data_role_clause(db_clause_list_t* clause_list, key_data_role_t role);
 
 /**
  * Create a clause for ds_at_parent of a key data object and add it to a database clause list.
@@ -418,7 +418,7 @@ db_clause_t* key_data_role_clause(db_clause_list_t* clause_list, key_data_role_t
  * \param[in] ds_at_parent a key_data_ds_at_parent_t.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* key_data_ds_at_parent_clause(db_clause_list_t* clause_list, key_data_ds_at_parent_t ds_at_parent);
+extern db_clause_t* key_data_ds_at_parent_clause(db_clause_list_t* clause_list, key_data_ds_at_parent_t ds_at_parent);
 
 /**
  * Create a clause for keytag of a key data object and add it to a database clause list.
@@ -429,14 +429,14 @@ db_clause_t* key_data_ds_at_parent_clause(db_clause_list_t* clause_list, key_dat
  * \param[in] keytag an unsigned integer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* key_data_keytag_clause(db_clause_list_t* clause_list, unsigned int keytag);
+extern db_clause_t* key_data_keytag_clause(db_clause_list_t* clause_list, unsigned int keytag);
 
 /**
  * Create a key data object in the database.
  * \param[in] key_data a key_data_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_create(key_data_t* key_data);
+extern int key_data_create(key_data_t* key_data);
 
 /**
  * Get a key data object from the database by a id specified in `id`.
@@ -444,21 +444,21 @@ int key_data_create(key_data_t* key_data);
  * \param[in] id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_get_by_id(key_data_t* key_data, const db_value_t* id);
+extern int key_data_get_by_id(key_data_t* key_data, const db_value_t* id);
 
 /**
  * Update a key data object in the database.
  * \param[in] key_data a key_data_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_update(key_data_t* key_data);
+extern int key_data_update(key_data_t* key_data);
 
 /**
  * Delete a key data object from the database.
  * \param[in] key_data a key_data_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_delete(key_data_t* key_data);
+extern int key_data_delete(key_data_t* key_data);
 
 /**
  * Count the number of key data objects in the database, if a selection of
@@ -470,7 +470,7 @@ int key_data_delete(key_data_t* key_data);
  * should be counted.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_count(key_data_t* key_data, db_clause_list_t* clause_list, size_t* count);
+extern int key_data_count(key_data_t* key_data, db_clause_list_t* clause_list, size_t* count);
 
 /**
  * A list of key data objects.
@@ -495,14 +495,14 @@ struct key_data_list {
  * \param[in] connection a db_connection_t pointer.
  * \return a key_data_list_t pointer or NULL on error.
  */
-key_data_list_t* key_data_list_new(const db_connection_t* connection);
+extern key_data_list_t* key_data_list_new(const db_connection_t* connection);
 
 /**
  * Create a new key data object list that is a copy of another.
  * \param[in] key_data_list a key_data_list_t pointer.
  * \return a key_data_list_t pointer or NULL on error.
  */
-key_data_list_t* key_data_list_new_copy(const key_data_list_t* key_data_copy);
+extern key_data_list_t* key_data_list_new_copy(const key_data_list_t* key_data_copy);
 
 /**
  * Specify that objects should be stored within the list as they are fetch,
@@ -510,13 +510,13 @@ key_data_list_t* key_data_list_new_copy(const key_data_list_t* key_data_copy);
  * \param[in] key_data_list a key_data_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_list_object_store(key_data_list_t* key_data_list);
+extern int key_data_list_object_store(key_data_list_t* key_data_list);
 
 /**
  * Delete a key data object list.
  * \param[in] key_data_list a key_data_list_t pointer.
  */
-void key_data_list_free(key_data_list_t* key_data_list);
+extern void key_data_list_free(key_data_list_t* key_data_list);
 
 /**
  * Copy the content of another key data object list.
@@ -524,21 +524,21 @@ void key_data_list_free(key_data_list_t* key_data_list);
  * \param[in] from_key_data_list a key_data_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_list_copy(key_data_list_t* key_data_list, const key_data_list_t* from_key_data_list);
+extern int key_data_list_copy(key_data_list_t* key_data_list, const key_data_list_t* from_key_data_list);
 
 /**
  * Get all key data objects.
  * \param[in] key_data_list a key_data_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_list_get(key_data_list_t* key_data_list);
+extern int key_data_list_get(key_data_list_t* key_data_list);
 
 /**
  * Get a new list with all key data objects.
  * \param[in] connection a db_connection_t pointer.
  * \return a key_data_list_t pointer or NULL on error.
  */
-key_data_list_t* key_data_list_new_get(const db_connection_t* connection);
+extern key_data_list_t* key_data_list_new_get(const db_connection_t* connection);
 
 /**
  * Get key data objects from the database by a clause list.
@@ -546,7 +546,7 @@ key_data_list_t* key_data_list_new_get(const db_connection_t* connection);
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_list_get_by_clauses(key_data_list_t* key_data_list, const db_clause_list_t* clause_list);
+extern int key_data_list_get_by_clauses(key_data_list_t* key_data_list, const db_clause_list_t* clause_list);
 
 /**
  * Get a new list of key data objects from the database by a clause list.
@@ -554,7 +554,7 @@ int key_data_list_get_by_clauses(key_data_list_t* key_data_list, const db_clause
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return a key_data_list_t pointer or NULL on error.
  */
-key_data_list_t* key_data_list_new_get_by_clauses(const db_connection_t* connection, const db_clause_list_t* clause_list);
+extern key_data_list_t* key_data_list_new_get_by_clauses(const db_connection_t* connection, const db_clause_list_t* clause_list);
 
 /**
  * Get key data objects from the database by a zone_id specified in `zone_id`.
@@ -562,7 +562,7 @@ key_data_list_t* key_data_list_new_get_by_clauses(const db_connection_t* connect
  * \param[in] zone_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_list_get_by_zone_id(key_data_list_t* key_data_list, const db_value_t* zone_id);
+extern int key_data_list_get_by_zone_id(key_data_list_t* key_data_list, const db_value_t* zone_id);
 
 /**
  * Get a new list of key data objects from the database by a zone_id specified in `zone_id`.
@@ -570,7 +570,7 @@ int key_data_list_get_by_zone_id(key_data_list_t* key_data_list, const db_value_
  * \param[in] zone_id a db_value_t pointer.
  * \return a key_data_list_t pointer or NULL on error.
  */
-key_data_list_t* key_data_list_new_get_by_zone_id(const db_connection_t* connection, const db_value_t* zone_id);
+extern key_data_list_t* key_data_list_new_get_by_zone_id(const db_connection_t* connection, const db_value_t* zone_id);
 
 /**
  * Get the first key data object in a key data object list and reset the
@@ -579,7 +579,7 @@ key_data_list_t* key_data_list_new_get_by_zone_id(const db_connection_t* connect
  * \return a key_data_t pointer or NULL on error or if there are no
  * key data objects in the key data object list.
  */
-const key_data_t* key_data_list_begin(key_data_list_t* key_data_list);
+extern const key_data_t* key_data_list_begin(key_data_list_t* key_data_list);
 
 /**
  * Get the first key data object in a key data object list and reset the
@@ -589,7 +589,7 @@ const key_data_t* key_data_list_begin(key_data_list_t* key_data_list);
  * \return a key_data_t pointer or NULL on error or if there are no
  * key data objects in the key data object list.
  */
-key_data_t* key_data_list_get_begin(key_data_list_t* key_data_list);
+extern key_data_t* key_data_list_get_begin(key_data_list_t* key_data_list);
 
 /**
  * Get the next key data object in a key data object list.
@@ -599,7 +599,7 @@ key_data_t* key_data_list_get_begin(key_data_list_t* key_data_list);
  * \return a key_data_t pointer or NULL on error or if there are no more
  * key data objects in the key data object list.
  */
-const key_data_t* key_data_list_next(key_data_list_t* key_data_list);
+extern const key_data_t* key_data_list_next(key_data_list_t* key_data_list);
 
 /**
  * Get the next key data object in a key data object list.
@@ -609,7 +609,7 @@ const key_data_t* key_data_list_next(key_data_list_t* key_data_list);
  * \return a key_data_t pointer or NULL on error or if there are no more
  * key data objects in the key data object list.
  */
-key_data_t* key_data_list_get_next(key_data_list_t* key_data_list);
+extern key_data_t* key_data_list_get_next(key_data_list_t* key_data_list);
 
 /**
  * Get the size of a key data object list.
@@ -617,11 +617,11 @@ key_data_t* key_data_list_get_next(key_data_list_t* key_data_list);
  * \return a size_t with the size of the list or zero on error, if the list is
  * empty or if the backend does not support returning the size.
  */
-size_t key_data_list_size(key_data_list_t* key_data_list);
+extern size_t key_data_list_size(key_data_list_t* key_data_list);
 
-key_data_t* key_data_new_get_by_hsm_key_id (const db_connection_t* connection, const db_value_t* hsm_key_id);
+extern key_data_t* key_data_new_get_by_hsm_key_id (const db_connection_t* connection, const db_value_t* hsm_key_id);
 
-int key_data_get_by_hsm_key_id (key_data_t* key_data, const db_value_t* hsm_key_id);
+extern int key_data_get_by_hsm_key_id (key_data_t* key_data, const db_value_t* hsm_key_id);
 
 hsm_key_list_t*
 hsm_key_list_new_get(const db_connection_t* connection);

--- a/enforcer/src/db/key_data_ext.h
+++ b/enforcer/src/db/key_data_ext.h
@@ -38,7 +38,7 @@
  * \param[in] key_data a key_data_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_data_cache_key_states(key_data_t* key_data);
+extern int key_data_cache_key_states(key_data_t* key_data);
 
 /**
  * Get the cached DS key state object of a key data object.
@@ -46,7 +46,7 @@ int key_data_cache_key_states(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-const key_state_t* key_data_cached_ds(key_data_t* key_data);
+extern const key_state_t* key_data_cached_ds(key_data_t* key_data);
 
 /**
  * Get the cached RRSIG key state object of a key data object.
@@ -54,7 +54,7 @@ const key_state_t* key_data_cached_ds(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-const key_state_t* key_data_cached_rrsig(key_data_t* key_data);
+extern const key_state_t* key_data_cached_rrsig(key_data_t* key_data);
 
 /**
  * Get the cached DNSKEY key state object of a key data object.
@@ -62,7 +62,7 @@ const key_state_t* key_data_cached_rrsig(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-const key_state_t* key_data_cached_dnskey(key_data_t* key_data);
+extern const key_state_t* key_data_cached_dnskey(key_data_t* key_data);
 
 /**
  * Get the cached RRSIG DNSKEY key state object of a key data object.
@@ -70,7 +70,7 @@ const key_state_t* key_data_cached_dnskey(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-const key_state_t* key_data_cached_rrsigdnskey(key_data_t* key_data);
+extern const key_state_t* key_data_cached_rrsigdnskey(key_data_t* key_data);
 
 /**
  * Get the cached DS key state object of a key data object.
@@ -78,7 +78,7 @@ const key_state_t* key_data_cached_rrsigdnskey(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-key_state_t* key_data_get_cached_ds(key_data_t* key_data);
+extern key_state_t* key_data_get_cached_ds(key_data_t* key_data);
 
 /**
  * Get the cached RRSIG key state object of a key data object.
@@ -86,7 +86,7 @@ key_state_t* key_data_get_cached_ds(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-key_state_t* key_data_get_cached_rrsig(key_data_t* key_data);
+extern key_state_t* key_data_get_cached_rrsig(key_data_t* key_data);
 
 /**
  * Get the cached DNSKEY key state object of a key data object.
@@ -94,7 +94,7 @@ key_state_t* key_data_get_cached_rrsig(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-key_state_t* key_data_get_cached_dnskey(key_data_t* key_data);
+extern key_state_t* key_data_get_cached_dnskey(key_data_t* key_data);
 
 /**
  * Get the cached RRSIG DNSKEY key state object of a key data object.
@@ -102,7 +102,7 @@ key_state_t* key_data_get_cached_dnskey(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-key_state_t* key_data_get_cached_rrsigdnskey(key_data_t* key_data);
+extern key_state_t* key_data_get_cached_rrsigdnskey(key_data_t* key_data);
 
 /**
  * Get the cached hsm key object of a key data object.
@@ -110,6 +110,6 @@ key_state_t* key_data_get_cached_rrsigdnskey(key_data_t* key_data);
  * \param[in] key_data a key_data_t pointer.
  * \return a key_state_t pointer.
  */
-const hsm_key_t* key_data_cached_hsm_key(const key_data_t* key_data);
+extern const hsm_key_t* key_data_cached_hsm_key(const key_data_t* key_data);
 
 #endif

--- a/enforcer/src/db/key_dependency.h
+++ b/enforcer/src/db/key_dependency.h
@@ -73,20 +73,20 @@ struct key_dependency {
  * \param[in] connection a db_connection_t pointer.
  * \return a key_dependency_t pointer or NULL on error.
  */
-key_dependency_t* key_dependency_new(const db_connection_t* connection);
+extern key_dependency_t* key_dependency_new(const db_connection_t* connection);
 
 /**
  * Create a new key dependency object that is a copy of another key dependency object.
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return a key_dependency_t pointer or NULL on error.
  */
-key_dependency_t* key_dependency_new_copy(const key_dependency_t* key_dependency);
+extern key_dependency_t* key_dependency_new_copy(const key_dependency_t* key_dependency);
 
 /**
  * Delete a key dependency object, this does not delete it from the database.
  * \param[in] key_dependency a key_dependency_t pointer.
  */
-void key_dependency_free(key_dependency_t* key_dependency);
+extern void key_dependency_free(key_dependency_t* key_dependency);
 
 /**
  * Copy the content of a key dependency object.
@@ -94,7 +94,7 @@ void key_dependency_free(key_dependency_t* key_dependency);
  * \param[in] key_dependency_copy a key_dependency_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_copy(key_dependency_t* key_dependency, const key_dependency_t* key_dependency_copy);
+extern int key_dependency_copy(key_dependency_t* key_dependency, const key_dependency_t* key_dependency_copy);
 
 /**
  * Set the content of a key dependency object based on a database result.
@@ -102,21 +102,21 @@ int key_dependency_copy(key_dependency_t* key_dependency, const key_dependency_t
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_from_result(key_dependency_t* key_dependency, const db_result_t* result);
+extern int key_dependency_from_result(key_dependency_t* key_dependency, const db_result_t* result);
 
 /**
  * Get the zone_id of a key dependency object.
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* key_dependency_zone_id(const key_dependency_t* key_dependency);
+extern const db_value_t* key_dependency_zone_id(const key_dependency_t* key_dependency);
 
 /**
  * Get the from_key_data_id of a key dependency object.
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* key_dependency_from_key_data_id(const key_dependency_t* key_dependency);
+extern const db_value_t* key_dependency_from_key_data_id(const key_dependency_t* key_dependency);
 
 /**
  * Get the from_key_data_id object related to a key dependency object.
@@ -124,21 +124,21 @@ const db_value_t* key_dependency_from_key_data_id(const key_dependency_t* key_de
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return a key_data_t pointer or NULL on error or if no object could be found.
  */
-key_data_t* key_dependency_get_from_key_data(const key_dependency_t* key_dependency);
+extern key_data_t* key_dependency_get_from_key_data(const key_dependency_t* key_dependency);
 
 /**
  * Get the to_key_data_id of a key dependency object.
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* key_dependency_to_key_data_id(const key_dependency_t* key_dependency);
+extern const db_value_t* key_dependency_to_key_data_id(const key_dependency_t* key_dependency);
 
 /**
  * Get the type of a key dependency object.
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return a key_dependency_type_t which may be KEY_DEPENDENCY_TYPE_INVALID on error or if no type has been set.
  */
-key_dependency_type_t key_dependency_type(const key_dependency_t* key_dependency);
+extern key_dependency_type_t key_dependency_type(const key_dependency_t* key_dependency);
 
 /**
  * Set the zone_id of a key dependency object. If this fails the original value may have been lost.
@@ -146,7 +146,7 @@ key_dependency_type_t key_dependency_type(const key_dependency_t* key_dependency
  * \param[in] zone_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_set_zone_id(key_dependency_t* key_dependency, const db_value_t* zone_id);
+extern int key_dependency_set_zone_id(key_dependency_t* key_dependency, const db_value_t* zone_id);
 
 /**
  * Set the from_key_data_id of a key dependency object. If this fails the original value may have been lost.
@@ -154,7 +154,7 @@ int key_dependency_set_zone_id(key_dependency_t* key_dependency, const db_value_
  * \param[in] from_key_data_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_set_from_key_data_id(key_dependency_t* key_dependency, const db_value_t* from_key_data_id);
+extern int key_dependency_set_from_key_data_id(key_dependency_t* key_dependency, const db_value_t* from_key_data_id);
 
 /**
  * Set the to_key_data_id of a key dependency object. If this fails the original value may have been lost.
@@ -162,7 +162,7 @@ int key_dependency_set_from_key_data_id(key_dependency_t* key_dependency, const 
  * \param[in] to_key_data_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_set_to_key_data_id(key_dependency_t* key_dependency, const db_value_t* to_key_data_id);
+extern int key_dependency_set_to_key_data_id(key_dependency_t* key_dependency, const db_value_t* to_key_data_id);
 
 /**
  * Set the type of a key dependency object.
@@ -170,14 +170,14 @@ int key_dependency_set_to_key_data_id(key_dependency_t* key_dependency, const db
  * \param[in] type a key_dependency_type_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_set_type(key_dependency_t* key_dependency, key_dependency_type_t type);
+extern int key_dependency_set_type(key_dependency_t* key_dependency, key_dependency_type_t type);
 
 /**
  * Create a key dependency object in the database.
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_create(key_dependency_t* key_dependency);
+extern int key_dependency_create(key_dependency_t* key_dependency);
 
 /**
  * Get a key dependency object from the database by a id specified in `id`.
@@ -185,14 +185,14 @@ int key_dependency_create(key_dependency_t* key_dependency);
  * \param[in] id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_get_by_id(key_dependency_t* key_dependency, const db_value_t* id);
+extern int key_dependency_get_by_id(key_dependency_t* key_dependency, const db_value_t* id);
 
 /**
  * Delete a key dependency object from the database.
  * \param[in] key_dependency a key_dependency_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_delete(key_dependency_t* key_dependency);
+extern int key_dependency_delete(key_dependency_t* key_dependency);
 
 /**
  * A list of key dependency objects.
@@ -218,14 +218,14 @@ struct key_dependency_list {
  * \param[in] connection a db_connection_t pointer.
  * \return a key_dependency_list_t pointer or NULL on error.
  */
-key_dependency_list_t* key_dependency_list_new(const db_connection_t* connection);
+extern key_dependency_list_t* key_dependency_list_new(const db_connection_t* connection);
 
 /**
  * Create a new key dependency object list that is a copy of another.
  * \param[in] key_dependency_list a key_dependency_list_t pointer.
  * \return a key_dependency_list_t pointer or NULL on error.
  */
-key_dependency_list_t* key_dependency_list_new_copy(const key_dependency_list_t* key_dependency_copy);
+extern key_dependency_list_t* key_dependency_list_new_copy(const key_dependency_list_t* key_dependency_copy);
 
 /**
  * Specify that objects should be stored within the list as they are fetch,
@@ -233,13 +233,13 @@ key_dependency_list_t* key_dependency_list_new_copy(const key_dependency_list_t*
  * \param[in] key_dependency_list a key_dependency_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_list_object_store(key_dependency_list_t* key_dependency_list);
+extern int key_dependency_list_object_store(key_dependency_list_t* key_dependency_list);
 
 /**
  * Delete a key dependency object list.
  * \param[in] key_dependency_list a key_dependency_list_t pointer.
  */
-void key_dependency_list_free(key_dependency_list_t* key_dependency_list);
+extern void key_dependency_list_free(key_dependency_list_t* key_dependency_list);
 
 /**
  * Copy the content of another key dependency object list.
@@ -247,7 +247,7 @@ void key_dependency_list_free(key_dependency_list_t* key_dependency_list);
  * \param[in] from_key_dependency_list a key_dependency_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_list_copy(key_dependency_list_t* key_dependency_list, const key_dependency_list_t* from_key_dependency_list);
+extern int key_dependency_list_copy(key_dependency_list_t* key_dependency_list, const key_dependency_list_t* from_key_dependency_list);
 
 /**
  * Get key dependency objects from the database by a clause list.
@@ -255,7 +255,7 @@ int key_dependency_list_copy(key_dependency_list_t* key_dependency_list, const k
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_list_get_by_clauses(key_dependency_list_t* key_dependency_list, const db_clause_list_t* clause_list);
+extern int key_dependency_list_get_by_clauses(key_dependency_list_t* key_dependency_list, const db_clause_list_t* clause_list);
 
 /**
  * Get key dependency objects from the database by a zone_id specified in `zone_id`.
@@ -263,7 +263,7 @@ int key_dependency_list_get_by_clauses(key_dependency_list_t* key_dependency_lis
  * \param[in] zone_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_dependency_list_get_by_zone_id(key_dependency_list_t* key_dependency_list, const db_value_t* zone_id);
+extern int key_dependency_list_get_by_zone_id(key_dependency_list_t* key_dependency_list, const db_value_t* zone_id);
 
 key_dependency_list_t*
 key_dependency_list_new_get(const db_connection_t* connection);
@@ -274,7 +274,7 @@ key_dependency_list_new_get(const db_connection_t* connection);
  * \param[in] zone_id a db_value_t pointer.
  * \return a key_dependency_list_t pointer or NULL on error.
  */
-key_dependency_list_t* key_dependency_list_new_get_by_zone_id(const db_connection_t* connection, const db_value_t* zone_id);
+extern key_dependency_list_t* key_dependency_list_new_get_by_zone_id(const db_connection_t* connection, const db_value_t* zone_id);
 
 /**
  * Get the first key dependency object in a key dependency object list and reset the
@@ -283,7 +283,7 @@ key_dependency_list_t* key_dependency_list_new_get_by_zone_id(const db_connectio
  * \return a key_dependency_t pointer or NULL on error or if there are no
  * key dependency objects in the key dependency object list.
  */
-const key_dependency_t* key_dependency_list_begin(key_dependency_list_t* key_dependency_list);
+extern const key_dependency_t* key_dependency_list_begin(key_dependency_list_t* key_dependency_list);
 
 /**
  * Get the first key dependency object in a key dependency object list and reset the
@@ -293,7 +293,7 @@ const key_dependency_t* key_dependency_list_begin(key_dependency_list_t* key_dep
  * \return a key_dependency_t pointer or NULL on error or if there are no
  * key dependency objects in the key dependency object list.
  */
-key_dependency_t* key_dependency_list_get_begin(key_dependency_list_t* key_dependency_list);
+extern key_dependency_t* key_dependency_list_get_begin(key_dependency_list_t* key_dependency_list);
 
 /**
  * Get the next key dependency object in a key dependency object list.
@@ -303,7 +303,7 @@ key_dependency_t* key_dependency_list_get_begin(key_dependency_list_t* key_depen
  * \return a key_dependency_t pointer or NULL on error or if there are no more
  * key dependency objects in the key dependency object list.
  */
-const key_dependency_t* key_dependency_list_next(key_dependency_list_t* key_dependency_list);
+extern const key_dependency_t* key_dependency_list_next(key_dependency_list_t* key_dependency_list);
 
 /**
  * Get the next key dependency object in a key dependency object list.
@@ -313,7 +313,7 @@ const key_dependency_t* key_dependency_list_next(key_dependency_list_t* key_depe
  * \return a key_dependency_t pointer or NULL on error or if there are no more
  * key dependency objects in the key dependency object list.
  */
-key_dependency_t* key_dependency_list_get_next(key_dependency_list_t* key_dependency_list);
+extern key_dependency_t* key_dependency_list_get_next(key_dependency_list_t* key_dependency_list);
 
 /**
  * Get the size of a key dependency object list.
@@ -321,6 +321,6 @@ key_dependency_t* key_dependency_list_get_next(key_dependency_list_t* key_depend
  * \return a size_t with the size of the list or zero on error, if the list is
  * empty or if the backend does not support returning the size.
  */
-size_t key_dependency_list_size(key_dependency_list_t* key_dependency_list);
+extern size_t key_dependency_list_size(key_dependency_list_t* key_dependency_list);
 
 #endif

--- a/enforcer/src/db/key_state.h
+++ b/enforcer/src/db/key_state.h
@@ -80,20 +80,20 @@ struct key_state {
  * \param[in] connection a db_connection_t pointer.
  * \return a key_state_t pointer or NULL on error.
  */
-key_state_t* key_state_new(const db_connection_t* connection);
+extern key_state_t* key_state_new(const db_connection_t* connection);
 
 /**
  * Create a new key state object that is a copy of another key state object.
  * \param[in] key_state a key_state_t pointer.
  * \return a key_state_t pointer or NULL on error.
  */
-key_state_t* key_state_new_copy(const key_state_t* key_state);
+extern key_state_t* key_state_new_copy(const key_state_t* key_state);
 
 /**
  * Delete a key state object, this does not delete it from the database.
  * \param[in] key_state a key_state_t pointer.
  */
-void key_state_free(key_state_t* key_state);
+extern void key_state_free(key_state_t* key_state);
 
 /**
  * Copy the content of a key state object.
@@ -101,7 +101,7 @@ void key_state_free(key_state_t* key_state);
  * \param[in] key_state_copy a key_state_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_copy(key_state_t* key_state, const key_state_t* key_state_copy);
+extern int key_state_copy(key_state_t* key_state, const key_state_t* key_state_copy);
 
 /**
  * Set the content of a key state object based on a database result.
@@ -109,63 +109,63 @@ int key_state_copy(key_state_t* key_state, const key_state_t* key_state_copy);
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_from_result(key_state_t* key_state, const db_result_t* result);
+extern int key_state_from_result(key_state_t* key_state, const db_result_t* result);
 
 /**
  * Get the key_data_id of a key state object.
  * \param[in] key_state a key_state_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* key_state_key_data_id(const key_state_t* key_state);
+extern const db_value_t* key_state_key_data_id(const key_state_t* key_state);
 
 /**
  * Get the type of a key state object.
  * \param[in] key_state a key_state_t pointer.
  * \return a key_state_type_t which may be KEY_STATE_TYPE_INVALID on error or if no type has been set.
  */
-key_state_type_t key_state_type(const key_state_t* key_state);
+extern key_state_type_t key_state_type(const key_state_t* key_state);
 
 /**
  * Get the type as text of a key state object.
  * \param[in] key_state a key_state_t pointer.
  * \return a character pointer or NULL on error or if no type has been set.
  */
-const char* key_state_type_text(const key_state_t* key_state);
+extern const char* key_state_type_text(const key_state_t* key_state);
 
 /**
  * Get the state of a key state object.
  * \param[in] key_state a key_state_t pointer.
  * \return a key_state_state_t which may be KEY_STATE_STATE_INVALID on error or if no state has been set.
  */
-key_state_state_t key_state_state(const key_state_t* key_state);
+extern key_state_state_t key_state_state(const key_state_t* key_state);
 
 /**
  * Get the state as text of a key state object.
  * \param[in] key_state a key_state_t pointer.
  * \return a character pointer or NULL on error or if no state has been set.
  */
-const char* key_state_state_text(const key_state_t* key_state);
+extern const char* key_state_state_text(const key_state_t* key_state);
 
 /**
  * Get the last_change of a key state object. Undefined behavior if `key_state` is NULL.
  * \param[in] key_state a key_state_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_state_last_change(const key_state_t* key_state);
+extern unsigned int key_state_last_change(const key_state_t* key_state);
 
 /**
  * Get the minimize of a key state object. Undefined behavior if `key_state` is NULL.
  * \param[in] key_state a key_state_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_state_minimize(const key_state_t* key_state);
+extern unsigned int key_state_minimize(const key_state_t* key_state);
 
 /**
  * Get the ttl of a key state object. Undefined behavior if `key_state` is NULL.
  * \param[in] key_state a key_state_t pointer.
  * \return an unsigned integer.
  */
-unsigned int key_state_ttl(const key_state_t* key_state);
+extern unsigned int key_state_ttl(const key_state_t* key_state);
 
 /**
  * Set the key_data_id of a key state object. If this fails the original value may have been lost.
@@ -173,7 +173,7 @@ unsigned int key_state_ttl(const key_state_t* key_state);
  * \param[in] key_data_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_set_key_data_id(key_state_t* key_state, const db_value_t* key_data_id);
+extern int key_state_set_key_data_id(key_state_t* key_state, const db_value_t* key_data_id);
 
 /**
  * Set the type of a key state object.
@@ -181,7 +181,7 @@ int key_state_set_key_data_id(key_state_t* key_state, const db_value_t* key_data
  * \param[in] type a key_state_type_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_set_type(key_state_t* key_state, key_state_type_t type);
+extern int key_state_set_type(key_state_t* key_state, key_state_type_t type);
 
 /**
  * Set the state of a key state object.
@@ -189,7 +189,7 @@ int key_state_set_type(key_state_t* key_state, key_state_type_t type);
  * \param[in] state a key_state_state_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_set_state(key_state_t* key_state, key_state_state_t state);
+extern int key_state_set_state(key_state_t* key_state, key_state_state_t state);
 
 /**
  * Set the last_change of a key state object.
@@ -197,7 +197,7 @@ int key_state_set_state(key_state_t* key_state, key_state_state_t state);
  * \param[in] last_change an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_set_last_change(key_state_t* key_state, unsigned int last_change);
+extern int key_state_set_last_change(key_state_t* key_state, unsigned int last_change);
 
 /**
  * Set the minimize of a key state object.
@@ -205,7 +205,7 @@ int key_state_set_last_change(key_state_t* key_state, unsigned int last_change);
  * \param[in] minimize an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_set_minimize(key_state_t* key_state, unsigned int minimize);
+extern int key_state_set_minimize(key_state_t* key_state, unsigned int minimize);
 
 /**
  * Set the ttl of a key state object.
@@ -213,7 +213,7 @@ int key_state_set_minimize(key_state_t* key_state, unsigned int minimize);
  * \param[in] ttl an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_set_ttl(key_state_t* key_state, unsigned int ttl);
+extern int key_state_set_ttl(key_state_t* key_state, unsigned int ttl);
 
 /**
  * Create a clause for key_data_id of a key state object and add it to a database clause list.
@@ -224,14 +224,14 @@ int key_state_set_ttl(key_state_t* key_state, unsigned int ttl);
  * \param[in] key_data_id a db_value_t pointer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* key_state_key_data_id_clause(db_clause_list_t* clause_list, const db_value_t* key_data_id);
+extern db_clause_t* key_state_key_data_id_clause(db_clause_list_t* clause_list, const db_value_t* key_data_id);
 
 /**
  * Create a key state object in the database.
  * \param[in] key_state a key_state_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_create(key_state_t* key_state);
+extern int key_state_create(key_state_t* key_state);
 
 /**
  * Get a key state object from the database by a id specified in `id`.
@@ -239,21 +239,21 @@ int key_state_create(key_state_t* key_state);
  * \param[in] id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_get_by_id(key_state_t* key_state, const db_value_t* id);
+extern int key_state_get_by_id(key_state_t* key_state, const db_value_t* id);
 
 /**
  * Update a key state object in the database.
  * \param[in] key_state a key_state_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_update(key_state_t* key_state);
+extern int key_state_update(key_state_t* key_state);
 
 /**
  * Delete a key state object from the database.
  * \param[in] key_state a key_state_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_delete(const key_state_t* key_state);
+extern int key_state_delete(const key_state_t* key_state);
 
 /**
  * A list of key state objects.
@@ -277,15 +277,15 @@ struct key_state_list {
  * \param[in] connection a db_connection_t pointer.
  * \return a key_state_list_t pointer or NULL on error.
  */
-key_state_list_t* key_state_list_new(const db_connection_t* connection);
+extern key_state_list_t* key_state_list_new(const db_connection_t* connection);
 
-int
+extern int
 key_state_list_get(key_state_list_t* key_state_list);
 
-key_state_list_t*
+extern key_state_list_t*
 key_state_list_new_get(const db_connection_t* connection);
 
-size_t
+extern size_t
 key_state_list_size(key_state_list_t* key_state_list);
 
 /**
@@ -301,13 +301,13 @@ key_state_list_t* key_state_list_new_copy(const key_state_list_t* key_state_copy
  * \param[in] key_state_list a key_state_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_list_object_store(key_state_list_t* key_state_list);
+extern int key_state_list_object_store(key_state_list_t* key_state_list);
 
 /**
  * Delete a key state object list.
  * \param[in] key_state_list a key_state_list_t pointer.
  */
-void key_state_list_free(key_state_list_t* key_state_list);
+extern void key_state_list_free(key_state_list_t* key_state_list);
 
 /**
  * Copy the content of another key state object list.
@@ -315,7 +315,7 @@ void key_state_list_free(key_state_list_t* key_state_list);
  * \param[in] from_key_state_list a key_state_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_list_copy(key_state_list_t* key_state_list, const key_state_list_t* from_key_state_list);
+extern int key_state_list_copy(key_state_list_t* key_state_list, const key_state_list_t* from_key_state_list);
 
 
 /**
@@ -324,7 +324,7 @@ int key_state_list_copy(key_state_list_t* key_state_list, const key_state_list_t
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_list_get_by_clauses(key_state_list_t* key_state_list, const db_clause_list_t* clause_list);
+extern int key_state_list_get_by_clauses(key_state_list_t* key_state_list, const db_clause_list_t* clause_list);
 
 /**
  * Get key state objects from the database by a key_data_id specified in `key_data_id`.
@@ -332,7 +332,7 @@ int key_state_list_get_by_clauses(key_state_list_t* key_state_list, const db_cla
  * \param[in] key_data_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int key_state_list_get_by_key_data_id(key_state_list_t* key_state_list, const db_value_t* key_data_id);
+extern int key_state_list_get_by_key_data_id(key_state_list_t* key_state_list, const db_value_t* key_data_id);
 
 /**
  * Get a new list of key state objects from the database by a key_data_id specified in `key_data_id`.
@@ -340,7 +340,7 @@ int key_state_list_get_by_key_data_id(key_state_list_t* key_state_list, const db
  * \param[in] key_data_id a db_value_t pointer.
  * \return a key_state_list_t pointer or NULL on error.
  */
-key_state_list_t* key_state_list_new_get_by_key_data_id(const db_connection_t* connection, const db_value_t* key_data_id);
+extern key_state_list_t* key_state_list_new_get_by_key_data_id(const db_connection_t* connection, const db_value_t* key_data_id);
 
 /**
  * Get the first key state object in a key state object list and reset the
@@ -349,7 +349,7 @@ key_state_list_t* key_state_list_new_get_by_key_data_id(const db_connection_t* c
  * \return a key_state_t pointer or NULL on error or if there are no
  * key state objects in the key state object list.
  */
-const key_state_t* key_state_list_begin(key_state_list_t* key_state_list);
+extern const key_state_t* key_state_list_begin(key_state_list_t* key_state_list);
 
 /**
  * Get the first key state object in a key state object list and reset the
@@ -359,7 +359,7 @@ const key_state_t* key_state_list_begin(key_state_list_t* key_state_list);
  * \return a key_state_t pointer or NULL on error or if there are no
  * key state objects in the key state object list.
  */
-key_state_t* key_state_list_get_begin(key_state_list_t* key_state_list);
+extern key_state_t* key_state_list_get_begin(key_state_list_t* key_state_list);
 
 /**
  * Get the next key state object in a key state object list.
@@ -369,7 +369,7 @@ key_state_t* key_state_list_get_begin(key_state_list_t* key_state_list);
  * \return a key_state_t pointer or NULL on error or if there are no more
  * key state objects in the key state object list.
  */
-const key_state_t* key_state_list_next(key_state_list_t* key_state_list);
+extern const key_state_t* key_state_list_next(key_state_list_t* key_state_list);
 
 /**
  * Get the next key state object in a key state object list.
@@ -379,6 +379,6 @@ const key_state_t* key_state_list_next(key_state_list_t* key_state_list);
  * \return a key_state_t pointer or NULL on error or if there are no more
  * key state objects in the key state object list.
  */
-key_state_t* key_state_list_get_next(key_state_list_t* key_state_list);
+extern key_state_t* key_state_list_get_next(key_state_list_t* key_state_list);
 
 #endif

--- a/enforcer/src/db/policy.h
+++ b/enforcer/src/db/policy.h
@@ -107,20 +107,20 @@ struct policy {
  * \param[in] connection a db_connection_t pointer.
  * \return a policy_t pointer or NULL on error.
  */
-policy_t* policy_new(const db_connection_t* connection);
+extern policy_t* policy_new(const db_connection_t* connection);
 
 /**
  * Create a new policy object that is a copy of another policy object.
  * \param[in] policy a policy_t pointer.
  * \return a policy_t pointer or NULL on error.
  */
-policy_t* policy_new_copy(const policy_t* policy);
+extern policy_t* policy_new_copy(const policy_t* policy);
 
 /**
  * Delete a policy object, this does not delete it from the database.
  * \param[in] policy a policy_t pointer.
  */
-void policy_free(policy_t* policy);
+extern void policy_free(policy_t* policy);
 
 /**
  * Copy the content of a policy object.
@@ -128,7 +128,7 @@ void policy_free(policy_t* policy);
  * \param[in] policy_copy a policy_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_copy(policy_t* policy, const policy_t* policy_copy);
+extern int policy_copy(policy_t* policy, const policy_t* policy_copy);
 
 /**
  * Set the content of a policy object based on a database result.
@@ -136,260 +136,260 @@ int policy_copy(policy_t* policy, const policy_t* policy_copy);
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_from_result(policy_t* policy, const db_result_t* result);
+extern int policy_from_result(policy_t* policy, const db_result_t* result);
 
 /**
  * Get the id of a policy object.
  * \param[in] policy a policy_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* policy_id(const policy_t* policy);
+extern const db_value_t* policy_id(const policy_t* policy);
 
 /**
  * Get the name of a policy object.
  * \param[in] policy a policy_t pointer.
  * \return a character pointer or NULL on error or if no name has been set.
  */
-const char* policy_name(const policy_t* policy);
+extern const char* policy_name(const policy_t* policy);
 
 /**
  * Get the passthrough of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_passthrough(const policy_t* policy);
+extern unsigned int policy_passthrough(const policy_t* policy);
 
 /**
  * Get the description of a policy object.
  * \param[in] policy a policy_t pointer.
  * \return a character pointer or NULL on error or if no description has been set.
  */
-const char* policy_description(const policy_t* policy);
+extern const char* policy_description(const policy_t* policy);
 
 /**
  * Get the signatures_resign of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_resign(const policy_t* policy);
+extern unsigned int policy_signatures_resign(const policy_t* policy);
 
 /**
  * Get the signatures_refresh of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_refresh(const policy_t* policy);
+extern unsigned int policy_signatures_refresh(const policy_t* policy);
 
 /**
  * Get the signatures_jitter of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_jitter(const policy_t* policy);
+extern unsigned int policy_signatures_jitter(const policy_t* policy);
 
 /**
  * Get the signatures_inception_offset of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_inception_offset(const policy_t* policy);
+extern unsigned int policy_signatures_inception_offset(const policy_t* policy);
 
 /**
  * Get the signatures_validity_default of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_validity_default(const policy_t* policy);
+extern unsigned int policy_signatures_validity_default(const policy_t* policy);
 
 /**
  * Get the signatures_validity_denial of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_validity_denial(const policy_t* policy);
+extern unsigned int policy_signatures_validity_denial(const policy_t* policy);
 
 /**
  * Get the signatures_validity_keyset of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_validity_keyset(const policy_t* policy);
+extern unsigned int policy_signatures_validity_keyset(const policy_t* policy);
 
 /**
  * Get the signatures_max_zone_ttl of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_signatures_max_zone_ttl(const policy_t* policy);
+extern unsigned int policy_signatures_max_zone_ttl(const policy_t* policy);
 
 /**
  * Get the denial_type of a policy object.
  * \param[in] policy a policy_t pointer.
  * \return a policy_denial_type_t which may be POLICY_DENIAL_TYPE_INVALID on error or if no denial_type has been set.
  */
-policy_denial_type_t policy_denial_type(const policy_t* policy);
+extern policy_denial_type_t policy_denial_type(const policy_t* policy);
 
 /**
  * Get the denial_optout of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_denial_optout(const policy_t* policy);
+extern unsigned int policy_denial_optout(const policy_t* policy);
 
 /**
  * Get the denial_ttl of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_denial_ttl(const policy_t* policy);
+extern unsigned int policy_denial_ttl(const policy_t* policy);
 
 /**
  * Get the denial_resalt of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_denial_resalt(const policy_t* policy);
+extern unsigned int policy_denial_resalt(const policy_t* policy);
 
 /**
  * Get the denial_algorithm of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_denial_algorithm(const policy_t* policy);
+extern unsigned int policy_denial_algorithm(const policy_t* policy);
 
 /**
  * Get the denial_iterations of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_denial_iterations(const policy_t* policy);
+extern unsigned int policy_denial_iterations(const policy_t* policy);
 
 /**
  * Get the denial_salt_length of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_denial_salt_length(const policy_t* policy);
+extern unsigned int policy_denial_salt_length(const policy_t* policy);
 
 /**
  * Get the denial_salt of a policy object.
  * \param[in] policy a policy_t pointer.
  * \return a character pointer or NULL on error or if no denial_salt has been set.
  */
-const char* policy_denial_salt(const policy_t* policy);
+extern const char* policy_denial_salt(const policy_t* policy);
 
 /**
  * Get the denial_salt_last_change of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_denial_salt_last_change(const policy_t* policy);
+extern unsigned int policy_denial_salt_last_change(const policy_t* policy);
 
 /**
  * Get the keys_ttl of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_keys_ttl(const policy_t* policy);
+extern unsigned int policy_keys_ttl(const policy_t* policy);
 
 /**
  * Get the keys_retire_safety of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_keys_retire_safety(const policy_t* policy);
+extern unsigned int policy_keys_retire_safety(const policy_t* policy);
 
 /**
  * Get the keys_publish_safety of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_keys_publish_safety(const policy_t* policy);
+extern unsigned int policy_keys_publish_safety(const policy_t* policy);
 
 /**
  * Get the keys_shared of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_keys_shared(const policy_t* policy);
+extern unsigned int policy_keys_shared(const policy_t* policy);
 
 /**
  * Get the keys_purge_after of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_keys_purge_after(const policy_t* policy);
+extern unsigned int policy_keys_purge_after(const policy_t* policy);
 
 /**
  * Get the zone_propagation_delay of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_zone_propagation_delay(const policy_t* policy);
+extern unsigned int policy_zone_propagation_delay(const policy_t* policy);
 
 /**
  * Get the zone_soa_ttl of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_zone_soa_ttl(const policy_t* policy);
+extern unsigned int policy_zone_soa_ttl(const policy_t* policy);
 
 /**
  * Get the zone_soa_minimum of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_zone_soa_minimum(const policy_t* policy);
+extern unsigned int policy_zone_soa_minimum(const policy_t* policy);
 
 /**
  * Get the zone_soa_serial as text of a policy object.
  * \param[in] policy a policy_t pointer.
  * \return a character pointer or NULL on error or if no zone_soa_serial has been set.
  */
-const char* policy_zone_soa_serial_text(const policy_t* policy);
-const char* policy_zone_soa_serial_text2(unsigned int zone_soa_serial);
+extern const char* policy_zone_soa_serial_text(const policy_t* policy);
+extern const char* policy_zone_soa_serial_text2(unsigned int zone_soa_serial);
 
 /**
  * Get the parent_registration_delay of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_parent_registration_delay(const policy_t* policy);
+extern unsigned int policy_parent_registration_delay(const policy_t* policy);
 
 /**
  * Get the parent_propagation_delay of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_parent_propagation_delay(const policy_t* policy);
+extern unsigned int policy_parent_propagation_delay(const policy_t* policy);
 
 /**
  * Get the parent_ds_ttl of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_parent_ds_ttl(const policy_t* policy);
+extern unsigned int policy_parent_ds_ttl(const policy_t* policy);
 
 /**
  * Get the parent_soa_ttl of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_parent_soa_ttl(const policy_t* policy);
+extern unsigned int policy_parent_soa_ttl(const policy_t* policy);
 
 /**
  * Get the parent_soa_minimum of a policy object. Undefined behavior if `policy` is NULL.
  * \param[in] policy a policy_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_parent_soa_minimum(const policy_t* policy);
+extern unsigned int policy_parent_soa_minimum(const policy_t* policy);
 
 /**
  * Get the zone objects related to a policy object.
  * \param[in] policy a policy_t pointer.
  * \return a zone_list_db_t pointer or NULL on error.
  */
-zone_list_db_t* policy_zone_list(policy_t* policy);
+extern zone_list_db_t* policy_zone_list(policy_t* policy);
 
 /**
  * Retrieve zone objects related to a policy object.
@@ -398,7 +398,7 @@ zone_list_db_t* policy_zone_list(policy_t* policy);
  * \param[in] policy a policy_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_retrieve_zone_list(policy_t* policy);
+extern int policy_retrieve_zone_list(policy_t* policy);
 
 /**
  * Set the name of a policy object.
@@ -406,7 +406,7 @@ int policy_retrieve_zone_list(policy_t* policy);
  * \param[in] name_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_name(policy_t* policy, const char* name_text);
+extern int policy_set_name(policy_t* policy, const char* name_text);
 
 /**
  * Set the passthrough of a policy object.
@@ -414,7 +414,7 @@ int policy_set_name(policy_t* policy, const char* name_text);
  * \param[in] passthrough an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_passthrough(policy_t* policy, unsigned int passthrough);
+extern int policy_set_passthrough(policy_t* policy, unsigned int passthrough);
 
 /**
  * Set the description of a policy object.
@@ -422,7 +422,7 @@ int policy_set_passthrough(policy_t* policy, unsigned int passthrough);
  * \param[in] description_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_description(policy_t* policy, const char* description_text);
+extern int policy_set_description(policy_t* policy, const char* description_text);
 
 /**
  * Set the signatures_resign of a policy object.
@@ -430,7 +430,7 @@ int policy_set_description(policy_t* policy, const char* description_text);
  * \param[in] signatures_resign an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_resign(policy_t* policy, unsigned int signatures_resign);
+extern int policy_set_signatures_resign(policy_t* policy, unsigned int signatures_resign);
 
 /**
  * Set the signatures_refresh of a policy object.
@@ -438,7 +438,7 @@ int policy_set_signatures_resign(policy_t* policy, unsigned int signatures_resig
  * \param[in] signatures_refresh an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_refresh(policy_t* policy, unsigned int signatures_refresh);
+extern int policy_set_signatures_refresh(policy_t* policy, unsigned int signatures_refresh);
 
 /**
  * Set the signatures_jitter of a policy object.
@@ -446,7 +446,7 @@ int policy_set_signatures_refresh(policy_t* policy, unsigned int signatures_refr
  * \param[in] signatures_jitter an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_jitter(policy_t* policy, unsigned int signatures_jitter);
+extern int policy_set_signatures_jitter(policy_t* policy, unsigned int signatures_jitter);
 
 /**
  * Set the signatures_inception_offset of a policy object.
@@ -454,7 +454,7 @@ int policy_set_signatures_jitter(policy_t* policy, unsigned int signatures_jitte
  * \param[in] signatures_inception_offset an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_inception_offset(policy_t* policy, unsigned int signatures_inception_offset);
+extern int policy_set_signatures_inception_offset(policy_t* policy, unsigned int signatures_inception_offset);
 
 /**
  * Set the signatures_validity_default of a policy object.
@@ -462,7 +462,7 @@ int policy_set_signatures_inception_offset(policy_t* policy, unsigned int signat
  * \param[in] signatures_validity_default an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_validity_default(policy_t* policy, unsigned int signatures_validity_default);
+extern int policy_set_signatures_validity_default(policy_t* policy, unsigned int signatures_validity_default);
 
 /**
  * Set the signatures_validity_denial of a policy object.
@@ -470,7 +470,7 @@ int policy_set_signatures_validity_default(policy_t* policy, unsigned int signat
  * \param[in] signatures_validity_denial an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_validity_denial(policy_t* policy, unsigned int signatures_validity_denial);
+extern int policy_set_signatures_validity_denial(policy_t* policy, unsigned int signatures_validity_denial);
 
 /**
  * Set the signatures_validity_keyset of a policy object.
@@ -478,7 +478,7 @@ int policy_set_signatures_validity_denial(policy_t* policy, unsigned int signatu
  * \param[in] signatures_validity_keyset an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_validity_keyset(policy_t* policy, unsigned int signatures_validity_keyset);
+extern int policy_set_signatures_validity_keyset(policy_t* policy, unsigned int signatures_validity_keyset);
 
 /**
  * Set the signatures_max_zone_ttl of a policy object.
@@ -486,7 +486,7 @@ int policy_set_signatures_validity_keyset(policy_t* policy, unsigned int signatu
  * \param[in] signatures_max_zone_ttl an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_signatures_max_zone_ttl(policy_t* policy, unsigned int signatures_max_zone_ttl);
+extern int policy_set_signatures_max_zone_ttl(policy_t* policy, unsigned int signatures_max_zone_ttl);
 
 /**
  * Set the denial_type of a policy object.
@@ -494,7 +494,7 @@ int policy_set_signatures_max_zone_ttl(policy_t* policy, unsigned int signatures
  * \param[in] denial_type a policy_denial_type_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_type(policy_t* policy, policy_denial_type_t denial_type);
+extern int policy_set_denial_type(policy_t* policy, policy_denial_type_t denial_type);
 
 /**
  * Set the denial_optout of a policy object.
@@ -502,7 +502,7 @@ int policy_set_denial_type(policy_t* policy, policy_denial_type_t denial_type);
  * \param[in] denial_optout an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_optout(policy_t* policy, unsigned int denial_optout);
+extern int policy_set_denial_optout(policy_t* policy, unsigned int denial_optout);
 
 /**
  * Set the denial_ttl of a policy object.
@@ -510,7 +510,7 @@ int policy_set_denial_optout(policy_t* policy, unsigned int denial_optout);
  * \param[in] denial_ttl an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_ttl(policy_t* policy, unsigned int denial_ttl);
+extern int policy_set_denial_ttl(policy_t* policy, unsigned int denial_ttl);
 
 /**
  * Set the denial_resalt of a policy object.
@@ -518,7 +518,7 @@ int policy_set_denial_ttl(policy_t* policy, unsigned int denial_ttl);
  * \param[in] denial_resalt an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_resalt(policy_t* policy, unsigned int denial_resalt);
+extern int policy_set_denial_resalt(policy_t* policy, unsigned int denial_resalt);
 
 /**
  * Set the denial_algorithm of a policy object.
@@ -526,7 +526,7 @@ int policy_set_denial_resalt(policy_t* policy, unsigned int denial_resalt);
  * \param[in] denial_algorithm an unsigned integer with a maximum value of 255.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_algorithm(policy_t* policy, unsigned int denial_algorithm);
+extern int policy_set_denial_algorithm(policy_t* policy, unsigned int denial_algorithm);
 
 /**
  * Set the denial_iterations of a policy object.
@@ -534,7 +534,7 @@ int policy_set_denial_algorithm(policy_t* policy, unsigned int denial_algorithm)
  * \param[in] denial_iterations an unsigned integer with a maximum value of 65535.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_iterations(policy_t* policy, unsigned int denial_iterations);
+extern int policy_set_denial_iterations(policy_t* policy, unsigned int denial_iterations);
 
 /**
  * Set the denial_salt_length of a policy object.
@@ -542,7 +542,7 @@ int policy_set_denial_iterations(policy_t* policy, unsigned int denial_iteration
  * \param[in] denial_salt_length an unsigned integer with a maximum value of 255.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_salt_length(policy_t* policy, unsigned int denial_salt_length);
+extern int policy_set_denial_salt_length(policy_t* policy, unsigned int denial_salt_length);
 
 /**
  * Set the denial_salt of a policy object.
@@ -550,7 +550,7 @@ int policy_set_denial_salt_length(policy_t* policy, unsigned int denial_salt_len
  * \param[in] denial_salt_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_salt(policy_t* policy, const char* denial_salt_text);
+extern int policy_set_denial_salt(policy_t* policy, const char* denial_salt_text);
 
 /**
  * Set the denial_salt_last_change of a policy object.
@@ -558,7 +558,7 @@ int policy_set_denial_salt(policy_t* policy, const char* denial_salt_text);
  * \param[in] denial_salt_last_change an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_denial_salt_last_change(policy_t* policy, unsigned int denial_salt_last_change);
+extern int policy_set_denial_salt_last_change(policy_t* policy, unsigned int denial_salt_last_change);
 
 /**
  * Set the keys_ttl of a policy object.
@@ -566,7 +566,7 @@ int policy_set_denial_salt_last_change(policy_t* policy, unsigned int denial_sal
  * \param[in] keys_ttl an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_keys_ttl(policy_t* policy, unsigned int keys_ttl);
+extern int policy_set_keys_ttl(policy_t* policy, unsigned int keys_ttl);
 
 /**
  * Set the keys_retire_safety of a policy object.
@@ -574,7 +574,7 @@ int policy_set_keys_ttl(policy_t* policy, unsigned int keys_ttl);
  * \param[in] keys_retire_safety an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_keys_retire_safety(policy_t* policy, unsigned int keys_retire_safety);
+extern int policy_set_keys_retire_safety(policy_t* policy, unsigned int keys_retire_safety);
 
 /**
  * Set the keys_publish_safety of a policy object.
@@ -582,7 +582,7 @@ int policy_set_keys_retire_safety(policy_t* policy, unsigned int keys_retire_saf
  * \param[in] keys_publish_safety an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_keys_publish_safety(policy_t* policy, unsigned int keys_publish_safety);
+extern int policy_set_keys_publish_safety(policy_t* policy, unsigned int keys_publish_safety);
 
 /**
  * Set the keys_shared of a policy object.
@@ -590,7 +590,7 @@ int policy_set_keys_publish_safety(policy_t* policy, unsigned int keys_publish_s
  * \param[in] keys_shared an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_keys_shared(policy_t* policy, unsigned int keys_shared);
+extern int policy_set_keys_shared(policy_t* policy, unsigned int keys_shared);
 
 /**
  * Set the keys_purge_after of a policy object.
@@ -598,7 +598,7 @@ int policy_set_keys_shared(policy_t* policy, unsigned int keys_shared);
  * \param[in] keys_purge_after an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_keys_purge_after(policy_t* policy, unsigned int keys_purge_after);
+extern int policy_set_keys_purge_after(policy_t* policy, unsigned int keys_purge_after);
 
 /**
  * Set the zone_propagation_delay of a policy object.
@@ -606,7 +606,7 @@ int policy_set_keys_purge_after(policy_t* policy, unsigned int keys_purge_after)
  * \param[in] zone_propagation_delay an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_zone_propagation_delay(policy_t* policy, unsigned int zone_propagation_delay);
+extern int policy_set_zone_propagation_delay(policy_t* policy, unsigned int zone_propagation_delay);
 
 /**
  * Set the zone_soa_ttl of a policy object.
@@ -614,7 +614,7 @@ int policy_set_zone_propagation_delay(policy_t* policy, unsigned int zone_propag
  * \param[in] zone_soa_ttl an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_zone_soa_ttl(policy_t* policy, unsigned int zone_soa_ttl);
+extern int policy_set_zone_soa_ttl(policy_t* policy, unsigned int zone_soa_ttl);
 
 /**
  * Set the zone_soa_minimum of a policy object.
@@ -622,7 +622,7 @@ int policy_set_zone_soa_ttl(policy_t* policy, unsigned int zone_soa_ttl);
  * \param[in] zone_soa_minimum an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_zone_soa_minimum(policy_t* policy, unsigned int zone_soa_minimum);
+extern int policy_set_zone_soa_minimum(policy_t* policy, unsigned int zone_soa_minimum);
 
 /**
  * Set the zone_soa_serial of a policy object from text.
@@ -630,7 +630,7 @@ int policy_set_zone_soa_minimum(policy_t* policy, unsigned int zone_soa_minimum)
  * \param[in] zone_soa_serial a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_zone_soa_serial_text(policy_t* policy, const char* zone_soa_serial);
+extern int policy_set_zone_soa_serial_text(policy_t* policy, const char* zone_soa_serial);
 
 /**
  * Set the parent_registration_delay of a policy object.
@@ -638,7 +638,7 @@ int policy_set_zone_soa_serial_text(policy_t* policy, const char* zone_soa_seria
  * \param[in] parent_registration_delay an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_parent_registration_delay(policy_t* policy, unsigned int parent_registration_delay);
+extern int policy_set_parent_registration_delay(policy_t* policy, unsigned int parent_registration_delay);
 
 /**
  * Set the parent_propagation_delay of a policy object.
@@ -646,7 +646,7 @@ int policy_set_parent_registration_delay(policy_t* policy, unsigned int parent_r
  * \param[in] parent_propagation_delay an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_parent_propagation_delay(policy_t* policy, unsigned int parent_propagation_delay);
+extern int policy_set_parent_propagation_delay(policy_t* policy, unsigned int parent_propagation_delay);
 
 /**
  * Set the parent_ds_ttl of a policy object.
@@ -654,7 +654,7 @@ int policy_set_parent_propagation_delay(policy_t* policy, unsigned int parent_pr
  * \param[in] parent_ds_ttl an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_parent_ds_ttl(policy_t* policy, unsigned int parent_ds_ttl);
+extern int policy_set_parent_ds_ttl(policy_t* policy, unsigned int parent_ds_ttl);
 
 /**
  * Set the parent_soa_ttl of a policy object.
@@ -662,7 +662,7 @@ int policy_set_parent_ds_ttl(policy_t* policy, unsigned int parent_ds_ttl);
  * \param[in] parent_soa_ttl an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_parent_soa_ttl(policy_t* policy, unsigned int parent_soa_ttl);
+extern int policy_set_parent_soa_ttl(policy_t* policy, unsigned int parent_soa_ttl);
 
 /**
  * Set the parent_soa_minimum of a policy object.
@@ -670,7 +670,7 @@ int policy_set_parent_soa_ttl(policy_t* policy, unsigned int parent_soa_ttl);
  * \param[in] parent_soa_minimum an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_set_parent_soa_minimum(policy_t* policy, unsigned int parent_soa_minimum);
+extern int policy_set_parent_soa_minimum(policy_t* policy, unsigned int parent_soa_minimum);
 
 /**
  * Create a clause for denial_type of a policy object and add it to a database clause list.
@@ -681,14 +681,14 @@ int policy_set_parent_soa_minimum(policy_t* policy, unsigned int parent_soa_mini
  * \param[in] denial_type a policy_denial_type_t.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* policy_denial_type_clause(db_clause_list_t* clause_list, policy_denial_type_t denial_type);
+extern db_clause_t* policy_denial_type_clause(db_clause_list_t* clause_list, policy_denial_type_t denial_type);
 
 /**
  * Create a policy object in the database.
  * \param[in] policy a policy_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_create(policy_t* policy);
+extern int policy_create(policy_t* policy);
 
 /**
  * Get a policy object from the database by a id specified in `id`.
@@ -696,7 +696,7 @@ int policy_create(policy_t* policy);
  * \param[in] id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_get_by_id(policy_t* policy, const db_value_t* id);
+extern int policy_get_by_id(policy_t* policy, const db_value_t* id);
 
 /**
  * Get a policy object from the database by a name specified in `name`.
@@ -704,7 +704,7 @@ int policy_get_by_id(policy_t* policy, const db_value_t* id);
  * \param[in] name a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_get_by_name(policy_t* policy, const char* name);
+extern int policy_get_by_name(policy_t* policy, const char* name);
 
 /**
  * Get a new policy object from the database by a name specified in `name`.
@@ -712,21 +712,21 @@ int policy_get_by_name(policy_t* policy, const char* name);
  * \param[in] name a character pointer.
  * \return a policy_t pointer or NULL on error or if it does not exist.
  */
-policy_t* policy_new_get_by_name(const db_connection_t* connection, const char* name);
+extern policy_t* policy_new_get_by_name(const db_connection_t* connection, const char* name);
 
 /**
  * Update a policy object in the database.
  * \param[in] policy a policy_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_update(policy_t* policy);
+extern int policy_update(policy_t* policy);
 
 /**
  * Delete a policy object from the database.
  * \param[in] policy a policy_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_delete(policy_t* policy);
+extern int policy_delete(policy_t* policy);
 
 /**
  * A list of policy objects.
@@ -749,14 +749,14 @@ struct policy_list {
  * \param[in] connection a db_connection_t pointer.
  * \return a policy_list_t pointer or NULL on error.
  */
-policy_list_t* policy_list_new(const db_connection_t* connection);
+extern policy_list_t* policy_list_new(const db_connection_t* connection);
 
 /**
  * Create a new policy object list that is a copy of another.
  * \param[in] policy_list a policy_list_t pointer.
  * \return a policy_list_t pointer or NULL on error.
  */
-policy_list_t* policy_list_new_copy(const policy_list_t* policy_copy);
+extern policy_list_t* policy_list_new_copy(const policy_list_t* policy_copy);
 
 /**
  * Specify that objects should be stored within the list as they are fetch,
@@ -764,13 +764,13 @@ policy_list_t* policy_list_new_copy(const policy_list_t* policy_copy);
  * \param[in] policy_list a policy_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_list_object_store(policy_list_t* policy_list);
+extern int policy_list_object_store(policy_list_t* policy_list);
 
 /**
  * Delete a policy object list.
  * \param[in] policy_list a policy_list_t pointer.
  */
-void policy_list_free(policy_list_t* policy_list);
+extern void policy_list_free(policy_list_t* policy_list);
 
 /**
  * Copy the content of another policy object list.
@@ -778,21 +778,21 @@ void policy_list_free(policy_list_t* policy_list);
  * \param[in] from_policy_list a policy_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_list_copy(policy_list_t* policy_list, const policy_list_t* from_policy_list);
+extern int policy_list_copy(policy_list_t* policy_list, const policy_list_t* from_policy_list);
 
 /**
  * Get all policy objects.
  * \param[in] policy_list a policy_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_list_get(policy_list_t* policy_list);
+extern int policy_list_get(policy_list_t* policy_list);
 
 /**
  * Get a new list with all policy objects.
  * \param[in] connection a db_connection_t pointer.
  * \return a policy_list_t pointer or NULL on error.
  */
-policy_list_t* policy_list_new_get(const db_connection_t* connection);
+extern policy_list_t* policy_list_new_get(const db_connection_t* connection);
 
 /**
  * Get policy objects from the database by a clause list.
@@ -800,7 +800,7 @@ policy_list_t* policy_list_new_get(const db_connection_t* connection);
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_list_get_by_clauses(policy_list_t* policy_list, const db_clause_list_t* clause_list);
+extern int policy_list_get_by_clauses(policy_list_t* policy_list, const db_clause_list_t* clause_list);
 
 /**
  * Get a new list of policy objects from the database by a clause list.
@@ -808,7 +808,7 @@ int policy_list_get_by_clauses(policy_list_t* policy_list, const db_clause_list_
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return a policy_list_t pointer or NULL on error.
  */
-policy_list_t* policy_list_new_get_by_clauses(const db_connection_t* connection, const db_clause_list_t* clause_list);
+extern policy_list_t* policy_list_new_get_by_clauses(const db_connection_t* connection, const db_clause_list_t* clause_list);
 
 /**
  * Get the first policy object in a policy object list and reset the
@@ -817,7 +817,7 @@ policy_list_t* policy_list_new_get_by_clauses(const db_connection_t* connection,
  * \return a policy_t pointer or NULL on error or if there are no
  * policy objects in the policy object list.
  */
-const policy_t* policy_list_begin(policy_list_t* policy_list);
+extern const policy_t* policy_list_begin(policy_list_t* policy_list);
 
 /**
  * Get the next policy object in a policy object list.
@@ -827,7 +827,7 @@ const policy_t* policy_list_begin(policy_list_t* policy_list);
  * \return a policy_t pointer or NULL on error or if there are no more
  * policy objects in the policy object list.
  */
-const policy_t* policy_list_next(policy_list_t* policy_list);
+extern const policy_t* policy_list_next(policy_list_t* policy_list);
 
 /**
  * Get the next policy object in a policy object list.
@@ -837,7 +837,7 @@ const policy_t* policy_list_next(policy_list_t* policy_list);
  * \return a policy_t pointer or NULL on error or if there are no more
  * policy objects in the policy object list.
  */
-policy_t* policy_list_get_next(policy_list_t* policy_list);
+extern policy_t* policy_list_get_next(policy_list_t* policy_list);
 
 size_t
 policy_list_size(policy_list_t* policy_list);

--- a/enforcer/src/db/policy_ext.h
+++ b/enforcer/src/db/policy_ext.h
@@ -41,7 +41,7 @@
  * \param[in] policy_node a xmlNodePtr to the XML for the policy.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_create_from_xml(policy_t* policy, xmlNodePtr policy_node);
+extern int policy_create_from_xml(policy_t* policy, xmlNodePtr policy_node);
 
 /**
  * Update a policy object from XML.
@@ -51,13 +51,13 @@ int policy_create_from_xml(policy_t* policy, xmlNodePtr policy_node);
  * values in the policy was updated.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_update_from_xml(policy_t* policy, xmlNodePtr policy_node, int* updated);
+extern int policy_update_from_xml(policy_t* policy, xmlNodePtr policy_node, int* updated);
 
 /**
  * Get the policy keys for a policy.
  * \param[in] policy a policy_t object.
  * \return a policy_key_list_t pointer or NULL on error.
  */
-policy_key_list_t* policy_get_policy_keys(const policy_t* policy);
+extern policy_key_list_t* policy_get_policy_keys(const policy_t* policy);
 
 #endif

--- a/enforcer/src/db/policy_key.h
+++ b/enforcer/src/db/policy_key.h
@@ -74,26 +74,26 @@ struct policy_key {
  * \param[in] connection a db_connection_t pointer.
  * \return a policy_key_t pointer or NULL on error.
  */
-policy_key_t* policy_key_new(const db_connection_t* connection);
+extern policy_key_t* policy_key_new(const db_connection_t* connection);
 
 /**
  * Create a new policy key object that is a copy of another policy key object.
  * \param[in] policy_key a policy_key_t pointer.
  * \return a policy_key_t pointer or NULL on error.
  */
-policy_key_t* policy_key_new_copy(const policy_key_t* policy_key);
+extern policy_key_t* policy_key_new_copy(const policy_key_t* policy_key);
 
 /**
  * Delete a policy key object, this does not delete it from the database.
  * \param[in] policy_key a policy_key_t pointer.
  */
-void policy_key_free(policy_key_t* policy_key);
+extern void policy_key_free(policy_key_t* policy_key);
 
 /**
  * Reset the content of a policy key object making it as if its new. This does not change anything in the database.
  * \param[in] policy_key a policy_key_t pointer.
  */
-void policy_key_reset(policy_key_t* policy_key);
+extern void policy_key_reset(policy_key_t* policy_key);
 
 /**
  * Copy the content of a policy key object.
@@ -101,7 +101,7 @@ void policy_key_reset(policy_key_t* policy_key);
  * \param[in] policy_key_copy a policy_key_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_copy(policy_key_t* policy_key, const policy_key_t* policy_key_copy);
+extern int policy_key_copy(policy_key_t* policy_key, const policy_key_t* policy_key_copy);
 
 /**
  * Compare two policy key objects and return less than, equal to,
@@ -112,7 +112,7 @@ int policy_key_copy(policy_key_t* policy_key, const policy_key_t* policy_key_cop
  * \return less than, equal to, or greater than zero if A is found, respectively,
  * to be less than, to match, or be greater than B.
  */
-int policy_key_cmp(const policy_key_t* policy_key_a, const policy_key_t* policy_key_b);
+extern int policy_key_cmp(const policy_key_t* policy_key_a, const policy_key_t* policy_key_b);
 
 /**
  * Set the content of a policy key object based on a database result.
@@ -120,21 +120,21 @@ int policy_key_cmp(const policy_key_t* policy_key_a, const policy_key_t* policy_
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_from_result(policy_key_t* policy_key, const db_result_t* result);
+extern int policy_key_from_result(policy_key_t* policy_key, const db_result_t* result);
 
 /**
  * Get the policy_id of a policy key object.
  * \param[in] policy_key a policy_key_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* policy_key_policy_id(const policy_key_t* policy_key);
+extern const db_value_t* policy_key_policy_id(const policy_key_t* policy_key);
 
 /**
  * Get the policy_id object related to a policy key object.
  * \param[in] policy_key a policy_key_t pointer.
  * \return a policy_t pointer or NULL on error or if no object could be found.
  */
-const policy_t* policy_key_policy(const policy_key_t* policy_key);
+extern const policy_t* policy_key_policy(const policy_key_t* policy_key);
 
 /**
  * Get the policy_id object related to a policy key object.
@@ -142,77 +142,77 @@ const policy_t* policy_key_policy(const policy_key_t* policy_key);
  * \param[in] policy_key a policy_key_t pointer.
  * \return a policy_t pointer or NULL on error or if no object could be found.
  */
-policy_t* policy_key_get_policy(const policy_key_t* policy_key);
+extern policy_t* policy_key_get_policy(const policy_key_t* policy_key);
 
 /**
  * Get the role of a policy key object.
  * \param[in] policy_key a policy_key_t pointer.
  * \return a policy_key_role_t which may be POLICY_KEY_ROLE_INVALID on error or if no role has been set.
  */
-policy_key_role_t policy_key_role(const policy_key_t* policy_key);
+extern policy_key_role_t policy_key_role(const policy_key_t* policy_key);
 
 /**
  * Get the role as text of a policy key object.
  * \param[in] policy_key a policy_key_t pointer.
  * \return a character pointer or NULL on error or if no role has been set.
  */
-const char* policy_key_role_text(const policy_key_t* policy_key);
+extern const char* policy_key_role_text(const policy_key_t* policy_key);
 
 /**
  * Get the algorithm of a policy key object. Undefined behavior if `policy_key` is NULL.
  * \param[in] policy_key a policy_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_key_algorithm(const policy_key_t* policy_key);
+extern unsigned int policy_key_algorithm(const policy_key_t* policy_key);
 
 /**
  * Get the bits of a policy key object. Undefined behavior if `policy_key` is NULL.
  * \param[in] policy_key a policy_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_key_bits(const policy_key_t* policy_key);
+extern unsigned int policy_key_bits(const policy_key_t* policy_key);
 
 /**
  * Get the lifetime of a policy key object. Undefined behavior if `policy_key` is NULL.
  * \param[in] policy_key a policy_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_key_lifetime(const policy_key_t* policy_key);
+extern unsigned int policy_key_lifetime(const policy_key_t* policy_key);
 
 /**
  * Get the repository of a policy key object.
  * \param[in] policy_key a policy_key_t pointer.
  * \return a character pointer or NULL on error or if no repository has been set.
  */
-const char* policy_key_repository(const policy_key_t* policy_key);
+extern const char* policy_key_repository(const policy_key_t* policy_key);
 
 /**
  * Get the standby of a policy key object. Undefined behavior if `policy_key` is NULL.
  * \param[in] policy_key a policy_key_t pointer.
  * \return an integer.
  */
-int policy_key_standby(const policy_key_t* policy_key);
+extern int policy_key_standby(const policy_key_t* policy_key);
 
 /**
  * Get the manual_rollover of a policy key object. Undefined behavior if `policy_key` is NULL.
  * \param[in] policy_key a policy_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_key_manual_rollover(const policy_key_t* policy_key);
+extern unsigned int policy_key_manual_rollover(const policy_key_t* policy_key);
 
 /**
  * Get the rfc5011 of a policy key object. Undefined behavior if `policy_key` is NULL.
  * \param[in] policy_key a policy_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_key_rfc5011(const policy_key_t* policy_key);
+extern unsigned int policy_key_rfc5011(const policy_key_t* policy_key);
 
 /**
  * Get the minimize of a policy key object. Undefined behavior if `policy_key` is NULL.
  * \param[in] policy_key a policy_key_t pointer.
  * \return an unsigned integer.
  */
-unsigned int policy_key_minimize(const policy_key_t* policy_key);
+extern unsigned int policy_key_minimize(const policy_key_t* policy_key);
 
 /**
  * Set the policy_id of a policy key object. If this fails the original value may have been lost.
@@ -220,7 +220,7 @@ unsigned int policy_key_minimize(const policy_key_t* policy_key);
  * \param[in] policy_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_policy_id(policy_key_t* policy_key, const db_value_t* policy_id);
+extern int policy_key_set_policy_id(policy_key_t* policy_key, const db_value_t* policy_id);
 
 /**
  * Set the role of a policy key object.
@@ -228,7 +228,7 @@ int policy_key_set_policy_id(policy_key_t* policy_key, const db_value_t* policy_
  * \param[in] role a policy_key_role_t.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_role(policy_key_t* policy_key, policy_key_role_t role);
+extern int policy_key_set_role(policy_key_t* policy_key, policy_key_role_t role);
 
 /**
  * Set the algorithm of a policy key object.
@@ -236,7 +236,7 @@ int policy_key_set_role(policy_key_t* policy_key, policy_key_role_t role);
  * \param[in] algorithm an unsigned integer with a maximum value of 255.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_algorithm(policy_key_t* policy_key, unsigned int algorithm);
+extern int policy_key_set_algorithm(policy_key_t* policy_key, unsigned int algorithm);
 
 /**
  * Set the bits of a policy key object.
@@ -244,7 +244,7 @@ int policy_key_set_algorithm(policy_key_t* policy_key, unsigned int algorithm);
  * \param[in] bits an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_bits(policy_key_t* policy_key, unsigned int bits);
+extern int policy_key_set_bits(policy_key_t* policy_key, unsigned int bits);
 
 /**
  * Set the lifetime of a policy key object.
@@ -252,7 +252,7 @@ int policy_key_set_bits(policy_key_t* policy_key, unsigned int bits);
  * \param[in] lifetime an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_lifetime(policy_key_t* policy_key, unsigned int lifetime);
+extern int policy_key_set_lifetime(policy_key_t* policy_key, unsigned int lifetime);
 
 /**
  * Set the repository of a policy key object.
@@ -260,7 +260,7 @@ int policy_key_set_lifetime(policy_key_t* policy_key, unsigned int lifetime);
  * \param[in] repository_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_repository(policy_key_t* policy_key, const char* repository_text);
+extern int policy_key_set_repository(policy_key_t* policy_key, const char* repository_text);
 
 /**
  * Set the standby of a policy key object.
@@ -268,7 +268,7 @@ int policy_key_set_repository(policy_key_t* policy_key, const char* repository_t
  * \param[in] standby an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_standby(policy_key_t* policy_key, unsigned int standby);
+extern int policy_key_set_standby(policy_key_t* policy_key, unsigned int standby);
 
 /**
  * Set the manual_rollover of a policy key object.
@@ -276,7 +276,7 @@ int policy_key_set_standby(policy_key_t* policy_key, unsigned int standby);
  * \param[in] manual_rollover an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_manual_rollover(policy_key_t* policy_key, unsigned int manual_rollover);
+extern int policy_key_set_manual_rollover(policy_key_t* policy_key, unsigned int manual_rollover);
 
 /**
  * Set the rfc5011 of a policy key object.
@@ -284,7 +284,7 @@ int policy_key_set_manual_rollover(policy_key_t* policy_key, unsigned int manual
  * \param[in] rfc5011 an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_rfc5011(policy_key_t* policy_key, unsigned int rfc5011);
+extern int policy_key_set_rfc5011(policy_key_t* policy_key, unsigned int rfc5011);
 
 /**
  * Set the minimize of a policy key object.
@@ -292,14 +292,14 @@ int policy_key_set_rfc5011(policy_key_t* policy_key, unsigned int rfc5011);
  * \param[in] minimize an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_set_minimize(policy_key_t* policy_key, unsigned int minimize);
+extern int policy_key_set_minimize(policy_key_t* policy_key, unsigned int minimize);
 
 /**
  * Create a policy key object in the database.
  * \param[in] policy_key a policy_key_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_create(policy_key_t* policy_key);
+extern int policy_key_create(policy_key_t* policy_key);
 
 /**
  * Get a policy key object from the database by a id specified in `id`.
@@ -307,14 +307,14 @@ int policy_key_create(policy_key_t* policy_key);
  * \param[in] id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_get_by_id(policy_key_t* policy_key, const db_value_t* id);
+extern int policy_key_get_by_id(policy_key_t* policy_key, const db_value_t* id);
 
 /**
  * Delete a policy key object from the database.
  * \param[in] policy_key a policy_key_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_delete(policy_key_t* policy_key);
+extern int policy_key_delete(policy_key_t* policy_key);
 
 /**
  * A list of policy key objects.
@@ -338,14 +338,14 @@ struct policy_key_list {
  * \param[in] connection a db_connection_t pointer.
  * \return a policy_key_list_t pointer or NULL on error.
  */
-policy_key_list_t* policy_key_list_new(const db_connection_t* connection);
+extern policy_key_list_t* policy_key_list_new(const db_connection_t* connection);
 
 /**
  * Create a new policy key object list that is a copy of another.
  * \param[in] policy_key_list a policy_key_list_t pointer.
  * \return a policy_key_list_t pointer or NULL on error.
  */
-policy_key_list_t* policy_key_list_new_copy(const policy_key_list_t* policy_key_copy);
+extern policy_key_list_t* policy_key_list_new_copy(const policy_key_list_t* policy_key_copy);
 
 /**
  * Specify that objects should be stored within the list as they are fetch,
@@ -353,13 +353,13 @@ policy_key_list_t* policy_key_list_new_copy(const policy_key_list_t* policy_key_
  * \param[in] policy_key_list a policy_key_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_list_object_store(policy_key_list_t* policy_key_list);
+extern int policy_key_list_object_store(policy_key_list_t* policy_key_list);
 
 /**
  * Delete a policy key object list.
  * \param[in] policy_key_list a policy_key_list_t pointer.
  */
-void policy_key_list_free(policy_key_list_t* policy_key_list);
+extern void policy_key_list_free(policy_key_list_t* policy_key_list);
 
 /**
  * Copy the content of another policy key object list.
@@ -367,7 +367,7 @@ void policy_key_list_free(policy_key_list_t* policy_key_list);
  * \param[in] from_policy_key_list a policy_key_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_list_copy(policy_key_list_t* policy_key_list, const policy_key_list_t* from_policy_key_list);
+extern int policy_key_list_copy(policy_key_list_t* policy_key_list, const policy_key_list_t* from_policy_key_list);
 
 policy_key_list_t*
 policy_key_list_new_get(const db_connection_t* connection);
@@ -378,7 +378,7 @@ policy_key_list_new_get(const db_connection_t* connection);
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_list_get_by_clauses(policy_key_list_t* policy_key_list, const db_clause_list_t* clause_list);
+extern int policy_key_list_get_by_clauses(policy_key_list_t* policy_key_list, const db_clause_list_t* clause_list);
 
 /**
  * Get policy key objects from the database by a policy_id specified in `policy_id`.
@@ -386,7 +386,7 @@ int policy_key_list_get_by_clauses(policy_key_list_t* policy_key_list, const db_
  * \param[in] policy_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_list_get_by_policy_id(policy_key_list_t* policy_key_list, const db_value_t* policy_id);
+extern int policy_key_list_get_by_policy_id(policy_key_list_t* policy_key_list, const db_value_t* policy_id);
 
 /**
  * Get a new list of policy key objects from the database by a policy_id specified in `policy_id`.
@@ -394,7 +394,7 @@ int policy_key_list_get_by_policy_id(policy_key_list_t* policy_key_list, const d
  * \param[in] policy_id a db_value_t pointer.
  * \return a policy_key_list_t pointer or NULL on error.
  */
-policy_key_list_t* policy_key_list_new_get_by_policy_id(const db_connection_t* connection, const db_value_t* policy_id);
+extern policy_key_list_t* policy_key_list_new_get_by_policy_id(const db_connection_t* connection, const db_value_t* policy_id);
 
 /**
  * Get the first policy key object in a policy key object list and reset the
@@ -403,7 +403,7 @@ policy_key_list_t* policy_key_list_new_get_by_policy_id(const db_connection_t* c
  * \return a policy_key_t pointer or NULL on error or if there are no
  * policy key objects in the policy key object list.
  */
-const policy_key_t* policy_key_list_begin(policy_key_list_t* policy_key_list);
+extern const policy_key_t* policy_key_list_begin(policy_key_list_t* policy_key_list);
 
 /**
  * Get the next policy key object in a policy key object list.
@@ -413,7 +413,7 @@ const policy_key_t* policy_key_list_begin(policy_key_list_t* policy_key_list);
  * \return a policy_key_t pointer or NULL on error or if there are no more
  * policy key objects in the policy key object list.
  */
-const policy_key_t* policy_key_list_next(policy_key_list_t* policy_key_list);
+extern const policy_key_t* policy_key_list_next(policy_key_list_t* policy_key_list);
 
 /**
  * Get the next policy key object in a policy key object list.
@@ -423,7 +423,7 @@ const policy_key_t* policy_key_list_next(policy_key_list_t* policy_key_list);
  * \return a policy_key_t pointer or NULL on error or if there are no more
  * policy key objects in the policy key object list.
  */
-policy_key_t* policy_key_list_get_next(policy_key_list_t* policy_key_list);
+extern policy_key_t* policy_key_list_get_next(policy_key_list_t* policy_key_list);
 
 /**
  * Get the size of a policy key object list.
@@ -431,9 +431,9 @@ policy_key_t* policy_key_list_get_next(policy_key_list_t* policy_key_list);
  * \return a size_t with the size of the list or zero on error, if the list is
  * empty or if the backend does not support returning the size.
  */
-size_t policy_key_list_size(policy_key_list_t* policy_key_list);
+extern size_t policy_key_list_size(policy_key_list_t* policy_key_list);
 
-policy_key_t * policy_key_new_get_by_policyid_and_role (const db_connection_t* connection, const db_value_t* policyid, const policy_key_role_t role);
+extern policy_key_t * policy_key_new_get_by_policyid_and_role (const db_connection_t* connection, const db_value_t* policyid, const policy_key_role_t role);
 
-int policy_key_get_by_policyid_and_role(policy_key_t* policy_key, const db_value_t* policyid , const policy_key_role_t role);
+extern int policy_key_get_by_policyid_and_role(policy_key_t* policy_key, const db_value_t* policyid , const policy_key_role_t role);
 #endif

--- a/enforcer/src/db/policy_key_ext.h
+++ b/enforcer/src/db/policy_key_ext.h
@@ -44,6 +44,6 @@
  * \param[in] key_node a xmlNodePtr to the XML for the policy key.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int policy_key_create_from_xml(policy_key_t* policy_key, xmlNodePtr key_node);
+extern int policy_key_create_from_xml(policy_key_t* policy_key, xmlNodePtr key_node);
 
 #endif

--- a/enforcer/src/db/test/test.h
+++ b/enforcer/src/db/test/test.h
@@ -32,53 +32,53 @@
 #ifndef __test_test_h
 #define __test_test_h
 
-int init_suite_classes(void);
-int clean_suite_classes(void);
-void test_class_db_backend_handle(void);
-void test_class_db_backend(void);
-void test_class_db_clause(void);
-void test_class_db_clause_list(void);
-void test_class_db_configuration(void);
-void test_class_db_configuration_list(void);
-void test_class_db_connection(void);
-void test_class_db_join(void);
-void test_class_db_join_list(void);
-void test_class_db_object_field(void);
-void test_class_db_object_field_list(void);
-void test_class_db_object(void);
-void test_class_db_value_set(void);
-void test_class_db_result(void);
-void test_class_db_result_list(void);
-void test_class_db_value(void);
-void test_class_end(void);
+extern int init_suite_classes(void);
+extern int clean_suite_classes(void);
+extern void test_class_db_backend_handle(void);
+extern void test_class_db_backend(void);
+extern void test_class_db_clause(void);
+extern void test_class_db_clause_list(void);
+extern void test_class_db_configuration(void);
+extern void test_class_db_configuration_list(void);
+extern void test_class_db_connection(void);
+extern void test_class_db_join(void);
+extern void test_class_db_join_list(void);
+extern void test_class_db_object_field(void);
+extern void test_class_db_object_field_list(void);
+extern void test_class_db_object(void);
+extern void test_class_db_value_set(void);
+extern void test_class_db_result(void);
+extern void test_class_db_result_list(void);
+extern void test_class_db_value(void);
+extern void test_class_end(void);
 
-int init_suite_initialization(void);
-int clean_suite_initialization(void);
-void test_initialization_configuration(void);
-void test_initialization_connection(void);
+extern int init_suite_initialization(void);
+extern int clean_suite_initialization(void);
+extern void test_initialization_configuration(void);
+extern void test_initialization_connection(void);
 
 #if defined(ENFORCER_DATABASE_SQLITE3)
-int init_suite_database_operations_sqlite(void);
+extern int init_suite_database_operations_sqlite(void);
 #endif
-int init_suite_database_operations_mysql(void);
-int clean_suite_database_operations(void);
-void test_database_operations_read_object1(void);
-void test_database_operations_create_object2(void);
-void test_database_operations_read_object2(void);
-void test_database_operations_update_object2(void);
-void test_database_operations_delete_object2(void);
-void test_database_operations_create_object3(void);
-void test_database_operations_delete_object3(void);
-void test_database_operations_read_all(void);
-void test_database_operations_count(void);
+extern int init_suite_database_operations_mysql(void);
+extern int clean_suite_database_operations(void);
+extern void test_database_operations_read_object1(void);
+extern void test_database_operations_create_object2(void);
+extern void test_database_operations_read_object2(void);
+extern void test_database_operations_update_object2(void);
+extern void test_database_operations_delete_object2(void);
+extern void test_database_operations_create_object3(void);
+extern void test_database_operations_delete_object3(void);
+extern void test_database_operations_read_all(void);
+extern void test_database_operations_count(void);
 
-void test_database_operations_read_object1_2(void);
-void test_database_operations_create_object2_2(void);
-void test_database_operations_read_object2_2(void);
-void test_database_operations_update_object2_2(void);
-void test_database_operations_delete_object2_2(void);
-void test_database_operations_create_object3_2(void);
-void test_database_operations_delete_object3_2(void);
-void test_database_operations_update_objects_revisions(void);
+extern void test_database_operations_read_object1_2(void);
+extern void test_database_operations_create_object2_2(void);
+extern void test_database_operations_read_object2_2(void);
+extern void test_database_operations_update_object2_2(void);
+extern void test_database_operations_delete_object2_2(void);
+extern void test_database_operations_create_object3_2(void);
+extern void test_database_operations_delete_object3_2(void);
+extern void test_database_operations_update_objects_revisions(void);
 
 #endif

--- a/enforcer/src/db/test/test_database_version.h
+++ b/enforcer/src/db/test/test_database_version.h
@@ -30,6 +30,6 @@
 #ifndef __test_database_version_h
 #define __test_database_version_h
 
-int test_database_version_add_suite(void);
+extern int test_database_version_add_suite(void);
 
 #endif

--- a/enforcer/src/db/test/test_hsm_key.h
+++ b/enforcer/src/db/test/test_hsm_key.h
@@ -30,6 +30,6 @@
 #ifndef __test_hsm_key_h
 #define __test_hsm_key_h
 
-int test_hsm_key_add_suite(void);
+extern int test_hsm_key_add_suite(void);
 
 #endif

--- a/enforcer/src/db/test/test_key_data.h
+++ b/enforcer/src/db/test/test_key_data.h
@@ -30,6 +30,6 @@
 #ifndef __test_key_data_h
 #define __test_key_data_h
 
-int test_key_data_add_suite(void);
+extern int test_key_data_add_suite(void);
 
 #endif

--- a/enforcer/src/db/test/test_key_dependency.h
+++ b/enforcer/src/db/test/test_key_dependency.h
@@ -30,6 +30,6 @@
 #ifndef __test_key_dependency_h
 #define __test_key_dependency_h
 
-int test_key_dependency_add_suite(void);
+extern int test_key_dependency_add_suite(void);
 
 #endif

--- a/enforcer/src/db/test/test_key_state.h
+++ b/enforcer/src/db/test/test_key_state.h
@@ -30,6 +30,6 @@
 #ifndef __test_key_state_h
 #define __test_key_state_h
 
-int test_key_state_add_suite(void);
+extern int test_key_state_add_suite(void);
 
 #endif

--- a/enforcer/src/db/test/test_policy.h
+++ b/enforcer/src/db/test/test_policy.h
@@ -30,6 +30,6 @@
 #ifndef __test_policy_h
 #define __test_policy_h
 
-int test_policy_add_suite(void);
+extern int test_policy_add_suite(void);
 
 #endif

--- a/enforcer/src/db/test/test_policy_key.h
+++ b/enforcer/src/db/test/test_policy_key.h
@@ -30,6 +30,6 @@
 #ifndef __test_policy_key_h
 #define __test_policy_key_h
 
-int test_policy_key_add_suite(void);
+extern int test_policy_key_add_suite(void);
 
 #endif

--- a/enforcer/src/db/test/test_zone.h
+++ b/enforcer/src/db/test/test_zone.h
@@ -30,6 +30,6 @@
 #ifndef __test_zone_h
 #define __test_zone_h
 
-int test_zone_add_suite(void);
+extern int test_zone_add_suite(void);
 
 #endif

--- a/enforcer/src/db/zone_db.h
+++ b/enforcer/src/db/zone_db.h
@@ -76,20 +76,20 @@ struct zone_db {
  * \param[in] connection a db_connection_t pointer.
  * \return a zone_db_t pointer or NULL on error.
  */
-zone_db_t* zone_db_new(const db_connection_t* connection);
+extern zone_db_t* zone_db_new(const db_connection_t* connection);
 
 /**
  * Create a new zone object that is a copy of another zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a zone_db_t pointer or NULL on error.
  */
-zone_db_t* zone_db_new_copy(const zone_db_t* zone);
+extern zone_db_t* zone_db_new_copy(const zone_db_t* zone);
 
 /**
  * Delete a zone object, this does not delete it from the database.
  * \param[in] zone a zone_db_t pointer.
  */
-void zone_db_free(zone_db_t* zone);
+extern void zone_db_free(zone_db_t* zone);
 
 /**
  * Copy the content of a zone object.
@@ -97,7 +97,7 @@ void zone_db_free(zone_db_t* zone);
  * \param[in] zone_copy a zone_db_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_copy(zone_db_t* zone, const zone_db_t* zone_copy);
+extern int zone_db_copy(zone_db_t* zone, const zone_db_t* zone_copy);
 
 /**
  * Set the content of a zone object based on a database result.
@@ -105,21 +105,21 @@ int zone_db_copy(zone_db_t* zone, const zone_db_t* zone_copy);
  * \param[in] result a db_result_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_from_result(zone_db_t* zone, const db_result_t* result);
+extern int zone_db_from_result(zone_db_t* zone, const db_result_t* result);
 
 /**
  * Get the id of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* zone_db_id(const zone_db_t* zone);
+extern const db_value_t* zone_db_id(const zone_db_t* zone);
 
 /**
  * Get the policy_id of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a db_value_t pointer or NULL on error.
  */
-const db_value_t* zone_db_policy_id(const zone_db_t* zone);
+extern const db_value_t* zone_db_policy_id(const zone_db_t* zone);
 
 /**
  * Get the policy_id object related to a zone object.
@@ -127,126 +127,126 @@ const db_value_t* zone_db_policy_id(const zone_db_t* zone);
  * \param[in] zone a zone_db_t pointer.
  * \return a policy_t pointer or NULL on error or if no object could be found.
  */
-policy_t* zone_db_get_policy(const zone_db_t* zone);
+extern policy_t* zone_db_get_policy(const zone_db_t* zone);
 
 /**
  * Get the name of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a character pointer or NULL on error or if no name has been set.
  */
-const char* zone_db_name(const zone_db_t* zone);
+extern const char* zone_db_name(const zone_db_t* zone);
 
 /**
  * Get the signconf_needs_writing of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_signconf_needs_writing(const zone_db_t* zone);
+extern unsigned int zone_db_signconf_needs_writing(const zone_db_t* zone);
 
 /**
  * Get the signconf_path of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a character pointer or NULL on error or if no signconf_path has been set.
  */
-const char* zone_db_signconf_path(const zone_db_t* zone);
+extern const char* zone_db_signconf_path(const zone_db_t* zone);
 
 /**
  * Get the next_change of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an integer.
  */
-int zone_db_next_change(const zone_db_t* zone);
+extern int zone_db_next_change(const zone_db_t* zone);
 
 /**
  * Get the ttl_end_ds of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_ttl_end_ds(const zone_db_t* zone);
+extern unsigned int zone_db_ttl_end_ds(const zone_db_t* zone);
 
 /**
  * Get the ttl_end_dk of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_ttl_end_dk(const zone_db_t* zone);
+extern unsigned int zone_db_ttl_end_dk(const zone_db_t* zone);
 
 /**
  * Get the ttl_end_rs of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_ttl_end_rs(const zone_db_t* zone);
+extern unsigned int zone_db_ttl_end_rs(const zone_db_t* zone);
 
 /**
  * Get the roll_ksk_now of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_roll_ksk_now(const zone_db_t* zone);
+extern unsigned int zone_db_roll_ksk_now(const zone_db_t* zone);
 
 /**
  * Get the roll_zsk_now of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_roll_zsk_now(const zone_db_t* zone);
+extern unsigned int zone_db_roll_zsk_now(const zone_db_t* zone);
 
 /**
  * Get the roll_csk_now of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_roll_csk_now(const zone_db_t* zone);
+extern unsigned int zone_db_roll_csk_now(const zone_db_t* zone);
 
 /**
  * Get the input_adapter_type of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a character pointer or NULL on error or if no input_adapter_type has been set.
  */
-const char* zone_db_input_adapter_type(const zone_db_t* zone);
+extern const char* zone_db_input_adapter_type(const zone_db_t* zone);
 
 /**
  * Get the input_adapter_uri of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a character pointer or NULL on error or if no input_adapter_uri has been set.
  */
-const char* zone_db_input_adapter_uri(const zone_db_t* zone);
+extern const char* zone_db_input_adapter_uri(const zone_db_t* zone);
 
 /**
  * Get the output_adapter_type of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a character pointer or NULL on error or if no output_adapter_type has been set.
  */
-const char* zone_db_output_adapter_type(const zone_db_t* zone);
+extern const char* zone_db_output_adapter_type(const zone_db_t* zone);
 
 /**
  * Get the output_adapter_uri of a zone object.
  * \param[in] zone a zone_db_t pointer.
  * \return a character pointer or NULL on error or if no output_adapter_uri has been set.
  */
-const char* zone_db_output_adapter_uri(const zone_db_t* zone);
+extern const char* zone_db_output_adapter_uri(const zone_db_t* zone);
 
 /**
  * Get the next_ksk_roll of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_next_ksk_roll(const zone_db_t* zone);
+extern unsigned int zone_db_next_ksk_roll(const zone_db_t* zone);
 
 /**
  * Get the next_zsk_roll of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_next_zsk_roll(const zone_db_t* zone);
+extern unsigned int zone_db_next_zsk_roll(const zone_db_t* zone);
 
 /**
  * Get the next_csk_roll of a zone object. Undefined behavior if `zone` is NULL.
  * \param[in] zone a zone_db_t pointer.
  * \return an unsigned integer.
  */
-unsigned int zone_db_next_csk_roll(const zone_db_t* zone);
+extern unsigned int zone_db_next_csk_roll(const zone_db_t* zone);
 
 /**
  * Set the policy_id of a zone object. If this fails the original value may have been lost.
@@ -254,7 +254,7 @@ unsigned int zone_db_next_csk_roll(const zone_db_t* zone);
  * \param[in] policy_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_policy_id(zone_db_t* zone, const db_value_t* policy_id);
+extern int zone_db_set_policy_id(zone_db_t* zone, const db_value_t* policy_id);
 
 /**
  * Set the name of a zone object.
@@ -262,7 +262,7 @@ int zone_db_set_policy_id(zone_db_t* zone, const db_value_t* policy_id);
  * \param[in] name_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_name(zone_db_t* zone, const char* name_text);
+extern int zone_db_set_name(zone_db_t* zone, const char* name_text);
 
 /**
  * Set the signconf_needs_writing of a zone object.
@@ -270,7 +270,7 @@ int zone_db_set_name(zone_db_t* zone, const char* name_text);
  * \param[in] signconf_needs_writing an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_signconf_needs_writing(zone_db_t* zone, unsigned int signconf_needs_writing);
+extern int zone_db_set_signconf_needs_writing(zone_db_t* zone, unsigned int signconf_needs_writing);
 
 /**
  * Set the signconf_path of a zone object.
@@ -278,7 +278,7 @@ int zone_db_set_signconf_needs_writing(zone_db_t* zone, unsigned int signconf_ne
  * \param[in] signconf_path_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_signconf_path(zone_db_t* zone, const char* signconf_path_text);
+extern int zone_db_set_signconf_path(zone_db_t* zone, const char* signconf_path_text);
 
 /**
  * Set the next_change of a zone object.
@@ -286,7 +286,7 @@ int zone_db_set_signconf_path(zone_db_t* zone, const char* signconf_path_text);
  * \param[in] next_change an integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_next_change(zone_db_t* zone, int next_change);
+extern int zone_db_set_next_change(zone_db_t* zone, int next_change);
 
 /**
  * Set the ttl_end_ds of a zone object.
@@ -294,7 +294,7 @@ int zone_db_set_next_change(zone_db_t* zone, int next_change);
  * \param[in] ttl_end_ds an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_ttl_end_ds(zone_db_t* zone, unsigned int ttl_end_ds);
+extern int zone_db_set_ttl_end_ds(zone_db_t* zone, unsigned int ttl_end_ds);
 
 /**
  * Set the ttl_end_dk of a zone object.
@@ -302,7 +302,7 @@ int zone_db_set_ttl_end_ds(zone_db_t* zone, unsigned int ttl_end_ds);
  * \param[in] ttl_end_dk an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_ttl_end_dk(zone_db_t* zone, unsigned int ttl_end_dk);
+extern int zone_db_set_ttl_end_dk(zone_db_t* zone, unsigned int ttl_end_dk);
 
 /**
  * Set the ttl_end_rs of a zone object.
@@ -310,7 +310,7 @@ int zone_db_set_ttl_end_dk(zone_db_t* zone, unsigned int ttl_end_dk);
  * \param[in] ttl_end_rs an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_ttl_end_rs(zone_db_t* zone, unsigned int ttl_end_rs);
+extern int zone_db_set_ttl_end_rs(zone_db_t* zone, unsigned int ttl_end_rs);
 
 /**
  * Set the roll_ksk_now of a zone object.
@@ -318,7 +318,7 @@ int zone_db_set_ttl_end_rs(zone_db_t* zone, unsigned int ttl_end_rs);
  * \param[in] roll_ksk_now an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_roll_ksk_now(zone_db_t* zone, unsigned int roll_ksk_now);
+extern int zone_db_set_roll_ksk_now(zone_db_t* zone, unsigned int roll_ksk_now);
 
 /**
  * Set the roll_zsk_now of a zone object.
@@ -326,7 +326,7 @@ int zone_db_set_roll_ksk_now(zone_db_t* zone, unsigned int roll_ksk_now);
  * \param[in] roll_zsk_now an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_roll_zsk_now(zone_db_t* zone, unsigned int roll_zsk_now);
+extern int zone_db_set_roll_zsk_now(zone_db_t* zone, unsigned int roll_zsk_now);
 
 /**
  * Set the roll_csk_now of a zone object.
@@ -334,7 +334,7 @@ int zone_db_set_roll_zsk_now(zone_db_t* zone, unsigned int roll_zsk_now);
  * \param[in] roll_csk_now an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_roll_csk_now(zone_db_t* zone, unsigned int roll_csk_now);
+extern int zone_db_set_roll_csk_now(zone_db_t* zone, unsigned int roll_csk_now);
 
 /**
  * Set the input_adapter_type of a zone object.
@@ -342,7 +342,7 @@ int zone_db_set_roll_csk_now(zone_db_t* zone, unsigned int roll_csk_now);
  * \param[in] input_adapter_type_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_input_adapter_type(zone_db_t* zone, const char* input_adapter_type_text);
+extern int zone_db_set_input_adapter_type(zone_db_t* zone, const char* input_adapter_type_text);
 
 /**
  * Set the input_adapter_uri of a zone object.
@@ -350,7 +350,7 @@ int zone_db_set_input_adapter_type(zone_db_t* zone, const char* input_adapter_ty
  * \param[in] input_adapter_uri_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_input_adapter_uri(zone_db_t* zone, const char* input_adapter_uri_text);
+extern int zone_db_set_input_adapter_uri(zone_db_t* zone, const char* input_adapter_uri_text);
 
 /**
  * Set the output_adapter_type of a zone object.
@@ -358,7 +358,7 @@ int zone_db_set_input_adapter_uri(zone_db_t* zone, const char* input_adapter_uri
  * \param[in] output_adapter_type_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_output_adapter_type(zone_db_t* zone, const char* output_adapter_type_text);
+extern int zone_db_set_output_adapter_type(zone_db_t* zone, const char* output_adapter_type_text);
 
 /**
  * Set the output_adapter_uri of a zone object.
@@ -366,7 +366,7 @@ int zone_db_set_output_adapter_type(zone_db_t* zone, const char* output_adapter_
  * \param[in] output_adapter_uri_text a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_output_adapter_uri(zone_db_t* zone, const char* output_adapter_uri_text);
+extern int zone_db_set_output_adapter_uri(zone_db_t* zone, const char* output_adapter_uri_text);
 
 /**
  * Set the next_ksk_roll of a zone object.
@@ -374,7 +374,7 @@ int zone_db_set_output_adapter_uri(zone_db_t* zone, const char* output_adapter_u
  * \param[in] next_ksk_roll an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_next_ksk_roll(zone_db_t* zone, unsigned int next_ksk_roll);
+extern int zone_db_set_next_ksk_roll(zone_db_t* zone, unsigned int next_ksk_roll);
 
 /**
  * Set the next_zsk_roll of a zone object.
@@ -382,7 +382,7 @@ int zone_db_set_next_ksk_roll(zone_db_t* zone, unsigned int next_ksk_roll);
  * \param[in] next_zsk_roll an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_next_zsk_roll(zone_db_t* zone, unsigned int next_zsk_roll);
+extern int zone_db_set_next_zsk_roll(zone_db_t* zone, unsigned int next_zsk_roll);
 
 /**
  * Set the next_csk_roll of a zone object.
@@ -390,7 +390,7 @@ int zone_db_set_next_zsk_roll(zone_db_t* zone, unsigned int next_zsk_roll);
  * \param[in] next_csk_roll an unsigned integer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_set_next_csk_roll(zone_db_t* zone, unsigned int next_csk_roll);
+extern int zone_db_set_next_csk_roll(zone_db_t* zone, unsigned int next_csk_roll);
 
 /**
  * Create a clause for policy_id of a zone object and add it to a database clause list.
@@ -401,14 +401,14 @@ int zone_db_set_next_csk_roll(zone_db_t* zone, unsigned int next_csk_roll);
  * \param[in] policy_id a db_value_t pointer.
  * \return a db_clause_t pointer to the added clause or NULL on error.
  */
-db_clause_t* zone_db_policy_id_clause(db_clause_list_t* clause_list, const db_value_t* policy_id);
+extern db_clause_t* zone_db_policy_id_clause(db_clause_list_t* clause_list, const db_value_t* policy_id);
 
 /**
  * Create a zone object in the database.
  * \param[in] zone a zone_db_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_create(zone_db_t* zone);
+extern int zone_db_create(zone_db_t* zone);
 
 /**
  * Get a zone object from the database by a id specified in `id`.
@@ -416,7 +416,7 @@ int zone_db_create(zone_db_t* zone);
  * \param[in] id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_get_by_id(zone_db_t* zone, const db_value_t* id);
+extern int zone_db_get_by_id(zone_db_t* zone, const db_value_t* id);
 
 /**
  * Get a zone object from the database by a name specified in `name`.
@@ -424,7 +424,7 @@ int zone_db_get_by_id(zone_db_t* zone, const db_value_t* id);
  * \param[in] name a character pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_get_by_name(zone_db_t* zone, const char* name);
+extern int zone_db_get_by_name(zone_db_t* zone, const char* name);
 
 /**
  * Get a new zone object from the database by a name specified in `name`.
@@ -432,21 +432,21 @@ int zone_db_get_by_name(zone_db_t* zone, const char* name);
  * \param[in] name a character pointer.
  * \return a zone_db_t pointer or NULL on error or if it does not exist.
  */
-zone_db_t* zone_db_new_get_by_name(const db_connection_t* connection, const char* name);
+extern zone_db_t* zone_db_new_get_by_name(const db_connection_t* connection, const char* name);
 
 /**
  * Update a zone object in the database.
  * \param[in] zone a zone_db_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_update(zone_db_t* zone);
+extern int zone_db_update(zone_db_t* zone);
 
 /**
  * Delete a zone object from the database.
  * \param[in] zone a zone_db_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_delete(zone_db_t* zone);
+extern int zone_db_delete(zone_db_t* zone);
 
 /**
  * Count the number of zone objects in the database, if a selection of
@@ -458,7 +458,7 @@ int zone_db_delete(zone_db_t* zone);
  * should be counted.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_count(zone_db_t* zone, db_clause_list_t* clause_list, size_t* count);
+extern int zone_db_count(zone_db_t* zone, db_clause_list_t* clause_list, size_t* count);
 
 /**
  * A list of zone objects.
@@ -482,14 +482,14 @@ struct zone_list_db {
  * \param[in] connection a db_connection_t pointer.
  * \return a zone_list_db_t pointer or NULL on error.
  */
-zone_list_db_t* zone_list_db_new(const db_connection_t* connection);
+extern zone_list_db_t* zone_list_db_new(const db_connection_t* connection);
 
 /**
  * Create a new zone object list that is a copy of another.
  * \param[in] zone_list_db a zone_list_db_t pointer.
  * \return a zone_list_db_t pointer or NULL on error.
  */
-zone_list_db_t* zone_list_db_new_copy(const zone_list_db_t* zone_copy);
+extern zone_list_db_t* zone_list_db_new_copy(const zone_list_db_t* zone_copy);
 
 /**
  * Specify that objects should be stored within the list as they are fetch,
@@ -497,13 +497,13 @@ zone_list_db_t* zone_list_db_new_copy(const zone_list_db_t* zone_copy);
  * \param[in] zone_list_db a zone_list_db_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_list_db_object_store(zone_list_db_t* zone_list_db);
+extern int zone_list_db_object_store(zone_list_db_t* zone_list_db);
 
 /**
  * Delete a zone object list.
  * \param[in] zone_list_db a zone_list_db_t pointer.
  */
-void zone_list_db_free(zone_list_db_t* zone_list_db);
+extern void zone_list_db_free(zone_list_db_t* zone_list_db);
 
 /**
  * Copy the content of another zone object list.
@@ -511,21 +511,21 @@ void zone_list_db_free(zone_list_db_t* zone_list_db);
  * \param[in] from_zone_list_db a zone_list_db_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_list_db_copy(zone_list_db_t* zone_list_db, const zone_list_db_t* from_zone_list_db);
+extern int zone_list_db_copy(zone_list_db_t* zone_list_db, const zone_list_db_t* from_zone_list_db);
 
 /**
  * Get all zone objects.
  * \param[in] zone_list_db a zone_list_db_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_list_db_get(zone_list_db_t* zone_list_db);
+extern int zone_list_db_get(zone_list_db_t* zone_list_db);
 
 /**
  * Get a new list with all zone objects.
  * \param[in] connection a db_connection_t pointer.
  * \return a zone_list_db_t pointer or NULL on error.
  */
-zone_list_db_t* zone_list_db_new_get(const db_connection_t* connection);
+extern zone_list_db_t* zone_list_db_new_get(const db_connection_t* connection);
 
 /**
  * Get zone objects from the database by a clause list.
@@ -533,7 +533,7 @@ zone_list_db_t* zone_list_db_new_get(const db_connection_t* connection);
  * \param[in] clause_list a db_clause_list_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_list_db_get_by_clauses(zone_list_db_t* zone_list_db, const db_clause_list_t* clause_list);
+extern int zone_list_db_get_by_clauses(zone_list_db_t* zone_list_db, const db_clause_list_t* clause_list);
 
 /**
  * Get zone objects from the database by a policy_id specified in `policy_id`.
@@ -541,7 +541,7 @@ int zone_list_db_get_by_clauses(zone_list_db_t* zone_list_db, const db_clause_li
  * \param[in] policy_id a db_value_t pointer.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_list_db_get_by_policy_id(zone_list_db_t* zone_list_db, const db_value_t* policy_id);
+extern int zone_list_db_get_by_policy_id(zone_list_db_t* zone_list_db, const db_value_t* policy_id);
 
 /**
  * Get a new list of zone objects from the database by a policy_id specified in `policy_id`.
@@ -549,7 +549,7 @@ int zone_list_db_get_by_policy_id(zone_list_db_t* zone_list_db, const db_value_t
  * \param[in] policy_id a db_value_t pointer.
  * \return a zone_list_db_t pointer or NULL on error.
  */
-zone_list_db_t* zone_list_db_new_get_by_policy_id(const db_connection_t* connection, const db_value_t* policy_id);
+extern zone_list_db_t* zone_list_db_new_get_by_policy_id(const db_connection_t* connection, const db_value_t* policy_id);
 
 /**
  * Get the first zone object in a zone object list and reset the
@@ -558,7 +558,7 @@ zone_list_db_t* zone_list_db_new_get_by_policy_id(const db_connection_t* connect
  * \return a zone_db_t pointer or NULL on error or if there are no
  * zone objects in the zone object list.
  */
-const zone_db_t* zone_list_db_begin(zone_list_db_t* zone_list_db);
+extern const zone_db_t* zone_list_db_begin(zone_list_db_t* zone_list_db);
 
 /**
  * Get the next zone object in a zone object list.
@@ -568,7 +568,7 @@ const zone_db_t* zone_list_db_begin(zone_list_db_t* zone_list_db);
  * \return a zone_db_t pointer or NULL on error or if there are no more
  * zone objects in the zone object list.
  */
-const zone_db_t* zone_list_db_next(zone_list_db_t* zone_list_db);
+extern const zone_db_t* zone_list_db_next(zone_list_db_t* zone_list_db);
 
 /**
  * Get the next zone object in a zone object list.
@@ -578,7 +578,7 @@ const zone_db_t* zone_list_db_next(zone_list_db_t* zone_list_db);
  * \return a zone_db_t pointer or NULL on error or if there are no more
  * zone objects in the zone object list.
  */
-zone_db_t* zone_list_db_get_next(zone_list_db_t* zone_list_db);
+extern zone_db_t* zone_list_db_get_next(zone_list_db_t* zone_list_db);
 
 /**
  * Get the size of a zone object list.
@@ -586,6 +586,6 @@ zone_db_t* zone_list_db_get_next(zone_list_db_t* zone_list_db);
  * \return a size_t with the size of the list or zero on error, if the list is
  * empty or if the backend does not support returning the size.
  */
-size_t zone_list_db_size(zone_list_db_t* zone_list_db);
+extern size_t zone_list_db_size(zone_list_db_t* zone_list_db);
 
 #endif

--- a/enforcer/src/db/zone_db_ext.h
+++ b/enforcer/src/db/zone_db_ext.h
@@ -39,7 +39,7 @@
  * Convert zone ID to name, caller must free resulting string.
  * return NULL on error
  */
-char *
+extern char *
 zone_db_ext_zonename_from_id(const db_connection_t* connection,
     const db_value_t* id);
 
@@ -48,14 +48,14 @@ zone_db_ext_zonename_from_id(const db_connection_t* connection,
  * \param[in] zone an zone_db_t pointer.
  * \return a key_data_list_t pointer or NULL on error.
  */
-key_data_list_t* zone_db_get_keys(const zone_db_t* zone);
+extern key_data_list_t* zone_db_get_keys(const zone_db_t* zone);
 
 /**
  * Get a list of key dependencies for an enforcer zone object.
  * \param[in] zone an zone_db_t pointer.
  * \return a key_dependency_list_t pointer or NULL on error.
  */
-key_dependency_list_t* zone_db_get_key_dependencies(const zone_db_t* zone);
+extern key_dependency_list_t* zone_db_get_key_dependencies(const zone_db_t* zone);
 
 /**
  * Create a zone object from XML.
@@ -63,7 +63,7 @@ key_dependency_list_t* zone_db_get_key_dependencies(const zone_db_t* zone);
  * \param[in] zone_node a xmlNodePtr to the XML for the zone.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_create_from_xml(zone_db_t* zone, xmlNodePtr zone_node);
+extern int zone_db_create_from_xml(zone_db_t* zone, xmlNodePtr zone_node);
 
 /**
  * Update a zone object from XML.
@@ -73,6 +73,6 @@ int zone_db_create_from_xml(zone_db_t* zone, xmlNodePtr zone_node);
  * values in the zone was updated.
  * \return DB_ERROR_* on failure, otherwise DB_OK.
  */
-int zone_db_update_from_xml(zone_db_t* zone, xmlNodePtr zone_node, int* updated);
+extern int zone_db_update_from_xml(zone_db_t* zone, xmlNodePtr zone_node, int* updated);
 
 #endif

--- a/enforcer/src/enforcer/autostart_cmd.h
+++ b/enforcer/src/enforcer/autostart_cmd.h
@@ -32,6 +32,6 @@
 
 #include "daemon/engine.h"
 
-void autostart(engine_type* engine);
+extern void autostart(engine_type* engine);
 
 #endif

--- a/enforcer/src/enforcer/enforce_cmd.h
+++ b/enforcer/src/enforcer/enforce_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _ENFORCER_ENFORCE_CMD_H_
 #define _ENFORCER_ENFORCE_CMD_H_
 
-struct cmd_func_block enforce_funcblock;
+extern struct cmd_func_block enforce_funcblock;
 
 #endif /* _ENFORCER_ENFORCE_CMD_H_ */

--- a/enforcer/src/enforcer/enforce_task.h
+++ b/enforcer/src/enforcer/enforce_task.h
@@ -35,18 +35,18 @@
 #include "scheduler/task.h"
 #include "db/dbw.h"
 
-task_type *enforce_task(engine_type *engine, char const *owner);
+extern task_type *enforce_task(engine_type *engine, char const *owner);
 
-time_t enforce_task_perform(task_type* task, char const *owner, void *context,
+extern time_t enforce_task_perform(task_type* task, char const *owner, void *context,
     void *dbconn);
 
 /* Schedule enforce tasks for *now* for zone. */
-void enforce_task_flush_zone(engine_type *engine, char const *zonename);
+extern void enforce_task_flush_zone(engine_type *engine, char const *zonename);
 
 /* Schedule enforce tasks for *now* for ALL zones of policy. */
-void enforce_task_flush_policy(engine_type *engine, struct dbw_policy *policy);
+extern void enforce_task_flush_policy(engine_type *engine, struct dbw_policy *policy);
 
 /* Schedule enforce tasks for *now* for ALL zones. */
-void enforce_task_flush_all(engine_type *engine, db_connection_t *dbconn);
+extern void enforce_task_flush_all(engine_type *engine, db_connection_t *dbconn);
 
 #endif

--- a/enforcer/src/enforcer/enforcer.h
+++ b/enforcer/src/enforcer/enforcer.h
@@ -46,11 +46,11 @@
  * @param[in] keyfactory
  * @return time_t Time the function wishes to be called again.
  * */
-time_t
+extern time_t
 update(engine_type *engine, struct dbw_db *db, struct dbw_zone *zone, time_t now, int *zone_updated);
 /**
  * same as above except will not create HSM keys.
  */
-time_t
+extern time_t
 update_mockup(engine_type *engine, struct dbw_db *db, struct dbw_zone *zone, time_t now, int *zone_updated);
 #endif /* _ENFORCER_ENFORCER_H_ */

--- a/enforcer/src/enforcer/repositorylist_cmd.h
+++ b/enforcer/src/enforcer/repositorylist_cmd.h
@@ -28,6 +28,6 @@
 #ifndef _ENFORCER_REPOSITORYLIST_CMD_H_
 #define _ENFORCER_REPOSITORYLIST_CMD_H_
 
-struct cmd_func_block repositorylist_funcblock;
+extern struct cmd_func_block repositorylist_funcblock;
 
 #endif

--- a/enforcer/src/enforcer/update_all_cmd.h
+++ b/enforcer/src/enforcer/update_all_cmd.h
@@ -30,6 +30,6 @@
 #ifndef UPDATE_ALL_CMD_H_
 #define UPDATE_ALL_CMD_H_
 
-struct cmd_func_block update_all_funcblock;
+extern struct cmd_func_block update_all_funcblock;
 
 #endif /* UPDATE_ALL_CMD_H_ */

--- a/enforcer/src/enforcer/update_conf_cmd.h
+++ b/enforcer/src/enforcer/update_conf_cmd.h
@@ -29,6 +29,6 @@
 #ifndef UPDATE_CONF_CMD_H_
 #define UPDATE_CONF_CMD_H_
 
-struct cmd_func_block update_conf_funcblock;
+extern struct cmd_func_block update_conf_funcblock;
 
 #endif /* UPDATE_CONF_CMD_H_ */

--- a/enforcer/src/enforcer/update_repositorylist_cmd.h
+++ b/enforcer/src/enforcer/update_repositorylist_cmd.h
@@ -30,6 +30,6 @@
 #ifndef UPDATE_REPOSITORYLIST_CMD_H_
 #define UPDATE_REPOSITORYLIST_CMD_H_
 
-struct cmd_func_block update_repositorylist_funcblock;
+extern struct cmd_func_block update_repositorylist_funcblock;
 
 #endif /* UPDATE_REPOSITORYLIST_CMD_H_ */

--- a/enforcer/src/hsmkey/backup_hsmkeys_cmd.h
+++ b/enforcer/src/hsmkey/backup_hsmkeys_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _HSMKEY_BACKUP_CMD_H_
 #define _HSMKEY_BACKUP_CMD_H_
 
-struct cmd_func_block backup_funcblock;
+extern struct cmd_func_block backup_funcblock;
 
 #endif /* _HSMKEY_BACKUP_CMD_H_ */

--- a/enforcer/src/hsmkey/hsm_key_factory.h
+++ b/enforcer/src/hsmkey/hsm_key_factory.h
@@ -34,9 +34,9 @@
 
 #include <time.h>
 
-void hsm_key_factory_deinit(void);
+extern void hsm_key_factory_deinit(void);
 
-void
+extern void
 hsm_key_factory_schedule(engine_type *engine, int id, int count);
 
 /**
@@ -50,7 +50,7 @@ hsm_key_factory_schedule(engine_type *engine, int id, int count);
  * \return an allocated HSM key or NULL on error or if there are no unused keys
  * available for allocation right now.
  */
-struct dbw_hsmkey *
+extern struct dbw_hsmkey *
 hsm_key_factory_get_key(engine_type *engine, struct dbw_db *db,
     struct dbw_policykey *pkey, struct dbw_zone *zone);
 
@@ -58,9 +58,9 @@ hsm_key_factory_get_key(engine_type *engine, struct dbw_db *db,
  * Release a key, if its not used anymore it will be marked DELETE.
  * \param[in] key
  */
-void
+extern void
 hsm_key_factory_release_key(struct dbw_hsmkey *hsmkey, struct dbw_key *key);
-void
+extern void
 hsm_key_factory_release_key_mockup(struct dbw_hsmkey *hsmkey, struct dbw_key *key, int mockup);
 
 #endif /* _HSM_KEY_FACTORY_H_ */

--- a/enforcer/src/hsmkey/key_generate_cmd.h
+++ b/enforcer/src/hsmkey/key_generate_cmd.h
@@ -29,6 +29,6 @@
 #ifndef HSMKEY_KEY_GENERATE_CMD_H_
 #define HSMKEY_KEY_GENERATE_CMD_H_
 
-struct cmd_func_block key_generate_funcblock;
+extern struct cmd_func_block key_generate_funcblock;
 
 #endif /* HSMKEY_KEY_GENERATE_CMD_H_ */

--- a/enforcer/src/keystate/key_purge.h
+++ b/enforcer/src/keystate/key_purge.h
@@ -3,8 +3,8 @@
 
 #include "db/dbw.h"
 
-int removeDeadKeysNow_zone(int sockfd, struct dbw_db *db, struct dbw_zone *zone);
-int removeDeadKeysNow_policy(int sockfd, struct dbw_db *db, struct dbw_policy *policy);
+extern int removeDeadKeysNow_zone(int sockfd, struct dbw_db *db, struct dbw_zone *zone);
+extern int removeDeadKeysNow_policy(int sockfd, struct dbw_db *db, struct dbw_policy *policy);
 
 #endif
 

--- a/enforcer/src/keystate/key_purge_cmd.h
+++ b/enforcer/src/keystate/key_purge_cmd.h
@@ -1,7 +1,7 @@
 #ifndef _KEYSTATE_KEY_PURGE_CMD_H_
 #define _KEYSTATE_KEY_PURGE_CMD_H_
 
-struct cmd_func_block key_purge_funcblock;
+extern struct cmd_func_block key_purge_funcblock;
 
 #endif /* _KEYSTATE_KEY_PURGE_CMD_H_ */
 

--- a/enforcer/src/keystate/keystate_ds.h
+++ b/enforcer/src/keystate/keystate_ds.h
@@ -30,12 +30,12 @@
 
 #include "db/dbw.h"
 
-int
+extern int
 change_keys_from_to(db_connection_t *dbconn, int sockfd, const char *zonename,
     const char *cka_id, int keytag, int state_from,
     int state_to, engine_type *engine, int cmd);
 
-int run_ds_cmd(int sockfd, const char *cmd,
+extern int run_ds_cmd(int sockfd, const char *cmd,
     db_connection_t *dbconn, key_data_ds_at_parent_t state_from,
     key_data_ds_at_parent_t state_to, engine_type* engine);
 

--- a/enforcer/src/keystate/keystate_ds_gone_cmd.h
+++ b/enforcer/src/keystate/keystate_ds_gone_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_DS_GONE_CMD_H_
 #define _KEYSTATE_DS_GONE_CMD_H_
 
-struct cmd_func_block key_ds_gone_funcblock;
+extern struct cmd_func_block key_ds_gone_funcblock;
 
 #endif /* _KEYSTATE_DS_GONE_CMD_H_ */

--- a/enforcer/src/keystate/keystate_ds_retract_cmd.h
+++ b/enforcer/src/keystate/keystate_ds_retract_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_DS_RETRACT_CMD_H_
 #define _KEYSTATE_DS_RETRACT_CMD_H_
 
-struct cmd_func_block key_ds_retract_funcblock;
+extern struct cmd_func_block key_ds_retract_funcblock;
 
 #endif /* _KEYSTATE_DS_RETRACT_CMD_H_ */

--- a/enforcer/src/keystate/keystate_ds_retract_task.h
+++ b/enforcer/src/keystate/keystate_ds_retract_task.h
@@ -30,7 +30,7 @@
 #ifndef _KEYSTATE_DS_RETRACT_TASK_H_
 #define _KEYSTATE_DS_RETRACT_TASK_H_
 
-task_type *
+extern task_type *
 keystate_ds_retract_task(engine_type *engine, char const *owner);
 
 #endif /*_KEYSTATE_DS_RETRACT_TASK_H_*/

--- a/enforcer/src/keystate/keystate_ds_seen_cmd.h
+++ b/enforcer/src/keystate/keystate_ds_seen_cmd.h
@@ -32,6 +32,6 @@
 
 #include "daemon/engine.h"
 
-struct cmd_func_block key_ds_seen_funcblock;
+extern struct cmd_func_block key_ds_seen_funcblock;
 
 #endif /* _KEYSTATE_DS_SEEN_CMD_H_ */

--- a/enforcer/src/keystate/keystate_ds_submit_cmd.h
+++ b/enforcer/src/keystate/keystate_ds_submit_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_DS_SUBMIT_CMD_H_
 #define _KEYSTATE_DS_SUBMIT_CMD_H_
 
-struct cmd_func_block key_ds_submit_funcblock;
+extern struct cmd_func_block key_ds_submit_funcblock;
 
 #endif /* _KEYSTATE_DS_SUBMIT_CMD_H_ */

--- a/enforcer/src/keystate/keystate_ds_submit_task.h
+++ b/enforcer/src/keystate/keystate_ds_submit_task.h
@@ -30,7 +30,7 @@
 #ifndef _KEYSTATE_DS_SUBMIT_TASK_H_
 #define _KEYSTATE_DS_SUBMIT_TASK_H_
 
-task_type *
+extern task_type *
 keystate_ds_submit_task(engine_type *engine, char const *owner);
 
 #endif

--- a/enforcer/src/keystate/keystate_export_cmd.h
+++ b/enforcer/src/keystate/keystate_export_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_EXPORT_CMD_H_
 #define _KEYSTATE_EXPORT_CMD_H_
 
-struct cmd_func_block key_export_funcblock;
+extern struct cmd_func_block key_export_funcblock;
 
 #endif /* _KEYSTATE_EXPORT_CMD_H_ */

--- a/enforcer/src/keystate/keystate_import_cmd.h
+++ b/enforcer/src/keystate/keystate_import_cmd.h
@@ -28,7 +28,7 @@
 #ifndef _KEYSTATE_IMPORT_CMD_H_
 #define _KEYSTATE_IMPORT_CMD_H_
 
-struct cmd_func_block key_import_funcblock;
+extern struct cmd_func_block key_import_funcblock;
 
 #endif /* _KEYSTATE_IMPORT_CMD_H_ */
 

--- a/enforcer/src/keystate/keystate_list_cmd.h
+++ b/enforcer/src/keystate/keystate_list_cmd.h
@@ -32,12 +32,12 @@
 
 #include "db/dbw.h"
 
-struct cmd_func_block key_list_funcblock;
+extern struct cmd_func_block key_list_funcblock;
 
-const char*
+extern const char*
 map_keystate(struct dbw_key *key);
 
-char*
+extern char*
 map_keytime(const struct dbw_key *key, time_t now);
 
 #endif /* _KEYSTATE_LIST_CMD_H_ */

--- a/enforcer/src/keystate/keystate_rollover_cmd.h
+++ b/enforcer/src/keystate/keystate_rollover_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_ROLLOVER_CMD_H_
 #define _KEYSTATE_ROLLOVER_CMD_H_
 
-struct cmd_func_block key_rollover_funcblock;
+extern struct cmd_func_block key_rollover_funcblock;
 
 #endif /* _KEYSTATE_ROLLOVER_CMD_H_ */

--- a/enforcer/src/keystate/rollover_list_cmd.h
+++ b/enforcer/src/keystate/rollover_list_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _ROLLOVER_LIST_CMD_H_
 #define _ROLLOVER_LIST_CMD_H_
 
-struct cmd_func_block rollover_list_funcblock;
+extern struct cmd_func_block rollover_list_funcblock;
 
 #endif /* _ROLLOVER_LIST_CMD_H_ */

--- a/enforcer/src/keystate/zone_add_cmd.h
+++ b/enforcer/src/keystate/zone_add_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_ZONE_ADD_CMD_H_
 #define _KEYSTATE_ZONE_ADD_CMD_H_
 
-struct cmd_func_block zone_add_funcblock;
+extern struct cmd_func_block zone_add_funcblock;
 
 #endif /* _KEYSTATE_ZONE_ADD_CMD_H_ */

--- a/enforcer/src/keystate/zone_del_cmd.h
+++ b/enforcer/src/keystate/zone_del_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_ZONE_DEL_CMD_H_
 #define _KEYSTATE_ZONE_DEL_CMD_H_
 
-struct cmd_func_block zone_del_funcblock;
+extern struct cmd_func_block zone_del_funcblock;
 
 #endif /* _KEYSTATE_ZONE_DEL_CMD_H_ */

--- a/enforcer/src/keystate/zone_list_cmd.h
+++ b/enforcer/src/keystate/zone_list_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _KEYSTATE_ZONE_LIST_CMD_H_
 #define _KEYSTATE_ZONE_LIST_CMD_H_
 
-struct cmd_func_block zone_list_funcblock;
+extern struct cmd_func_block zone_list_funcblock;
 
 #endif /* _KEYSTATE_ZONE_LIST_CMD_H_ */

--- a/enforcer/src/keystate/zone_set_policy_cmd.h
+++ b/enforcer/src/keystate/zone_set_policy_cmd.h
@@ -29,6 +29,6 @@
 #ifndef _KEYSTATE_ZONE_SET_POLICY_CMD_H_
 #define _KEYSTATE_ZONE_SET_POLICY_CMD_H_
 
-struct cmd_func_block zone_set_policy_funcblock;
+extern struct cmd_func_block zone_set_policy_funcblock;
 
 #endif /* _KEYSTATE_ZONE_SET_POLICY_CMD_H_ */

--- a/enforcer/src/keystate/zonelist_export.h
+++ b/enforcer/src/keystate/zonelist_export.h
@@ -64,6 +64,6 @@
  * \param[in] comment if non-zero include a comment about the zonelist file.
  * \return ZONELIST_EXPORT_ERR_* on error otherwise ZONELIST_EXPORT_OK.
  */
-int zonelist_export(int sockfd, db_connection_t* connection, const char* filename, int comment);
+extern int zonelist_export(int sockfd, db_connection_t* connection, const char* filename, int comment);
 
 #endif /* _KEYSTATE_ZONELIST_EXPORT_H_ */

--- a/enforcer/src/keystate/zonelist_export_cmd.h
+++ b/enforcer/src/keystate/zonelist_export_cmd.h
@@ -29,6 +29,6 @@
 #ifndef _KEYSTATE_ZONELIST_EXPORT_CMD_H_
 #define _KEYSTATE_ZONELIST_EXPORT_CMD_H_
 
-struct cmd_func_block zonelist_export_funcblock;
+extern struct cmd_func_block zonelist_export_funcblock;
 
 #endif /* _KEYSTATE_ZONELIST_EXPORT_CMD_H_ */

--- a/enforcer/src/keystate/zonelist_import.h
+++ b/enforcer/src/keystate/zonelist_import.h
@@ -68,7 +68,7 @@
  * \return ZONELIST_IMPORT_ERR_* on error otherwise ZONELIST_IMPORT_OK or
  * ZONELIST_IMPORT_NO_CHANGE.
  */
-int zonelist_import(int sockfd, engine_type* engine, db_connection_t *dbconn,
+extern int zonelist_import(int sockfd, engine_type* engine, db_connection_t *dbconn,
     int do_delete, const char* zonelist_path);
 
 #endif /* _KEYSTATE_ZONELIST_IMPORT_H_ */

--- a/enforcer/src/keystate/zonelist_import_cmd.h
+++ b/enforcer/src/keystate/zonelist_import_cmd.h
@@ -29,6 +29,6 @@
 #ifndef _KEYSTATE_ZONELIST_IMPORT_CMD_H_
 #define _KEYSTATE_ZONELIST_IMPORT_CMD_H_
 
-struct cmd_func_block zonelist_import_funcblock;
+extern struct cmd_func_block zonelist_import_funcblock;
 
 #endif /* _KEYSTATE_ZONELIST_IMPORT_CMD_H_ */

--- a/enforcer/src/keystate/zonelist_update.h
+++ b/enforcer/src/keystate/zonelist_update.h
@@ -64,7 +64,7 @@
  * \param[in] comment if non-zero include a comment about the zonelist file.
  * \return ZONELIST_UPDATE_ERR_* on error otherwise ZONELIST_UPDATE_OK.
  */
-int zonelist_update_add(int sockfd, const char* filename,
+extern int zonelist_update_add(int sockfd, const char* filename,
        const struct dbw_zone* zone, const char *policyname, int comment);
 
 /**
@@ -75,6 +75,6 @@ int zonelist_update_add(int sockfd, const char* filename,
  * \param[in] comment if non-zero include a comment about the zonelist file.
  * \return ZONELIST_UPDATE_ERR_* on error otherwise ZONELIST_UPDATE_OK.
  */
-int zonelist_update_delete(int sockfd, const char* filename,
+extern int zonelist_update_delete(int sockfd, const char* filename,
        const struct dbw_zone* zone, const char *policyname, int comment);
 #endif /* _KEYSTATE_ZONELIST_UPDATE_H_ */

--- a/enforcer/src/policy/policy_export.h
+++ b/enforcer/src/policy/policy_export.h
@@ -63,7 +63,7 @@
  * \param[in] filename the filename to write to, if NULL write to stdout.
  * \return POLICY_EXPORT_ERR_* on error otherwise POLICY_EXPORT_OK.
  */
-int policy_export_all(int sockfd, db_connection_t* connection, const char* filename);
+extern int policy_export_all(int sockfd, db_connection_t* connection, const char* filename);
 
 /**
  * Export the policy from the database to XML.
@@ -72,6 +72,6 @@ int policy_export_all(int sockfd, db_connection_t* connection, const char* filen
  * \param[in] filename the filename to write to, if NULL write to stdout.
  * \return POLICY_EXPORT_ERR_* on error otherwise POLICY_EXPORT_OK.
  */
-int policy_export(int sockfd, const struct dbw_policy *policy, const char* filename);
+extern int policy_export(int sockfd, const struct dbw_policy *policy, const char* filename);
 
 #endif /* _POLICY_POLICY_EXPORT_H_ */

--- a/enforcer/src/policy/policy_export_cmd.h
+++ b/enforcer/src/policy/policy_export_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _POLICY_POLICY_EXPORT_CMD_H_
 #define _POLICY_POLICY_EXPORT_CMD_H_
 
-struct cmd_func_block policy_export_funcblock;
+extern struct cmd_func_block policy_export_funcblock;
 
 #endif /* _POLICY_POLICY_EXPORT_CMD_H_ */

--- a/enforcer/src/policy/policy_import.h
+++ b/enforcer/src/policy/policy_import.h
@@ -68,7 +68,7 @@
  * in the KASP if non-zero.
  * \return POLICY_IMPORT_ERR_* on error otherwise POLICY_IMPORT_OK.
  */
-int policy_import(int sockfd, engine_type* engine, db_connection_t *dbconn,
+extern int policy_import(int sockfd, engine_type* engine, db_connection_t *dbconn,
     int do_delete);
 
 #endif /* _POLICY_POLICY_IMPORT_H_ */

--- a/enforcer/src/policy/policy_import_cmd.h
+++ b/enforcer/src/policy/policy_import_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _POLICY_POLICY_IMPORT_CMD_H_
 #define _POLICY_POLICY_IMPORT_CMD_H_
 
-struct cmd_func_block policy_import_funcblock;
+extern struct cmd_func_block policy_import_funcblock;
 
 #endif /* _POLICY_POLICY_IMPORT_CMD_H_ */

--- a/enforcer/src/policy/policy_list_cmd.h
+++ b/enforcer/src/policy/policy_list_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _POLICY_POLICY_LIST_CMD_H_
 #define _POLICY_POLICY_LIST_CMD_H_
 
-struct cmd_func_block policy_list_funcblock;
+extern struct cmd_func_block policy_list_funcblock;
 
 #endif /* _POLICY_POLICY_LIST_CMD_H_ */

--- a/enforcer/src/policy/policy_purge_cmd.h
+++ b/enforcer/src/policy/policy_purge_cmd.h
@@ -1,6 +1,6 @@
 #ifndef _POLICY_POLICY_PURGE_CMD_H_
 #define _POLICY_POLICY_PURGE_CMD_H_
 
-struct cmd_func_block policy_purge_funcblock;
+extern struct cmd_func_block policy_purge_funcblock;
 
 #endif /* _POLICY_POLICY_PURGE_CMD_H_ */

--- a/enforcer/src/policy/policy_resalt_cmd.h
+++ b/enforcer/src/policy/policy_resalt_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _POLICY_POLICY_RESALT_CMD_H_
 #define _POLICY_POLICY_RESALT_CMD_H_
 
-struct cmd_func_block resalt_funcblock;
+extern struct cmd_func_block resalt_funcblock;
 
 #endif /*_POLICY_POLICY_RESALT_CMD_H_*/

--- a/enforcer/src/policy/policy_resalt_task.h
+++ b/enforcer/src/policy/policy_resalt_task.h
@@ -36,13 +36,13 @@
 /**
  * reschedule resalt tasks for *now*. If policyname not given flush *all*
  */
-int
+extern int
 resalt_task_flush(engine_type *engine, db_connection_t *dbconn,
     const char *policy);
 
 /**
  * Schedule all resalt tasks
  */
-int resalt_task_schedule(engine_type *engine, db_connection_t *dbconn);
+extern int resalt_task_schedule(engine_type *engine, db_connection_t *dbconn);
 
 #endif

--- a/enforcer/src/signconf/signconf_cmd.h
+++ b/enforcer/src/signconf/signconf_cmd.h
@@ -30,6 +30,6 @@
 #ifndef _SIGNCONF_SIGNCONF_CMD_H_
 #define _SIGNCONF_SIGNCONF_CMD_H_
 
-struct cmd_func_block signconf_funcblock;
+extern struct cmd_func_block signconf_funcblock;
 
 #endif /* _SIGNCONF_SIGNCONF_CMD_H_ */

--- a/enforcer/src/signconf/signconf_task.h
+++ b/enforcer/src/signconf/signconf_task.h
@@ -33,12 +33,12 @@
 #include "daemon/engine.h"
 #include "db/dbw.h"
 
-void signconf_task_flush_zone(engine_type *engine, db_connection_t *dbconn,
+extern void signconf_task_flush_zone(engine_type *engine, db_connection_t *dbconn,
     const char* zonename);
 
-void signconf_task_flush_policy(engine_type *engine, db_connection_t *dbconn,
+extern void signconf_task_flush_policy(engine_type *engine, db_connection_t *dbconn,
     char const *policyname);
 
-void signconf_task_flush_all(engine_type *engine, db_connection_t *dbconn);
+extern void signconf_task_flush_all(engine_type *engine, db_connection_t *dbconn);
 
 #endif

--- a/enforcer/src/signconf/signconf_xml.h
+++ b/enforcer/src/signconf/signconf_xml.h
@@ -67,7 +67,7 @@
  * \return SIGNCONF_EXPORT_ERR_* on error, otherwise SIGNCONF_EXPORT_OK or
  * SIGNCONF_EXPORT_NO_CHANGE.
  */
-int
+extern int
 signconf_export_zone(char const *zonename, db_connection_t* dbconn);
 
 /**
@@ -80,7 +80,7 @@ signconf_export_zone(char const *zonename, db_connection_t* dbconn);
  * \return SIGNCONF_EXPORT_ERR_* on error, otherwise SIGNCONF_EXPORT_OK or
  * SIGNCONF_EXPORT_NO_CHANGE.
  */
-int signconf_export_policy(int sockfd, db_connection_t* connection,
+extern int signconf_export_policy(int sockfd, db_connection_t* connection,
     struct dbw_policy *policy, int force);
 
 #endif /* SIGNCONF_SIGNCONF_H_ */

--- a/enforcer/src/utils/kc_helper.h
+++ b/enforcer/src/utils/kc_helper.h
@@ -45,44 +45,44 @@ typedef struct {
 	char *TokenLabel;
 } KC_REPO;
 
-int check_conf(const char *conf, char **kasp, char **zonelist, 
+extern int check_conf(const char *conf, char **kasp, char **zonelist, 
 	char ***repo_listout, int *repo_countout, int verbose);
-int check_kasp(const char *kasp, char **repo_list, int repo_count, int verbose,
+extern int check_kasp(const char *kasp, char **repo_list, int repo_count, int verbose,
     char ***policy_names_out, int *policy_count_out);
-int check_zonelist(const char *zonelist, int verbose, char **policy_names,
+extern int check_zonelist(const char *zonelist, int verbose, char **policy_names,
     int policy_count);
 
-void log_init(int facility, const char *program_name);
-void log_switch(int facility, const char *program_name);
-void dual_log(const char *format, ...)
+extern void log_init(int facility, const char *program_name);
+extern void log_switch(int facility, const char *program_name);
+extern void dual_log(const char *format, ...)
 #ifdef HAVE___ATTRIBUTE__
      __attribute__ ((format (printf, 1, 2)))
 #endif
      ;
 
 
-int check_rng(const char *filename, const char *rngfilename, int verbose);
+extern int check_rng(const char *filename, const char *rngfilename, int verbose);
 
-int check_file(const char *filename, const char *log_string);
-int check_file_from_xpath(xmlXPathContextPtr xpath_ctx, const char *log_string, const xmlChar *file_xexpr);
+extern int check_file(const char *filename, const char *log_string);
+extern int check_file_from_xpath(xmlXPathContextPtr xpath_ctx, const char *log_string, const xmlChar *file_xexpr);
 
-int check_path(const char *pathname, const char *log_string);
-int check_path_from_xpath(xmlXPathContextPtr xpath_ctx, const char *log_string, const xmlChar *path_xexpr);
+extern int check_path(const char *pathname, const char *log_string);
+extern int check_path_from_xpath(xmlXPathContextPtr xpath_ctx, const char *log_string, const xmlChar *path_xexpr);
 
-int check_user_group(xmlXPathContextPtr xpath_ctx, const xmlChar *user_xexpr, const xmlChar *group_xexpr);
+extern int check_user_group(xmlXPathContextPtr xpath_ctx, const xmlChar *user_xexpr, const xmlChar *group_xexpr);
 
-int check_time_def(const char *time_expr, const char *location, const char *field, const char *filename, int* interval);
-int check_time_def_from_xpath(xmlXPathContextPtr xpath_ctx, const xmlChar *time_xexpr, const char *location, const char *field, const char *filename);
+extern int check_time_def(const char *time_expr, const char *location, const char *field, const char *filename, int* interval);
+extern int check_time_def_from_xpath(xmlXPathContextPtr xpath_ctx, const xmlChar *time_xexpr, const char *location, const char *field, const char *filename);
 
 /* if repo_list NULL, will skip the check to see all repositories in kasp are available in conf */
-int check_policy(xmlNode *curNode, const char *policy_name, char **repo_list, int repo_count, const char *kasp);
+extern int check_policy(xmlNode *curNode, const char *policy_name, char **repo_list, int repo_count, const char *kasp);
 
-int DtXMLIntervalSeconds(const char* text, int* interval);
-int StrStrtoi(const char* string, int* value);
-int StrStrtol(const char* string, long* value);
-char* StrStrdup(const char* string);
-void StrTrimR(char *text);
-char* StrTrimL(char* text);
-void* MemCalloc(size_t nmemb, size_t size);
+extern int DtXMLIntervalSeconds(const char* text, int* interval);
+extern int StrStrtoi(const char* string, int* value);
+extern int StrStrtol(const char* string, long* value);
+extern char* StrStrdup(const char* string);
+extern void StrTrimR(char *text);
+extern char* StrTrimL(char* text);
+extern void* MemCalloc(size_t nmemb, size_t size);
 
 #endif /* KC_HELPER_H */

--- a/libhsm/src/lib/libhsm.h
+++ b/libhsm/src/lib/libhsm.h
@@ -146,7 +146,7 @@ the given strings.
 \param action   action for which the error occured
 \param message  error message format string
 */
-void
+extern void
 hsm_ctx_set_error(hsm_ctx_t *ctx, int error, const char *action,
                  const char *message, ...)
 #ifdef HAVE___ATTRIBUTE__
@@ -154,7 +154,7 @@ hsm_ctx_set_error(hsm_ctx_t *ctx, int error, const char *action,
 #endif
      ;
 
-struct engineconfig_repository *
+extern struct engineconfig_repository *
 hsm_find_repository(struct engineconfig_repository *rlist, char const *name);
 
 /*! Open HSM library
@@ -172,7 +172,7 @@ Also creates initial sessions (not part of any context; every API
 function that takes a context can be passed NULL, in which case the
 global context will be used) and log into each HSM.
 */
-int
+extern int
 hsm_open2(struct engineconfig_repository* rlist,
          char *(pin_callback)(unsigned int, const char *, unsigned int));
 
@@ -186,7 +186,7 @@ hsm_open2(struct engineconfig_repository* rlist,
 \param mode The type of mode the function should run in.
 \return The string the user enters
 */
-char *
+extern char *
 hsm_prompt_pin(unsigned int id, const char *repository, unsigned int mode);
 
 
@@ -198,7 +198,7 @@ hsm_prompt_pin(unsigned int id, const char *repository, unsigned int mode);
 \param mode The type of mode the function should run in.
 \return The string the user enters
 */
-char *
+extern char *
 hsm_check_pin(unsigned int id, const char *repository, unsigned int mode);
 
 
@@ -208,7 +208,7 @@ hsm_check_pin(unsigned int id, const char *repository, unsigned int mode);
     semaphore. Any authenticated process will still be able to interact
     with the HSM.
 */
-int
+extern int
 hsm_logout_pin(void);
 
 
@@ -218,7 +218,7 @@ hsm_logout_pin(void);
     This cleans up all data for libhsm, and should be the last function
     called.
 */
-void
+extern void
 hsm_close(void);
 
 
@@ -227,7 +227,7 @@ hsm_close(void);
 Creates a new session for each attached HSM. The returned hsm_ctx_t *
 can be freed with hsm_destroy_context()
 */
-hsm_ctx_t *
+extern hsm_ctx_t *
 hsm_create_context(void);
 
 
@@ -239,7 +239,7 @@ If they are not alive, then try re-open libhsm.
 \param context HSM context
 \return 0 if successful, !0 if failed
 */
-int
+extern int
 hsm_check_context();
 
 
@@ -249,10 +249,10 @@ hsm_check_context();
 
 Also destroys any associated sessions.
 */
-void
+extern void
 hsm_destroy_context(hsm_ctx_t *context);
 
-void
+extern void
 libhsm_key_free(libhsm_key_t *key);
 
 /*! List all known keys in all attached HSMs
@@ -267,7 +267,7 @@ freed with libhsm_key_free()
 \param context HSM context
 \param count location to store the number of keys found
 */
-libhsm_key_t **
+extern libhsm_key_t **
 hsm_list_keys(hsm_ctx_t *context, size_t *count);
 
 
@@ -284,7 +284,7 @@ freed with libhsm_key_free()
 \param count location to store the number of keys found
 \param repository repository to list the keys in
 */
-libhsm_key_t **
+extern libhsm_key_t **
 hsm_list_keys_repository(hsm_ctx_t *context,
                          size_t *count,
                          const char *repository);
@@ -300,7 +300,7 @@ The returned key structure can be freed with libhsm_key_free()
           string of hex characters)
 \return key identifier or NULL if not found (or invalid input)
 */
-libhsm_key_t *
+extern libhsm_key_t *
 hsm_find_key_by_id(hsm_ctx_t *context,
                    const char *id);
 
@@ -317,7 +317,7 @@ The returned key structure can be freed with libhsm_key_free()
 \param keysize Size of RSA key
 \return return key identifier or NULL if key generation failed
 */
-libhsm_key_t *
+extern libhsm_key_t *
 hsm_generate_rsa_key(hsm_ctx_t *context,
                      const char *repository,
                      unsigned long keysize);
@@ -334,7 +334,7 @@ The returned key structure can be freed with libhsm_key_free()
 \param keysize Size of DSA key
 \return return key identifier or NULL if key generation failed
 */
-libhsm_key_t *
+extern libhsm_key_t *
 hsm_generate_dsa_key(hsm_ctx_t *context,
                      const char *repository,
                      unsigned long keysize);
@@ -350,7 +350,7 @@ The returned key structure can be freed with libhsm_key_free()
 \param repository repository in where to create the key
 \return return key identifier or NULL if key generation failed
 */
-libhsm_key_t *
+extern libhsm_key_t *
 hsm_generate_gost_key(hsm_ctx_t *context,
                      const char *repository);
 
@@ -366,7 +366,7 @@ The returned key structure can be freed with libhsm_key_free()
 \param curve which curve to use
 \return return key identifier or NULL if key generation failed
 */
-libhsm_key_t *
+extern libhsm_key_t *
 hsm_generate_ecdsa_key(hsm_ctx_t *context,
                        const char *repository,
                        const char *curve);
@@ -381,7 +381,7 @@ needs to be freed.
 \param key Key pair to be removed
 \return 0 if successful, !0 if failed
 */
-int
+extern int
 hsm_remove_key(hsm_ctx_t *context, libhsm_key_t *key);
 
 
@@ -391,7 +391,7 @@ hsm_list_keys()
 \param key_list The array of keys to free
 \param count The number of keys in the array
 */
-void
+extern void
 libhsm_key_list_free(libhsm_key_t **key_list, size_t count);
 
 
@@ -403,7 +403,7 @@ The returned id is allocated data, and must be free()d by the caller
 \param key Key pair to get the ID from
 \return id of key pair
 */
-char *
+extern char *
 hsm_get_key_id(hsm_ctx_t *context,
                const libhsm_key_t *key);
 
@@ -417,7 +417,7 @@ With libhsm_key_info_free()
 \param key Key pair to get information about
 \return key information
 */
-libhsm_key_info_t *
+extern libhsm_key_info_t *
 hsm_get_key_info(hsm_ctx_t *context,
                  const libhsm_key_t *key);
 
@@ -426,7 +426,7 @@ hsm_get_key_info(hsm_ctx_t *context,
 
 \param key_info The structure to free
 */
-void
+extern void
 libhsm_key_info_free(libhsm_key_info_t *key_info);
 
 /*! Fill a buffer with random data from any attached HSM
@@ -437,7 +437,7 @@ libhsm_key_info_free(libhsm_key_info_t *key_info);
 \return 0 if successful, !0 if failed
 
 */
-int
+extern int
 hsm_random_buffer(hsm_ctx_t *ctx,
                   unsigned char *buffer,
                   unsigned long length);
@@ -448,7 +448,7 @@ hsm_random_buffer(hsm_ctx_t *ctx,
 \return 32-bit random number, or 0 if no HSM with a random generator is
                attached
 */
-uint32_t
+extern uint32_t
 hsm_random32(hsm_ctx_t *ctx);
 
 
@@ -457,7 +457,7 @@ hsm_random32(hsm_ctx_t *ctx);
 \return 64-bit random number, or 0 if no HSM with a random generator is
                attached
 */
-uint64_t
+extern uint64_t
 hsm_random64(hsm_ctx_t *ctx);
 
 
@@ -477,7 +477,7 @@ hsm_random64(hsm_ctx_t *ctx);
 \param config optional configuration
 \return 0 on success, -1 on error
 */
-int
+extern int
 hsm_attach(const char *repository,
            const char *token_name,
            const char *path,
@@ -489,7 +489,7 @@ hsm_attach(const char *repository,
 \param token_name The name of the token
 \return 1 if the token is attached, 0 if not found
 */
-int
+extern int
 hsm_token_attached(hsm_ctx_t *ctx,
                    const char *repository);
 
@@ -501,15 +501,15 @@ The returned message is allocated data, and must be free()d by the caller
 \return error message string
 */
 
-char *
+extern char *
 hsm_get_error(hsm_ctx_t *gctx);
 
 /* a few debug functions for applications */
-void hsm_print_session(hsm_session_t *session);
-void hsm_print_ctx(hsm_ctx_t *ctx);
-void hsm_print_key(hsm_ctx_t *ctx, libhsm_key_t *key);
-void hsm_print_error(hsm_ctx_t *ctx);
-void hsm_print_tokeninfo(hsm_ctx_t *ctx);
+extern void hsm_print_session(hsm_session_t *session);
+extern void hsm_print_ctx(hsm_ctx_t *ctx);
+extern void hsm_print_key(hsm_ctx_t *ctx, libhsm_key_t *key);
+extern void hsm_print_error(hsm_ctx_t *ctx);
+extern void hsm_print_tokeninfo(hsm_ctx_t *ctx);
 
 /* implementation of a key cache per context, needs changing see
  * OPENDNSSEC-799.

--- a/libhsm/src/lib/libhsmdns.h
+++ b/libhsm/src/lib/libhsmdns.h
@@ -50,7 +50,7 @@ typedef struct {
 /*!
  * Returns an allocated hsm_sign_params_t with some defaults
  */
-hsm_sign_params_t * hsm_sign_params_new(void);
+extern hsm_sign_params_t * hsm_sign_params_new(void);
 
 
 /*!
@@ -61,7 +61,7 @@ on it.
 
 \param params The signer parameters to free
 */
-void
+extern void
 hsm_sign_params_free(hsm_sign_params_t *params);
 
 
@@ -74,7 +74,7 @@ The returned ldns_rr structure can be freed with ldns_rr_free()
 \param key Key pair used to sign
 \return ldns_rr* Signed RRset
 */
-ldns_rr*
+extern ldns_rr*
 hsm_sign_rrset(hsm_ctx_t *ctx,
                const ldns_rr_list* rrset,
                const libhsm_key_t *key,
@@ -90,7 +90,7 @@ The returned ldns_rr structure can be freed with ldns_rr_free()
 \param sign_params the signing parameters (flags, algorithm, etc)
 \return ldns_rr*
 */
-ldns_rr*
+extern ldns_rr*
 hsm_get_dnskey(hsm_ctx_t *ctx,
                const libhsm_key_t *key,
                const hsm_sign_params_t *sign_params);
@@ -103,6 +103,6 @@ hsm_get_dnskey(hsm_ctx_t *ctx,
  * @param[out] keytag: the calculated keytag
  * return: non-zero in case of failure
  */
-int hsm_keytag(const char* loc, int alg, int ksk, uint16_t* keytag);
+extern int hsm_keytag(const char* loc, int alg, int ksk, uint16_t* keytag);
 
 #endif /* HSMDNS_H */

--- a/signer/src/adapter/adapi.h
+++ b/signer/src/adapter/adapi.h
@@ -46,7 +46,7 @@
  * \return ldns_rdf* origin
  *
  */
-ldns_rdf* adapi_get_origin(zone_type* zone);
+extern ldns_rdf* adapi_get_origin(zone_type* zone);
 
 /**
  * Get ttl.
@@ -54,7 +54,7 @@ ldns_rdf* adapi_get_origin(zone_type* zone);
  * \return uint32_t ttl
  *
  */
-uint32_t adapi_get_ttl(zone_type* zone);
+extern uint32_t adapi_get_ttl(zone_type* zone);
 
 /*
  * Do full zone transaction.
@@ -62,7 +62,7 @@ uint32_t adapi_get_ttl(zone_type* zone);
  * \param[in] more_coming more transactions are possible
  *
  */
-void adapi_trans_full(zone_type* zone, names_view_type view, unsigned more_coming);
+extern void adapi_trans_full(zone_type* zone, names_view_type view, unsigned more_coming);
 
 /*
  * Do incremental zone transaction.
@@ -70,7 +70,7 @@ void adapi_trans_full(zone_type* zone, names_view_type view, unsigned more_comin
  * \param[in] more_coming more transactions are possible
  *
  */
-void adapi_trans_diff(zone_type* zone, names_view_type view, unsigned more_coming);
+extern void adapi_trans_diff(zone_type* zone, names_view_type view, unsigned more_coming);
 
 /**
  * Add RR.
@@ -80,7 +80,7 @@ void adapi_trans_diff(zone_type* zone, names_view_type view, unsigned more_comin
  * \return ods_status status
  *
  */
-ods_status adapi_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int backup);
+extern ods_status adapi_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int backup);
 
 /**
  * Delete RR.
@@ -90,7 +90,7 @@ ods_status adapi_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int 
  * \return ods_status status
  *
  */
-ods_status adapi_del_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int backup);
+extern ods_status adapi_del_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int backup);
 
 /**
  * Print zonefile.
@@ -99,7 +99,7 @@ ods_status adapi_del_rr(zone_type* zone, names_view_type view, ldns_rr* rr, int 
  * \return ods_status status
  *
  */
-ods_status adapi_printzone(FILE* fd, zone_type* zone, names_view_type view);
+extern ods_status adapi_printzone(FILE* fd, zone_type* zone, names_view_type view);
 
 /**
  * Print ixfr.
@@ -108,6 +108,6 @@ ods_status adapi_printzone(FILE* fd, zone_type* zone, names_view_type view);
  * \return ods_status status
  *
  */
-ods_status adapi_printixfr(FILE* fd, zone_type* zone);
+extern ods_status adapi_printixfr(FILE* fd, zone_type* zone);
 
 #endif /* ADAPTER_ADAPI_H */

--- a/signer/src/adapter/adapter.h
+++ b/signer/src/adapter/adapter.h
@@ -71,7 +71,7 @@ struct adapter_struct {
  * \return adapter_type* created adapter
  *
  */
-adapter_type* adapter_create(const char* str, adapter_mode type, unsigned in);
+extern adapter_type* adapter_create(const char* str, adapter_mode type, unsigned in);
 
 /**
  * Load configuration.
@@ -79,7 +79,7 @@ adapter_type* adapter_create(const char* str, adapter_mode type, unsigned in);
  * \return ods_status status
  *
  */
-ods_status adapter_load_config(adapter_type* adapter);
+extern ods_status adapter_load_config(adapter_type* adapter);
 
 /**
  * Compare adapters.
@@ -88,7 +88,7 @@ ods_status adapter_load_config(adapter_type* adapter);
  * \return int 0 on equal, -1 if a1 < a2, 1 if a1 > a2
  *
  */
-int adapter_compare(adapter_type* a1, adapter_type* a2);
+extern int adapter_compare(adapter_type* a1, adapter_type* a2);
 
 /**
  * Read zone from input adapter.
@@ -96,7 +96,7 @@ int adapter_compare(adapter_type* a1, adapter_type* a2);
  * \return ods_status status
  *
  */
-ods_status adapter_read(zone_type* zone, names_view_type view);
+extern ods_status adapter_read(zone_type* zone, names_view_type view);
 
 /**
  * Write zone to output adapter.
@@ -104,13 +104,13 @@ ods_status adapter_read(zone_type* zone, names_view_type view);
  * \return ods_status status
  *
  */
-ods_status adapter_write(zone_type* zone);
+extern ods_status adapter_write(zone_type* zone);
 
 /**
  * Clean up adapter.
  * \param[in] adapter adapter to cleanup
  *
  */
-void adapter_cleanup(adapter_type* adapter);
+extern void adapter_cleanup(adapter_type* adapter);
 
 #endif /* ADAPTER_ADAPTER_H */

--- a/signer/src/adapter/addns.h
+++ b/signer/src/adapter/addns.h
@@ -71,14 +71,14 @@ struct dnsout_struct {
  * \return dnsin_type* DNS input adapter
  *
  */
-dnsin_type* dnsin_create(void);
+extern dnsin_type* dnsin_create(void);
 
 /**
  * Create DNS output adapter.
  * \return dnsout_type* DNS output adapter
  *
  */
-dnsout_type* dnsout_create(void);
+extern dnsout_type* dnsout_create(void);
 
 /**
  * Update DNS input adapter.
@@ -88,7 +88,7 @@ dnsout_type* dnsout_create(void);
  * \return ods_status status
  *
  */
-ods_status dnsin_update(dnsin_type** addns, const char* filename,
+extern ods_status dnsin_update(dnsin_type** addns, const char* filename,
     time_t* last_mod);
 
 /**
@@ -99,7 +99,7 @@ ods_status dnsin_update(dnsin_type** addns, const char* filename,
  * \return ods_status status
  *
  */
-ods_status dnsout_update(dnsout_type** addns, const char* filename,
+extern ods_status dnsout_update(dnsout_type** addns, const char* filename,
     time_t* last_mod);
 
 /**
@@ -114,7 +114,7 @@ ods_status dnsout_update(dnsout_type** addns, const char* filename,
  * \return ldns_rr* RR
  *
  */
-ldns_rr* addns_read_rr(FILE* fd, char* line, ldns_rdf** orig, ldns_rdf** prev,
+extern ldns_rr* addns_read_rr(FILE* fd, char* line, ldns_rdf** orig, ldns_rdf** prev,
     uint32_t* ttl, ldns_status* status, unsigned int* l);
 
 
@@ -124,7 +124,7 @@ ldns_rr* addns_read_rr(FILE* fd, char* line, ldns_rdf** orig, ldns_rdf** prev,
  * \return ods_status status
  *
  */
-ods_status addns_read(zone_type* zone, names_view_type view);
+extern ods_status addns_read(zone_type* zone, names_view_type view);
 
 /**
  * Write zone to DNS output adapter.
@@ -132,7 +132,7 @@ ods_status addns_read(zone_type* zone, names_view_type view);
  * \return ods_status status
  *
  */
-ods_status addns_write(zone_type* zone, names_view_type view);
+extern ods_status addns_write(zone_type* zone, names_view_type view);
 
 /**
  * Clean up DNS input adapter.

--- a/signer/src/adapter/adfile.h
+++ b/signer/src/adapter/adfile.h
@@ -51,7 +51,7 @@
  * \return ods_status status
  *
  */
-ods_status adfile_read(zone_type* zone, names_view_type view);
+extern ods_status adfile_read(zone_type* zone, names_view_type view);
 
 /**
  * Write zone to output file adapter.
@@ -60,6 +60,6 @@ ods_status adfile_read(zone_type* zone, names_view_type view);
  * \return ods_status status
  *
  */
-ods_status adfile_write(zone_type* zone, names_view_type view, const char* filename);
+extern ods_status adfile_write(zone_type* zone, names_view_type view, const char* filename);
 
 #endif /* ADAPTER_ADFILE_H */

--- a/signer/src/adapter/adutil.h
+++ b/signer/src/adapter/adutil.h
@@ -49,7 +49,7 @@
  * \return int number of characters read
  *
  */
-int adutil_readline_frm_file(FILE* fd, char* line, unsigned int* l,
+extern int adutil_readline_frm_file(FILE* fd, char* line, unsigned int* l,
     int keep_comments);
 
 /*
@@ -58,7 +58,7 @@ int adutil_readline_frm_file(FILE* fd, char* line, unsigned int* l,
  * \param[out] line_len maintain line length
  *
  */
-void adutil_rtrim_line(char* line, int* line_len);
+extern void adutil_rtrim_line(char* line, int* line_len);
 
 /**
  * Check for white space.
@@ -66,7 +66,7 @@ void adutil_rtrim_line(char* line, int* line_len);
  * \param[in] line_len line length
  *
  */
-int adutil_whitespace_line(char* line, int line_len);
+extern int adutil_whitespace_line(char* line, int line_len);
 
 /**
  * Produce an AXFR or IXFR file, the file is immediately deleted, but an

--- a/signer/src/daemon/dnshandler.h
+++ b/signer/src/daemon/dnshandler.h
@@ -68,7 +68,7 @@ struct dnshandler_struct {
  * \return dnshandler_type* created dns handler
  *
  */
-dnshandler_type* dnshandler_create(listener_type* interfaces);
+extern dnshandler_type* dnshandler_create(listener_type* interfaces);
 
 /**
  * Start dns handler listener.
@@ -76,21 +76,21 @@ dnshandler_type* dnshandler_create(listener_type* interfaces);
  * \return ods_status status
  *
  */
-ods_status dnshandler_listen(dnshandler_type* dnshandler);
+extern ods_status dnshandler_listen(dnshandler_type* dnshandler);
 
 /**
  * Start dns handler.
  * \param[in] dnshandler_type* dns handler
  *
  */
-void dnshandler_start(dnshandler_type* dnshandler);
+extern void dnshandler_start(dnshandler_type* dnshandler);
 
 /**
  * Signal dns handler.
  * \param[in] dnshandler_type* dns handler
  *
  */
-void dnshandler_signal(dnshandler_type* dnshandler);
+extern void dnshandler_signal(dnshandler_type* dnshandler);
 
 /**
  * Forward notify to zone transfer handler.
@@ -99,7 +99,7 @@ void dnshandler_signal(dnshandler_type* dnshandler);
  * \param[in] len packet length
  *
  */
-void dnshandler_fwd_notify(dnshandler_type* dnshandler,
+extern void dnshandler_fwd_notify(dnshandler_type* dnshandler,
     uint8_t* pkt, size_t len);
 
 /**
@@ -107,6 +107,6 @@ void dnshandler_fwd_notify(dnshandler_type* dnshandler,
  * \param[in] dnshandler_type* dns handler
  *
  */
-void dnshandler_cleanup(dnshandler_type* dnshandler);
+extern void dnshandler_cleanup(dnshandler_type* dnshandler);
 
 #endif /* DAEMON_DNSHANDLER_H */

--- a/signer/src/daemon/engine.h
+++ b/signer/src/daemon/engine.h
@@ -73,22 +73,22 @@ struct engine_struct {
 };
 
 engine_type* engine_create(void);
-ods_status engine_setup_preconfig(engine_type* engine, const char* cfgfile);
-ods_status engine_setup_config(engine_type* engine, const char* cfgfile, int cmdline_verbosity, int daemonize);
-ods_status engine_setup_initialize(engine_type* engine, int* fdptr);
-ods_status engine_setup_signals(engine_type* engine);
-ods_status engine_setup_workstart(engine_type* engine);
-ods_status engine_setup_netwstart(engine_type* engine);
-ods_status engine_setup_finish(engine_type* engine, int fd);
-int engine_start(engine_type*);
-ods_status engine_setup_signals(engine_type* engine);
+extern ods_status engine_setup_preconfig(engine_type* engine, const char* cfgfile);
+extern ods_status engine_setup_config(engine_type* engine, const char* cfgfile, int cmdline_verbosity, int daemonize);
+extern ods_status engine_setup_initialize(engine_type* engine, int* fdptr);
+extern ods_status engine_setup_signals(engine_type* engine);
+extern ods_status engine_setup_workstart(engine_type* engine);
+extern ods_status engine_setup_netwstart(engine_type* engine);
+extern ods_status engine_setup_finish(engine_type* engine, int fd);
+extern int engine_start(engine_type*);
+extern ods_status engine_setup_signals(engine_type* engine);
 
 /**
  * Wake up workers.
  * \param[in] engine engine
  *
  */
-void engine_wakeup_workers(engine_type* engine);
+extern void engine_wakeup_workers(engine_type* engine);
 
 /**
  * Update zones.
@@ -96,15 +96,15 @@ void engine_wakeup_workers(engine_type* engine);
  * \param[in] zl_changed whether the zonelist has changed or not
  *
  */
-void engine_update_zones(engine_type* engine, ods_status zl_changed);
+extern void engine_update_zones(engine_type* engine, ods_status zl_changed);
 
 /**
  * Clean up engine.
  * \param[in] engine engine
  *
  */
-void engine_cleanup(engine_type* engine);
+extern void engine_cleanup(engine_type* engine);
 
-listener_type* create_listener(struct engineconfig_listener* list);
+extern listener_type* create_listener(struct engineconfig_listener* list);
 
 #endif /* DAEMON_ENGINE_H */

--- a/signer/src/daemon/signercommands.h
+++ b/signer/src/daemon/signercommands.h
@@ -35,7 +35,7 @@
 #include "config.h"
 #include "cmdhandler.h"
 
-struct cmd_func_block** signercommands;
+extern struct cmd_func_block** signercommands;
 
 extern engine_type* getglobalcontext(cmdhandler_ctx_type*);
 extern void command_stop(engine_type*);

--- a/signer/src/daemon/signertasks.h
+++ b/signer/src/daemon/signertasks.h
@@ -44,14 +44,14 @@ struct worker_context {
     names_view_type view;
 };
 
-void drudge(worker_type* worker);
+extern void drudge(worker_type* worker);
 
-time_t do_readsignconf(task_type* task, const char* zonename, void* zonearg, void *contextarg);
-time_t do_forcereadsignconf(task_type* task, const char* zonename, void* zonearg, void *contextarg);
-time_t do_signzone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
-time_t do_readzone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
-time_t do_forcereadzone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
-void do_purgezone(zone_type* zone);
-time_t do_writezone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
+extern time_t do_readsignconf(task_type* task, const char* zonename, void* zonearg, void *contextarg);
+extern time_t do_forcereadsignconf(task_type* task, const char* zonename, void* zonearg, void *contextarg);
+extern time_t do_signzone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
+extern time_t do_readzone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
+extern time_t do_forcereadzone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
+extern void do_purgezone(zone_type* zone);
+extern time_t do_writezone(task_type* task, const char* zonename, void* zonearg, void *contextarg);
 
 #endif /* SIGNERTASKS_H */

--- a/signer/src/daemon/xfrhandler.h
+++ b/signer/src/daemon/xfrhandler.h
@@ -79,14 +79,14 @@ struct xfrhandler_struct {
  * \return xfrhandler_type* created zoned transfer handler
  *
  */
-xfrhandler_type* xfrhandler_create(void);
+extern xfrhandler_type* xfrhandler_create(void);
 
 /**
  * Start zone transfer handler.
  * \param[in] xfrhandler_type* zone transfer handler
  *
  */
-void xfrhandler_start(xfrhandler_type* xfrhandler);
+extern void xfrhandler_start(xfrhandler_type* xfrhandler);
 
 /**
  * Get current time from the zone transfer handler.
@@ -94,20 +94,20 @@ void xfrhandler_start(xfrhandler_type* xfrhandler);
  * \return time_t current time
  *
  */
-time_t xfrhandler_time(xfrhandler_type* xfrhandler);
+extern time_t xfrhandler_time(xfrhandler_type* xfrhandler);
 
 /**
  * Signal zone transfer handler.
  * \param[in] xfrhandler_type* zone transfer handler
  *
  */
-void xfrhandler_signal(xfrhandler_type* xfrhandler);
+extern void xfrhandler_signal(xfrhandler_type* xfrhandler);
 
 /**
  * Cleanup zone transfer handler.
  * \param[in] xfrhandler_type* zone transfer handler
  *
  */
-void xfrhandler_cleanup(xfrhandler_type* xfrhandler);
+extern void xfrhandler_cleanup(xfrhandler_type* xfrhandler);
 
 #endif /* DAEMON_XFRHANDLER_H */

--- a/signer/src/hsm.h
+++ b/signer/src/hsm.h
@@ -51,7 +51,7 @@
  * \return ods_status status
  *
  */
-ods_status lhsm_get_key(hsm_ctx_t* ctx, ldns_rdf* owner, key_type* key_id, int skip_hsm_access);
+extern ods_status lhsm_get_key(hsm_ctx_t* ctx, ldns_rdf* owner, key_type* key_id, int skip_hsm_access);
 
 /**
  * Get RRSIG from one of the HSMs, given a RRset and a key.
@@ -64,7 +64,7 @@ ods_status lhsm_get_key(hsm_ctx_t* ctx, ldns_rdf* owner, key_type* key_id, int s
  * \return ldns_rr* RRSIG record
  *
  */
-ldns_rr* lhsm_sign(hsm_ctx_t* ctx, ldns_rr_list* rrset, key_type* key_id,
+extern ldns_rr* lhsm_sign(hsm_ctx_t* ctx, ldns_rr_list* rrset, key_type* key_id,
     time_t inception, time_t expiration);
 
 #endif /* SHARED_HSM_H */

--- a/signer/src/parser/addnsparser.h
+++ b/signer/src/parser/addnsparser.h
@@ -46,7 +46,7 @@
  * \return acl_type* ACL
  *
  */
-acl_type* parse_addns_request_xfr(const char* filename, tsig_type* tsig);
+extern acl_type* parse_addns_request_xfr(const char* filename, tsig_type* tsig);
 
 /**
  * Parse <AllowNotify/>.
@@ -56,7 +56,7 @@ acl_type* parse_addns_request_xfr(const char* filename, tsig_type* tsig);
  * \return acl_type* ACL
  *
  */
-acl_type* parse_addns_allow_notify(const char* filename, tsig_type* tsig);
+extern acl_type* parse_addns_allow_notify(const char* filename, tsig_type* tsig);
 
 /**
  * Parse <ProvideTransfer/>.
@@ -66,7 +66,7 @@ acl_type* parse_addns_allow_notify(const char* filename, tsig_type* tsig);
  * \return acl_type* ACL
  *
  */
-acl_type* parse_addns_provide_xfr(const char* filename, tsig_type* tsig);
+extern acl_type* parse_addns_provide_xfr(const char* filename, tsig_type* tsig);
 
 /**
  * Parse <Notify/>.
@@ -76,7 +76,7 @@ acl_type* parse_addns_provide_xfr(const char* filename, tsig_type* tsig);
  * \return acl_type* ACL
  *
  */
-acl_type* parse_addns_do_notify(const char* filename, tsig_type* tsig);
+extern acl_type* parse_addns_do_notify(const char* filename, tsig_type* tsig);
 
 /**
  * Parse <TSIG/>.
@@ -85,6 +85,6 @@ acl_type* parse_addns_do_notify(const char* filename, tsig_type* tsig);
  * \return tsig_type* TSIG
  *
  */
-tsig_type* parse_addns_tsig(const char* filename);
+extern tsig_type* parse_addns_tsig(const char* filename);
 
 #endif /* PARSER_ADDNSPARSER_H */

--- a/signer/src/parser/signconfparser.h
+++ b/signer/src/parser/signconfparser.h
@@ -47,7 +47,7 @@
  * \return keylist_type* key list
  *
  */
-keylist_type* parse_sc_keys(void* sc, const char* cfgfile);
+extern keylist_type* parse_sc_keys(void* sc, const char* cfgfile);
 
 /**
  * Parse elements from the configuration file.
@@ -55,19 +55,19 @@ keylist_type* parse_sc_keys(void* sc, const char* cfgfile);
  * \return duration_type* duration
  *
  */
-duration_type* parse_sc_sig_resign_interval(const char* cfgfile);
-duration_type* parse_sc_sig_refresh_interval(const char* cfgfile);
-duration_type* parse_sc_sig_validity_default(const char* cfgfile);
-duration_type* parse_sc_sig_validity_denial(const char* cfgfile);
-duration_type* parse_sc_sig_validity_keyset(const char* cfgfile);
-duration_type* parse_sc_sig_jitter(const char* cfgfile);
-duration_type* parse_sc_sig_inception_offset(const char* cfgfile);
-duration_type* parse_sc_dnskey_ttl(const char* cfgfile);
-const char** parse_sc_dnskey_sigrrs(const char* cfgfile);
-duration_type* parse_sc_nsec3param_ttl(const char* cfgfile);
-duration_type* parse_sc_soa_ttl(const char* cfgfile);
-duration_type* parse_sc_soa_min(const char* cfgfile);
-duration_type* parse_sc_max_zone_ttl(const char* cfgfile);
+extern duration_type* parse_sc_sig_resign_interval(const char* cfgfile);
+extern duration_type* parse_sc_sig_refresh_interval(const char* cfgfile);
+extern duration_type* parse_sc_sig_validity_default(const char* cfgfile);
+extern duration_type* parse_sc_sig_validity_denial(const char* cfgfile);
+extern duration_type* parse_sc_sig_validity_keyset(const char* cfgfile);
+extern duration_type* parse_sc_sig_jitter(const char* cfgfile);
+extern duration_type* parse_sc_sig_inception_offset(const char* cfgfile);
+extern duration_type* parse_sc_dnskey_ttl(const char* cfgfile);
+extern const char** parse_sc_dnskey_sigrrs(const char* cfgfile);
+extern duration_type* parse_sc_nsec3param_ttl(const char* cfgfile);
+extern duration_type* parse_sc_soa_ttl(const char* cfgfile);
+extern duration_type* parse_sc_soa_min(const char* cfgfile);
+extern duration_type* parse_sc_max_zone_ttl(const char* cfgfile);
 
 /**
  * Parse elements from the configuration file.
@@ -75,7 +75,7 @@ duration_type* parse_sc_max_zone_ttl(const char* cfgfile);
  * \return ldns_rr_type rr type
  *
  */
-ldns_rr_type parse_sc_nsec_type(const char* cfgfile);
+extern ldns_rr_type parse_sc_nsec_type(const char* cfgfile);
 
 /**
  * Parse elements from the configuration file.
@@ -83,8 +83,8 @@ ldns_rr_type parse_sc_nsec_type(const char* cfgfile);
  * \return uint32_t integer
  *
  */
-uint32_t parse_sc_nsec3_algorithm(const char* cfgfile);
-uint32_t parse_sc_nsec3_iterations(const char* cfgfile);
+extern uint32_t parse_sc_nsec3_algorithm(const char* cfgfile);
+extern uint32_t parse_sc_nsec3_iterations(const char* cfgfile);
 
 /**
  * Parse elements from the configuration file.
@@ -92,14 +92,14 @@ uint32_t parse_sc_nsec3_iterations(const char* cfgfile);
  * \return int integer
  *
  */
-int parse_sc_nsec3_optout(const char* cfgfile);
+extern int parse_sc_nsec3_optout(const char* cfgfile);
 
 /**
  * Parse elements from the configuration file.
  * \param[in] cfgfile the configuration file name.
  * \return boolean
  */
-int parse_sc_passthrough(const char* cfgfile);
+extern int parse_sc_passthrough(const char* cfgfile);
 
 /**
  * Parse elements from the configuration file.
@@ -107,7 +107,7 @@ int parse_sc_passthrough(const char* cfgfile);
  * \return const char* string
  *
  */
-const char* parse_sc_soa_serial(const char* cfgfile);
-const char* parse_sc_nsec3_salt(const char* cfgfile);
+extern const char* parse_sc_soa_serial(const char* cfgfile);
+extern const char* parse_sc_nsec3_salt(const char* cfgfile);
 
 #endif /* PARSER_SIGNCONFPARSER_H */

--- a/signer/src/parser/zonelistparser.h
+++ b/signer/src/parser/zonelistparser.h
@@ -45,6 +45,6 @@
  * \return ods_status status
  *
  */
-ods_status parse_zonelist_zones(void* zlist, const char* zlfile);
+extern ods_status parse_zonelist_zones(void* zlist, const char* zlfile);
 
 #endif /* PARSER_ZONELISTPARSER_H */

--- a/signer/src/signer/keys.h
+++ b/signer/src/signer/keys.h
@@ -75,7 +75,7 @@ struct keylist_struct {
  * \return keylist_type* key list
  *
  */
-keylist_type* keylist_create(signconf_type* sc);
+extern keylist_type* keylist_create(signconf_type* sc);
 
 /**
  * Lookup a key in the key list by locator.
@@ -84,7 +84,7 @@ keylist_type* keylist_create(signconf_type* sc);
  * \return key_type* key if it exists, NULL otherwise
  *
  */
-key_type* keylist_lookup_by_locator(keylist_type* kl, const char* locator);
+extern key_type* keylist_lookup_by_locator(keylist_type* kl, const char* locator);
 
 /**
  * Push a key to the keylist.
@@ -98,7 +98,7 @@ key_type* keylist_lookup_by_locator(keylist_type* kl, const char* locator);
  * \return key_type* key
  *
  */
-key_type* keylist_push(keylist_type* kl, const char* locator, const char* resourcerecord,
+extern key_type* keylist_push(keylist_type* kl, const char* locator, const char* resourcerecord,
     uint8_t algorithm, uint32_t flags, int publish, int ksk, int zsk);
 
 /**
@@ -107,13 +107,13 @@ key_type* keylist_push(keylist_type* kl, const char* locator, const char* resour
  * \param[in] name zone name
  *
  */
-void keylist_log(keylist_type* kl, const char* name);
+extern void keylist_log(keylist_type* kl, const char* name);
 
 /**
  * Clean up key list.
  * \param[in] kl key list to clean up
  *
  */
-void keylist_cleanup(keylist_type* kl);
+extern void keylist_cleanup(keylist_type* kl);
 
 #endif /* SIGNER_KEYS_H */

--- a/signer/src/signer/nsec3params.h
+++ b/signer/src/signer/nsec3params.h
@@ -62,7 +62,7 @@ struct nsec3params_struct {
  * \return ods_status status
  *
  */
-ods_status nsec3params_create_salt(const char* salt_str, uint8_t* salt_len,
+extern ods_status nsec3params_create_salt(const char* salt_str, uint8_t* salt_len,
     uint8_t** salt);
 
 /**
@@ -75,7 +75,7 @@ ods_status nsec3params_create_salt(const char* salt_str, uint8_t* salt_len,
  * \return nsec3params_type* the created nsec3params
  *
  */
-nsec3params_type* nsec3params_create(void* sc, uint8_t algo, uint8_t flags,
+extern nsec3params_type* nsec3params_create(void* sc, uint8_t algo, uint8_t flags,
     uint16_t iter, const char* salt);
 
 /**
@@ -83,6 +83,6 @@ nsec3params_type* nsec3params_create(void* sc, uint8_t algo, uint8_t flags,
  * \param[in] nsec3params the nsec3param to be deleted
  *
  */
-void nsec3params_cleanup(nsec3params_type* nsec3params);
+extern void nsec3params_cleanup(nsec3params_type* nsec3params);
 
 #endif /* SIGNER_NSEC3PARAMS_H */

--- a/signer/src/signer/signconf.h
+++ b/signer/src/signer/signconf.h
@@ -77,7 +77,7 @@ struct signconf_struct {
  * \return signconf_type* signer configuration
  *
  */
-signconf_type* signconf_create(void);
+extern signconf_type* signconf_create(void);
 
 /**
  * Update signer configuration.
@@ -87,7 +87,7 @@ signconf_type* signconf_create(void);
  * \return ods_status status
  *
  */
-ods_status signconf_update(signconf_type** signconf, const char* scfile,
+extern ods_status signconf_update(signconf_type** signconf, const char* scfile,
     time_t last_modified);
 
 /**
@@ -96,7 +96,7 @@ ods_status signconf_update(signconf_type** signconf, const char* scfile,
  * \return ods_status status
  *
  */
-ods_status signconf_check(signconf_type* signconf);
+extern ods_status signconf_check(signconf_type* signconf);
 
 /**
  * Compare signer configurations on denial of existence material.
@@ -105,7 +105,7 @@ ods_status signconf_check(signconf_type* signconf);
  * \return task_id what task needs to be scheduled
  *
  */
-task_id signconf_compare_denial(signconf_type* a, signconf_type* b);
+extern task_id signconf_compare_denial(signconf_type* a, signconf_type* b);
 
 /**
  * Log signer configuration.
@@ -113,13 +113,13 @@ task_id signconf_compare_denial(signconf_type* a, signconf_type* b);
  * \param[in] name zone name
  *
  */
-void signconf_log(signconf_type* sc, const char* name);
+extern void signconf_log(signconf_type* sc, const char* name);
 
 /**
  * Clean up signer configuration.
  * \param[in] sc signconf to cleanup
  *
  */
-void signconf_cleanup(signconf_type* sc);
+extern void signconf_cleanup(signconf_type* sc);
 
 #endif /* SIGNER_SIGNCONF_H */

--- a/signer/src/signer/stats.h
+++ b/signer/src/signer/stats.h
@@ -67,7 +67,7 @@ struct stats_struct {
  * \return the initialized stats;
  *
  */
-stats_type* stats_create(void);
+extern stats_type* stats_create(void);
 
 /**
  * Log statistics.
@@ -77,7 +77,7 @@ stats_type* stats_create(void);
  * \param[in] nsec_type NSEC or NSEC3
  *
  */
-void stats_log(stats_type* stats, const char* name, uint32_t serial,
+extern void stats_log(stats_type* stats, const char* name, uint32_t serial,
     ldns_rr_type nsec_type);
 
 /**
@@ -85,13 +85,13 @@ void stats_log(stats_type* stats, const char* name, uint32_t serial,
  * \param[in] stats statistics to be cleared
  *
  */
-void stats_clear(stats_type* stats);
+extern void stats_clear(stats_type* stats);
 
 /**
  * Clean up statistics.
  * \param[in] stats statistics to be deleted
  *
  */
-void stats_cleanup(stats_type* stats);
+extern void stats_cleanup(stats_type* stats);
 
 #endif /* SIGNER_STATS_H */

--- a/signer/src/signer/tools.h
+++ b/signer/src/signer/tools.h
@@ -38,7 +38,7 @@
  * \return ods_status status
  *
  */
-ods_status tools_signconf(zone_type* zone);
+extern ods_status tools_signconf(zone_type* zone);
 
 /**
  * Read zone from input adapter.
@@ -46,7 +46,7 @@ ods_status tools_signconf(zone_type* zone);
  * \return ods_status status
  *
  */
-ods_status tools_input(zone_type* zone);
+extern ods_status tools_input(zone_type* zone);
 
 /**
  * Write zone to output adapter.
@@ -55,6 +55,6 @@ ods_status tools_input(zone_type* zone);
  * \return ods_status status
  *
  */
-ods_status tools_output(zone_type* zone, engine_type* engine);
+extern ods_status tools_output(zone_type* zone, engine_type* engine);
 
 #endif /* SIGNER_TOOLS_H */

--- a/signer/src/signer/zone.h
+++ b/signer/src/signer/zone.h
@@ -119,7 +119,7 @@ struct zone_struct {
  * \return zone_type* zone
  *
  */
-zone_type* zone_create(char* name, ldns_rr_class klass);
+extern zone_type* zone_create(char* name, ldns_rr_class klass);
 
 /**
  * Load signer configuration for zone.
@@ -131,7 +131,7 @@ zone_type* zone_create(char* name, ldns_rr_class klass);
  *         other: signer configuration not loaded, error occurred
  *
  */
-ods_status zone_load_signconf(zone_type* zone, signconf_type** new_signconf);
+extern ods_status zone_load_signconf(zone_type* zone, signconf_type** new_signconf);
 
 /**
  * Reschedule task for zone.
@@ -141,7 +141,7 @@ ods_status zone_load_signconf(zone_type* zone, signconf_type** new_signconf);
  * \return ods_status status
  *
  */
-ods_status zone_reschedule_task(zone_type* zone, schedule_type* taskq,
+extern ods_status zone_reschedule_task(zone_type* zone, schedule_type* taskq,
     task_id what);
 
 /**
@@ -150,7 +150,7 @@ ods_status zone_reschedule_task(zone_type* zone, schedule_type* taskq,
  * \return ods_status status
  *
  */
-ods_status zone_publish_dnskeys(zone_type* zone, names_view_type view, int skip_hsm_access);
+extern ods_status zone_publish_dnskeys(zone_type* zone, names_view_type view, int skip_hsm_access);
 
 /**
  * Publish the NSEC3 parameters as indicated by the signer configuration.
@@ -158,7 +158,7 @@ ods_status zone_publish_dnskeys(zone_type* zone, names_view_type view, int skip_
  * \return ods_status status
  *
  */
-ods_status zone_publish_nsec3param(zone_type* zone, names_view_type view);
+extern ods_status zone_publish_nsec3param(zone_type* zone, names_view_type view);
 
 /**
  * Prepare keys for signing.
@@ -166,7 +166,7 @@ ods_status zone_publish_nsec3param(zone_type* zone, names_view_type view);
  * \return ods_status status
  *
  */
-ods_status zone_prepare_keys(zone_type* zone);
+extern ods_status zone_prepare_keys(zone_type* zone);
 
 /**
  * Update serial.
@@ -174,7 +174,7 @@ ods_status zone_prepare_keys(zone_type* zone);
  * \return ods_status status
  *
  */
-ods_status zone_update_serial(zone_type* zone, names_view_type view);
+extern ods_status zone_update_serial(zone_type* zone, names_view_type view);
 
 /**
  * Lookup RRset.
@@ -184,7 +184,7 @@ ods_status zone_update_serial(zone_type* zone, names_view_type view);
  * \return rrset_type* RRset, if found
  *
  */
-ldns_rr* zone_lookup_apex_rrset(names_view_type view, ldns_rr_type type,ldns_rr*);
+extern ldns_rr* zone_lookup_apex_rrset(names_view_type view, ldns_rr_type type,ldns_rr*);
 
 /**
  * Add RR.
@@ -197,7 +197,7 @@ ldns_rr* zone_lookup_apex_rrset(names_view_type view, ldns_rr_type type,ldns_rr*
  *         other: rr not added to zone, error occurred
  *
  */
-ods_status zone_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr);
+extern ods_status zone_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr);
 
 /**
  * Delete RR.
@@ -210,13 +210,13 @@ ods_status zone_add_rr(zone_type* zone, names_view_type view, ldns_rr* rr);
  *         other: rr not removed from zone, error occurred
  *
  */
-ods_status zone_del_rr(zone_type* zone, names_view_type view, ldns_rr* rr);
+extern ods_status zone_del_rr(zone_type* zone, names_view_type view, ldns_rr* rr);
 
 /**
  * Remove all NSEC3PARAM RRs from the zone
  * \return ODS_STATUS_UNCHANGED or ODS_STATUS_OK
  */ 
-ods_status zone_del_nsec3params(zone_type* zone, names_view_type view);
+extern ods_status zone_del_nsec3params(zone_type* zone, names_view_type view);
 
 /**
  * Merge zones. Values that are merged:
@@ -228,14 +228,14 @@ ods_status zone_del_nsec3params(zone_type* zone, names_view_type view);
  * \param[in] z2 zone with new values
  *
  */
-void zone_merge(zone_type* z1, zone_type* z2);
+extern void zone_merge(zone_type* z1, zone_type* z2);
 
 /**
  * Clean up zone.
  * \param[in] zone zone
  *
  */
-void zone_cleanup(zone_type* zone);
+extern void zone_cleanup(zone_type* zone);
 
 /**
  * Mark the zone ready to be used.
@@ -243,7 +243,7 @@ void zone_cleanup(zone_type* zone);
  * \param[in] zone zone
  *
  */
-void zone_start(zone_type* zone);
+extern void zone_start(zone_type* zone);
 
 /**
  * recover from old-style backup file format.
@@ -251,7 +251,7 @@ void zone_start(zone_type* zone);
  * @param view the input view of the zone
  * @return returns whether the recvering was successfull
  */
-ods_status
+extern ods_status
 zone_recover(zone_type* zone);
 
 #endif /* SIGNER_ZONE_H */

--- a/signer/src/signer/zonelist.h
+++ b/signer/src/signer/zonelist.h
@@ -58,7 +58,7 @@ struct zonelist_struct {
  * \return zonelist_type* created zone list
  *
  */
-zonelist_type* zonelist_create(void);
+extern zonelist_type* zonelist_create(void);
 
 /**
  * Lookup zone by name and class.
@@ -68,7 +68,7 @@ zonelist_type* zonelist_create(void);
  * \return zone_type* found zone
  *
  */
-zone_type* zonelist_lookup_zone_by_name(zonelist_type* zonelist,
+extern zone_type* zonelist_lookup_zone_by_name(zonelist_type* zonelist,
     const char* name, ldns_rr_class klass);
 
 /**
@@ -79,7 +79,7 @@ zone_type* zonelist_lookup_zone_by_name(zonelist_type* zonelist,
  * \return zone_type* found zone
  *
  */
-zone_type* zonelist_lookup_zone_by_dname(zonelist_type* zonelist,
+extern zone_type* zonelist_lookup_zone_by_dname(zonelist_type* zonelist,
     ldns_rdf* dname, ldns_rr_class klass);
 
 /**
@@ -89,7 +89,7 @@ zone_type* zonelist_lookup_zone_by_dname(zonelist_type* zonelist,
  * \return zone_type* added zone
  *
  */
-zone_type* zonelist_add_zone(zonelist_type* zl, zone_type* zone);
+extern zone_type* zonelist_add_zone(zonelist_type* zl, zone_type* zone);
 
 /**
  * Delete zone.
@@ -97,7 +97,7 @@ zone_type* zonelist_add_zone(zonelist_type* zl, zone_type* zone);
  * \param[in] zone zone
  *
  */
-void zonelist_del_zone(zonelist_type* zlist, zone_type* zone);
+extern void zonelist_del_zone(zonelist_type* zlist, zone_type* zone);
 
 /**
  * Update zonelist.
@@ -106,21 +106,21 @@ void zonelist_del_zone(zonelist_type* zlist, zone_type* zone);
  * \return ods_status status
  *
  */
-ods_status zonelist_update(zonelist_type* zl, const char* zlfile);
+extern ods_status zonelist_update(zonelist_type* zl, const char* zlfile);
 
 /**
  * Clean up zone list.
  * \param[in] zl zone list
  *
  */
-void zonelist_cleanup(zonelist_type* zl);
+extern void zonelist_cleanup(zonelist_type* zl);
 
 /**
  * Free zone list.
  * \param[in] zl zone list
  *
  */
-void zonelist_free(zonelist_type* zl);
+extern void zonelist_free(zonelist_type* zl);
 
 /**
  * Obtain a certain view from for the named zone. 

--- a/signer/src/wire/acl.h
+++ b/signer/src/wire/acl.h
@@ -81,7 +81,7 @@ struct acl_struct {
  * \return acl_type* ACL
  *
  */
-acl_type* acl_create(char* address,
+extern acl_type* acl_create(char* address,
     char* port, char* tsig_name, tsig_type* tsig);
 
 /**
@@ -92,7 +92,7 @@ acl_type* acl_create(char* address,
  * \return acl_type* ACL that matches
  *
  */
-acl_type* acl_find(acl_type* acl, struct sockaddr_storage* addr,
+extern acl_type* acl_find(acl_type* acl, struct sockaddr_storage* addr,
     tsig_rr_type* tsig);
 
 /**
@@ -101,7 +101,7 @@ acl_type* acl_find(acl_type* acl, struct sockaddr_storage* addr,
  * \return int address family
  *
  */
-int acl_parse_family(const char* a);
+extern int acl_parse_family(const char* a);
 
 /**
  * Address storage to IP string.
@@ -111,7 +111,7 @@ int acl_parse_family(const char* a);
  * \return int 0 if failed, 1 otherwise
  *
  */
-int addr2ip(struct sockaddr_storage addr, char* ip, size_t len);
+extern int addr2ip(struct sockaddr_storage addr, char* ip, size_t len);
 
 /**
  * Clean up ACL.
@@ -119,6 +119,6 @@ int addr2ip(struct sockaddr_storage addr, char* ip, size_t len);
  * \param[in] allocator memory allocator
  *
  */
-void acl_cleanup(acl_type* acl);
+extern void acl_cleanup(acl_type* acl);
 
 #endif /* WIRE_ACL_H */

--- a/signer/src/wire/axfr.h
+++ b/signer/src/wire/axfr.h
@@ -49,7 +49,7 @@
  * \return query_state state of the query
  *
  */
-query_state soa_request(query_type* q, engine_type* engine);
+extern query_state soa_request(query_type* q, engine_type* engine);
 
 /**
  * Do AXFR.
@@ -59,7 +59,7 @@ query_state soa_request(query_type* q, engine_type* engine);
  * \return query_state state of the query
  *
  */
-query_state axfr(query_type* q, engine_type* engine, int fallback);
+extern query_state axfr(query_type* q, engine_type* engine, int fallback);
 
 /**
  * Do IXFR.
@@ -68,6 +68,6 @@ query_state axfr(query_type* q, engine_type* engine, int fallback);
  * \return query_state state of the query
  *
  */
-query_state ixfr(query_type* q, engine_type* engine);
+extern query_state ixfr(query_type* q, engine_type* engine);
 
 #endif /* WIRE_AXFR_H */

--- a/signer/src/wire/buffer.h
+++ b/signer/src/wire/buffer.h
@@ -124,7 +124,7 @@ struct buffer_struct {
  * \return buffer_type* buffer
  *
  */
-buffer_type* buffer_create(size_t capacity);
+extern buffer_type* buffer_create(size_t capacity);
 
 /**
  * Clear the buffer and make it ready for writing.
@@ -132,7 +132,7 @@ buffer_type* buffer_create(size_t capacity);
  * \param[in] buffer buffer
  *
  */
-void buffer_clear(buffer_type* buffer);
+extern void buffer_clear(buffer_type* buffer);
 
 /**
  * Flip the buffer and make it ready for reading.
@@ -150,7 +150,7 @@ void buffer_flip(buffer_type* buffer);
  * \return size_t position
  *
  */
-size_t buffer_position(buffer_type* buffer);
+extern size_t buffer_position(buffer_type* buffer);
 
 /**
  * Set the buffer's position.
@@ -159,7 +159,7 @@ size_t buffer_position(buffer_type* buffer);
  * \param[in] pos position
  *
  */
-void buffer_set_position(buffer_type* buffer, size_t pos);
+extern void buffer_set_position(buffer_type* buffer, size_t pos);
 
 /**
  * Change the buffer's position.
@@ -169,7 +169,7 @@ void buffer_set_position(buffer_type* buffer, size_t pos);
  * \param[in] count number of bytes to skip
  *
  */
-void buffer_skip(buffer_type* buffer, ssize_t count);
+extern void buffer_skip(buffer_type* buffer, ssize_t count);
 
 /**
  * Change the buffer's position so that one dname is skipped.
@@ -178,7 +178,7 @@ void buffer_skip(buffer_type* buffer, ssize_t count);
  *             1 otherwise
  *
  */
-int buffer_skip_dname(buffer_type* buffer);
+extern int buffer_skip_dname(buffer_type* buffer);
 
 /**
  * Change the buffer's position so that one RR is skipped.
@@ -188,7 +188,7 @@ int buffer_skip_dname(buffer_type* buffer);
  *             1 otherwise
  *
  */
-int buffer_skip_rr(buffer_type* buffer, unsigned qrr);
+extern int buffer_skip_rr(buffer_type* buffer, unsigned qrr);
 
 /**
  * Get the buffer's limit.
@@ -196,7 +196,7 @@ int buffer_skip_rr(buffer_type* buffer, unsigned qrr);
  * \return size_t limit
  *
  */
-size_t buffer_limit(buffer_type* buffer);
+extern size_t buffer_limit(buffer_type* buffer);
 
 /**
  * Set the buffer's limit. If the buffer's position is greater
@@ -205,7 +205,7 @@ size_t buffer_limit(buffer_type* buffer);
  * \param[in] limit limit
  *
  */
-void buffer_set_limit(buffer_type* buffer, size_t limit);
+extern void buffer_set_limit(buffer_type* buffer, size_t limit);
 
 /**
  * Get the buffer's capacity.
@@ -213,7 +213,7 @@ void buffer_set_limit(buffer_type* buffer, size_t limit);
  * \return size_t capacity
  *
  */
-size_t buffer_capacity(buffer_type* buffer);
+extern size_t buffer_capacity(buffer_type* buffer);
 
 /**
  * Return a pointer to the data at the indicated position.
@@ -222,7 +222,7 @@ size_t buffer_capacity(buffer_type* buffer);
  * \return uint8_t* pointer to the data at the indicated position
  *
  */
-uint8_t* buffer_at(buffer_type* buffer, size_t at);
+extern uint8_t* buffer_at(buffer_type* buffer, size_t at);
 
 /**
  * Return a pointer to the data at the beginning of the buffer.
@@ -230,7 +230,7 @@ uint8_t* buffer_at(buffer_type* buffer, size_t at);
  * \return uint8_t* pointer to the data at the begin of the buffer
  *
  */
-uint8_t* buffer_begin(buffer_type* buffer);
+extern uint8_t* buffer_begin(buffer_type* buffer);
 
 /**
  * Return a pointer to the data at the buffer's current position.
@@ -238,7 +238,7 @@ uint8_t* buffer_begin(buffer_type* buffer);
  * \return uint8_t* pointer to the data at the buffer's current position
  *
  */
-uint8_t* buffer_current(buffer_type* buffer);
+extern uint8_t* buffer_current(buffer_type* buffer);
 
 /**
  * The number of bytes remaining between the buffer's position and limit.
@@ -246,7 +246,7 @@ uint8_t* buffer_current(buffer_type* buffer);
  * \return size_t remaining number of bytes
  *
  */
-size_t buffer_remaining(buffer_type* buffer);
+extern size_t buffer_remaining(buffer_type* buffer);
 
 /**
  * Check if the buffer has enough bytes available.
@@ -256,7 +256,7 @@ size_t buffer_remaining(buffer_type* buffer);
  *             1 otherwise
  *
  */
-int buffer_available(buffer_type* buffer, size_t count);
+extern int buffer_available(buffer_type* buffer, size_t count);
 
 /**
  * Write to buffer.
@@ -265,7 +265,7 @@ int buffer_available(buffer_type* buffer, size_t count);
  * \param[in] count number of bytes to write
  *
  */
-void buffer_write(buffer_type* buffer, const void* data, size_t count);
+extern void buffer_write(buffer_type* buffer, const void* data, size_t count);
 
 /**
  * Write uint8_t to buffer.
@@ -273,7 +273,7 @@ void buffer_write(buffer_type* buffer, const void* data, size_t count);
  * \param[in] data data to write
  *
  */
-void buffer_write_u8(buffer_type* buffer, uint8_t data);
+extern void buffer_write_u8(buffer_type* buffer, uint8_t data);
 
 /**
  * Write uint16_t to buffer.
@@ -281,7 +281,7 @@ void buffer_write_u8(buffer_type* buffer, uint8_t data);
  * \param[in] data data to write
  *
  */
-void buffer_write_u16(buffer_type* buffer, uint16_t data);
+extern void buffer_write_u16(buffer_type* buffer, uint16_t data);
 
 /**
  * Write uint16_t to buffer at indicated position.
@@ -290,7 +290,7 @@ void buffer_write_u16(buffer_type* buffer, uint16_t data);
  * \param[in] data data to write
  *
  */
-void buffer_write_u16_at(buffer_type* buffer, size_t at, uint16_t data);
+extern void buffer_write_u16_at(buffer_type* buffer, size_t at, uint16_t data);
 
 /**
  * Write uint32_t to buffer.
@@ -298,7 +298,7 @@ void buffer_write_u16_at(buffer_type* buffer, size_t at, uint16_t data);
  * \param[in] data data to write
  *
  */
-void buffer_write_u32(buffer_type* buffer, uint32_t data);
+extern void buffer_write_u32(buffer_type* buffer, uint32_t data);
 
 /**
  * Write rdf to buffer.
@@ -306,7 +306,7 @@ void buffer_write_u32(buffer_type* buffer, uint32_t data);
  * \param[in] rdf data to write
  *
  */
-void buffer_write_rdf(buffer_type* buffer, ldns_rdf* rdf);
+extern void buffer_write_rdf(buffer_type* buffer, ldns_rdf* rdf);
 
 /**
  * Write rr to buffer.
@@ -315,7 +315,7 @@ void buffer_write_rdf(buffer_type* buffer, ldns_rdf* rdf);
  * \return int 1 if rr fits, 0 otherwise
  *
  */
-int buffer_write_rr(buffer_type* buffer, ldns_rr* rr);
+extern int buffer_write_rr(buffer_type* buffer, ldns_rr* rr);
 
 /**
  * Read from buffer.
@@ -324,7 +324,7 @@ int buffer_write_rr(buffer_type* buffer, ldns_rr* rr);
  * \param[in] count number of bytes to read
  *
  */
-void buffer_read(buffer_type* buffer, void* data, size_t count);
+extern void buffer_read(buffer_type* buffer, void* data, size_t count);
 
 /**
  * Read uint8_t from buffer.
@@ -332,7 +332,7 @@ void buffer_read(buffer_type* buffer, void* data, size_t count);
  * \return uint8_t read data
  *
  */
-uint8_t buffer_read_u8(buffer_type* buffer);
+extern uint8_t buffer_read_u8(buffer_type* buffer);
 
 /**
  * Read uint16_t from buffer.
@@ -340,7 +340,7 @@ uint8_t buffer_read_u8(buffer_type* buffer);
  * \return uint16_t read data
  *
  */
-uint16_t buffer_read_u16(buffer_type* buffer);
+extern uint16_t buffer_read_u16(buffer_type* buffer);
 
 /**
  * Read uint32_t from buffer.
@@ -348,7 +348,7 @@ uint16_t buffer_read_u16(buffer_type* buffer);
  * \return uint32_t read data
  *
  */
-uint32_t buffer_read_u32(buffer_type* buffer);
+extern uint32_t buffer_read_u32(buffer_type* buffer);
 
 /**
  * Read dname from buffer.
@@ -358,7 +358,7 @@ uint32_t buffer_read_u32(buffer_type* buffer);
  * \return int dname length
  *
  */
-size_t buffer_read_dname(buffer_type* buffer, uint8_t* dname,
+extern size_t buffer_read_dname(buffer_type* buffer, uint8_t* dname,
     unsigned allow_pointers);
 
 /**
@@ -367,14 +367,14 @@ size_t buffer_read_dname(buffer_type* buffer, uint8_t* dname,
  * \return uint16_t query id
  *
  */
-uint16_t buffer_pkt_id(buffer_type* buffer);
+extern uint16_t buffer_pkt_id(buffer_type* buffer);
 
 /**
  * Set random query id in buffer.
  * \param[in] buffer buffer
  *
  */
-void buffer_pkt_set_random_id(buffer_type* buffer);
+extern void buffer_pkt_set_random_id(buffer_type* buffer);
 
 /**
  * Get flags from buffer.
@@ -382,7 +382,7 @@ void buffer_pkt_set_random_id(buffer_type* buffer);
  * \return uint16_t flags
  *
  */
-uint16_t buffer_pkt_flags(buffer_type* buffer);
+extern uint16_t buffer_pkt_flags(buffer_type* buffer);
 
 /**
  * Set flags in buffer.
@@ -390,7 +390,7 @@ uint16_t buffer_pkt_flags(buffer_type* buffer);
  * \param[in] flags flags
  *
  */
-void buffer_pkt_set_flags(buffer_type* buffer, uint16_t flags);
+extern void buffer_pkt_set_flags(buffer_type* buffer, uint16_t flags);
 
 /**
  * Get QR bit from buffer.
@@ -399,21 +399,21 @@ void buffer_pkt_set_flags(buffer_type* buffer, uint16_t flags);
  *             1 if QR bit is set
  *
  */
-int buffer_pkt_qr(buffer_type* buffer);
+extern int buffer_pkt_qr(buffer_type* buffer);
 
 /**
  * Set QR bit in buffer.
  * \param[in] buffer buffer
  *
  */
-void buffer_pkt_set_qr(buffer_type* buffer);
+extern void buffer_pkt_set_qr(buffer_type* buffer);
 
 /**
  * Clear QR bit in buffer.
  * \param[in] buffer buffer
  *
  */
-void buffer_pkt_clear_qr(buffer_type* buffer);
+extern void buffer_pkt_clear_qr(buffer_type* buffer);
 
 /**
  * Get AA bit from buffer.
@@ -422,14 +422,14 @@ void buffer_pkt_clear_qr(buffer_type* buffer);
  *             1 if AA bit is set
  *
  */
-int buffer_pkt_aa(buffer_type* buffer);
+extern int buffer_pkt_aa(buffer_type* buffer);
 
 /**
  * Set AA bit in buffer.
  * \param[in] buffer buffer
  *
  */
-void buffer_pkt_set_aa(buffer_type* buffer);
+extern void buffer_pkt_set_aa(buffer_type* buffer);
 
 /**
  * Get TC bit from buffer.
@@ -438,7 +438,7 @@ void buffer_pkt_set_aa(buffer_type* buffer);
  *             1 if TC bit is set
  *
  */
-int buffer_pkt_tc(buffer_type* buffer);
+extern int buffer_pkt_tc(buffer_type* buffer);
 
 /**
  * Get RD bit from buffer.
@@ -447,7 +447,7 @@ int buffer_pkt_tc(buffer_type* buffer);
  *             1 if RD bit is set
  *
  */
-int buffer_pkt_rd(buffer_type* buffer);
+extern int buffer_pkt_rd(buffer_type* buffer);
 
 /**
  * Get RA bit from buffer.
@@ -456,7 +456,7 @@ int buffer_pkt_rd(buffer_type* buffer);
  *             1 if RA bit is set
  *
  */
-int buffer_pkt_ra(buffer_type* buffer);
+extern int buffer_pkt_ra(buffer_type* buffer);
 
 /**
  * Get AD bit from buffer.
@@ -465,7 +465,7 @@ int buffer_pkt_ra(buffer_type* buffer);
  *             1 if AD bit is set
  *
  */
-int buffer_pkt_ad(buffer_type* buffer);
+extern int buffer_pkt_ad(buffer_type* buffer);
 
 /**
  * Get CD bit from buffer.
@@ -474,7 +474,7 @@ int buffer_pkt_ad(buffer_type* buffer);
  *             1 if CD bit is set
  *
  */
-int buffer_pkt_cd(buffer_type* buffer);
+extern int buffer_pkt_cd(buffer_type* buffer);
 
 /**
  * Get OPCODE from buffer.
@@ -482,7 +482,7 @@ int buffer_pkt_cd(buffer_type* buffer);
  * \return ldns_pkt_opcode OPCODE
  *
  */
-ldns_pkt_opcode buffer_pkt_opcode(buffer_type* buffer);
+extern ldns_pkt_opcode buffer_pkt_opcode(buffer_type* buffer);
 
 /**
  * Set OPCODE in buffer.
@@ -490,7 +490,7 @@ ldns_pkt_opcode buffer_pkt_opcode(buffer_type* buffer);
  * \param[in] opcode OPCODE
  *
  */
-void buffer_pkt_set_opcode(buffer_type* buffer, ldns_pkt_opcode opcode);
+extern void buffer_pkt_set_opcode(buffer_type* buffer, ldns_pkt_opcode opcode);
 
 /**
  * Get RCODE from buffer.
@@ -498,7 +498,7 @@ void buffer_pkt_set_opcode(buffer_type* buffer, ldns_pkt_opcode opcode);
  * \return ldns_pkt_rcode RCODE
  *
  */
-ldns_pkt_rcode buffer_pkt_rcode(buffer_type* buffer);
+extern ldns_pkt_rcode buffer_pkt_rcode(buffer_type* buffer);
 
 /**
  * Set RCODE in buffer.
@@ -506,7 +506,7 @@ ldns_pkt_rcode buffer_pkt_rcode(buffer_type* buffer);
  * \param[in] rcode RCODE
  *
  */
-void buffer_pkt_set_rcode(buffer_type* buffer, ldns_pkt_rcode rcode);
+extern void buffer_pkt_set_rcode(buffer_type* buffer, ldns_pkt_rcode rcode);
 
 /**
  * Look up a descriptive text by each rcode.
@@ -514,7 +514,7 @@ void buffer_pkt_set_rcode(buffer_type* buffer, ldns_pkt_rcode rcode);
  * \return const char* descriptive text
  *
  */
-const char* buffer_rcode2str(ldns_pkt_rcode rcode);
+extern const char* buffer_rcode2str(ldns_pkt_rcode rcode);
 
 /**
  * Get QDCOUNT from buffer.
@@ -522,7 +522,7 @@ const char* buffer_rcode2str(ldns_pkt_rcode rcode);
  * \return uint16_t QDCOUNT
  *
  */
-uint16_t buffer_pkt_qdcount(buffer_type* buffer);
+extern uint16_t buffer_pkt_qdcount(buffer_type* buffer);
 
 /**
  * Set QDCOUNT in buffer.
@@ -530,7 +530,7 @@ uint16_t buffer_pkt_qdcount(buffer_type* buffer);
  * \param[in] count QDCOUNT
  *
  */
-void buffer_pkt_set_qdcount(buffer_type* buffer, uint16_t count);
+extern void buffer_pkt_set_qdcount(buffer_type* buffer, uint16_t count);
 
 /**
  * Get ANCOUNT from buffer.
@@ -538,7 +538,7 @@ void buffer_pkt_set_qdcount(buffer_type* buffer, uint16_t count);
  * \return uint16_t ANCOUNT
  *
  */
-uint16_t buffer_pkt_ancount(buffer_type* buffer);
+extern uint16_t buffer_pkt_ancount(buffer_type* buffer);
 
 /**
  * Set ANCOUNT in buffer.
@@ -546,7 +546,7 @@ uint16_t buffer_pkt_ancount(buffer_type* buffer);
  * \param[in] count ANCOUNT
  *
  */
-void buffer_pkt_set_ancount(buffer_type* buffer, uint16_t count);
+extern void buffer_pkt_set_ancount(buffer_type* buffer, uint16_t count);
 
 /**
  * Get NSCOUNT from buffer.
@@ -554,7 +554,7 @@ void buffer_pkt_set_ancount(buffer_type* buffer, uint16_t count);
  * \return uint16_t NSCOUNT
  *
  */
-uint16_t buffer_pkt_nscount(buffer_type* buffer);
+extern uint16_t buffer_pkt_nscount(buffer_type* buffer);
 
 /**
  * Set NSCOUNT in buffer.
@@ -562,7 +562,7 @@ uint16_t buffer_pkt_nscount(buffer_type* buffer);
  * \param[in] count NSCOUNT
  *
  */
-void buffer_pkt_set_nscount(buffer_type* buffer, uint16_t count);
+extern void buffer_pkt_set_nscount(buffer_type* buffer, uint16_t count);
 
 /**
  * Get ARCOUNT from buffer.
@@ -570,7 +570,7 @@ void buffer_pkt_set_nscount(buffer_type* buffer, uint16_t count);
  * \return uint16_t ARCOUNT
  *
  */
-uint16_t buffer_pkt_arcount(buffer_type* buffer);
+extern uint16_t buffer_pkt_arcount(buffer_type* buffer);
 
 /**
  * Set ARCOUNT in buffer.
@@ -578,7 +578,7 @@ uint16_t buffer_pkt_arcount(buffer_type* buffer);
  * \param[in] count ARCOUNT
  *
  */
-void buffer_pkt_set_arcount(buffer_type* buffer, uint16_t count);
+extern void buffer_pkt_set_arcount(buffer_type* buffer, uint16_t count);
 
 /**
  * Make a new query.
@@ -588,7 +588,7 @@ void buffer_pkt_set_arcount(buffer_type* buffer, uint16_t count);
  * \param[in] qclass qclass
  *
  */
-void
+extern void
 buffer_pkt_query(buffer_type* buffer, ldns_rdf* qname, ldns_rr_type qtype,
    ldns_rr_class qclass);
 
@@ -599,7 +599,7 @@ buffer_pkt_query(buffer_type* buffer, ldns_rdf* qname, ldns_rr_type qtype,
  * \param[in] qclass qclass
  *
  */
-void
+extern void
 buffer_pkt_notify(buffer_type* buffer, ldns_rdf* qname, ldns_rr_class qclass);
 
 /**
@@ -608,7 +608,7 @@ buffer_pkt_notify(buffer_type* buffer, ldns_rdf* qname, ldns_rr_class qclass);
  * \param[in] allocator memory allocator
  *
  */
-void buffer_cleanup(buffer_type* buffer);
+extern void buffer_cleanup(buffer_type* buffer);
 
 /** UTIL **/
 

--- a/signer/src/wire/edns.h
+++ b/signer/src/wire/edns.h
@@ -87,7 +87,7 @@ struct edns_rr_struct {
  * \param[in] max_length maximum length.
  *
  */
-void edns_init(edns_data_type* data, uint16_t max_length);
+extern void edns_init(edns_data_type* data, uint16_t max_length);
 
 /**
  * Create new EDNS RR.
@@ -95,7 +95,7 @@ void edns_init(edns_data_type* data, uint16_t max_length);
  * \return edns_rr_type* EDNS RR.
  *
  */
-edns_rr_type* edns_rr_create(void);
+extern edns_rr_type* edns_rr_create(void);
 
 
 /**
@@ -103,7 +103,7 @@ edns_rr_type* edns_rr_create(void);
  * \param[in] err EDNS record.
  *
  */
-void edns_rr_reset(edns_rr_type* err);
+extern void edns_rr_reset(edns_rr_type* err);
 
 /**
  * Parse EDNS OPT RR.
@@ -112,7 +112,7 @@ void edns_rr_reset(edns_rr_type* err);
  * \return int 1 if EDNS and valid, 0 otherwise.
  *
  */
-int edns_rr_parse(edns_rr_type* err, buffer_type* buffer);
+extern int edns_rr_parse(edns_rr_type* err, buffer_type* buffer);
 
 /**
  * The amount of space to reserve in the response for the EDNS data.
@@ -120,9 +120,9 @@ int edns_rr_parse(edns_rr_type* err, buffer_type* buffer);
  * \return size_t amount of space to reserve.
  *
  */
-size_t edns_rr_reserved_space(edns_rr_type* err);
+extern size_t edns_rr_reserved_space(edns_rr_type* err);
 
-void edns_rr_cleanup(edns_rr_type* err);
+extern void edns_rr_cleanup(edns_rr_type* err);
 
 
 #endif /* WIRE_EDNS_H */

--- a/signer/src/wire/listener.h
+++ b/signer/src/wire/listener.h
@@ -89,7 +89,7 @@ struct listener_struct {
  * \return listener_type* listener
  *
  */
-listener_type* listener_create(void);
+extern listener_type* listener_create(void);
 
 /**
  * Push an interface to the listener.
@@ -100,7 +100,7 @@ listener_type* listener_create(void);
  * \return interface_type* added interface
  *
  */
-interface_type* listener_push(listener_type* list, char* address, int family,
+extern interface_type* listener_push(listener_type* list, char* address, int family,
     const char* port);
 
 /**
@@ -108,13 +108,13 @@ interface_type* listener_push(listener_type* list, char* address, int family,
  * \param[in] i interface
  *
  */
-void interface_cleanup(interface_type* i);
+extern void interface_cleanup(interface_type* i);
 
 /**
  * Clean up listener.
  * \param[in] listener listener to clean up
  *
  */
-void listener_cleanup(listener_type* listener);
+extern void listener_cleanup(listener_type* listener);
 
 #endif /* WIRE_LISTENER_H */

--- a/signer/src/wire/netio.h
+++ b/signer/src/wire/netio.h
@@ -162,7 +162,7 @@ struct netio_struct {
  * \return netio_type* netio instance
  *
  */
-netio_type* netio_create(void);
+extern netio_type* netio_create(void);
 
 /*
  * Add a new handler to netio.
@@ -170,7 +170,7 @@ netio_type* netio_create(void);
  * \param[in] handler handler
  *
  */
-void netio_add_handler(netio_type* netio, netio_handler_type* handler);
+extern void netio_add_handler(netio_type* netio, netio_handler_type* handler);
 
 /*
  * Remove the handler from netio.
@@ -178,7 +178,7 @@ void netio_add_handler(netio_type* netio, netio_handler_type* handler);
  * \param[in] handler handler
  *
  */
-void netio_remove_handler(netio_type* netio, netio_handler_type* handler);
+extern void netio_remove_handler(netio_type* netio, netio_handler_type* handler);
 
 /*
  * Retrieve the current time (using gettimeofday(2)).
@@ -186,7 +186,7 @@ void netio_remove_handler(netio_type* netio, netio_handler_type* handler);
  * \return const struct timespec* current time
  *
  */
-const struct timespec* netio_current_time(netio_type* netio);
+extern const struct timespec* netio_current_time(netio_type* netio);
 
 /*
  * Check for events and dispatch them to the handlers.
@@ -198,7 +198,7 @@ const struct timespec* netio_current_time(netio_type* netio);
  *             and -1 on error (with errno set appropriately).
  *
  */
-int netio_dispatch(netio_type* netio, const struct timespec* timeout,
+extern int netio_dispatch(netio_type* netio, const struct timespec* timeout,
    const sigset_t* sigmask);
 
 /**
@@ -206,8 +206,8 @@ int netio_dispatch(netio_type* netio, const struct timespec* timeout,
  * \param[in] netio netio instance
  *
  */
-void netio_cleanup(netio_type* netio);
-void netio_cleanup_shallow(netio_type* netio);
+extern void netio_cleanup(netio_type* netio);
+extern void netio_cleanup_shallow(netio_type* netio);
 
 /**
  * Add timespecs.
@@ -215,7 +215,7 @@ void netio_cleanup_shallow(netio_type* netio);
  * \param[in] right right
  *
  */
-void timespec_add(struct timespec* left, const struct timespec* right);
+extern void timespec_add(struct timespec* left, const struct timespec* right);
 
 
 #ifdef __cplusplus

--- a/signer/src/wire/notify.h
+++ b/signer/src/wire/notify.h
@@ -74,7 +74,7 @@ struct notify_struct {
  * \return notify_type* notify structure.
  *
  */
-notify_type* notify_create(xfrhandler_type* xfrhandler, zone_type* zone);
+extern notify_type* notify_create(xfrhandler_type* xfrhandler, zone_type* zone);
 
 /**
  * Enable notify.
@@ -82,20 +82,20 @@ notify_type* notify_create(xfrhandler_type* xfrhandler, zone_type* zone);
  * \param[in] soa current soa
  *
  */
-void notify_enable(notify_type* notify, ldns_rr* soa);
+extern void notify_enable(notify_type* notify, ldns_rr* soa);
 
 /**
  * Send notify.
  * \param[in] notify notify structure
  *
  */
-void notify_send(notify_type* notify);
+extern void notify_send(notify_type* notify);
 
 /**
  * Cleanup notify structure.
  * \param[in] notify notify structure.
  *
  */
-void notify_cleanup(notify_type* notify);
+extern void notify_cleanup(notify_type* notify);
 
 #endif /* WIRE_NOTIFY_H */

--- a/signer/src/wire/query.h
+++ b/signer/src/wire/query.h
@@ -107,14 +107,14 @@ struct response_struct {
  * \return query_type* query
  *
  */
-query_type* query_create(void);
+extern query_type* query_create(void);
 
 /**
  * Prepare response.
  * \param[in] q query
  *
  */
-void query_prepare(query_type* q);
+extern void query_prepare(query_type* q);
 
 /**
  * Process query.
@@ -123,7 +123,7 @@ void query_prepare(query_type* q);
  * \return query_state state of the query
  *
  */
-query_state query_process(query_type* q, engine_type* engine);
+extern query_state query_process(query_type* q, engine_type* engine);
 
 /**
  * Reset query.
@@ -132,7 +132,7 @@ query_state query_process(query_type* q, engine_type* engine);
  * \param[in] is_tcp 1 if tcp query
  *
  */
-void query_reset(query_type* q, size_t maxlen, int is_tcp);
+extern void query_reset(query_type* q, size_t maxlen, int is_tcp);
 
 /**
  * Add optional RRs to query.
@@ -140,7 +140,7 @@ void query_reset(query_type* q, size_t maxlen, int is_tcp);
  * \param[in] engine signer engine
  *
  */
-void query_add_optional(query_type* q, engine_type* engine);
+extern void query_add_optional(query_type* q, engine_type* engine);
 
 /**
  * Add RR to query.
@@ -149,13 +149,13 @@ void query_add_optional(query_type* q, engine_type* engine);
  * \return int 1 if ok, 0 if overflow.
  *
  */
-int query_add_rr(query_type* q, ldns_rr* rr);
+extern int query_add_rr(query_type* q, ldns_rr* rr);
 
 /**
  * Cleanup query.
  * \param[in] q query
  *
  */
-void query_cleanup(query_type* q);
+extern void query_cleanup(query_type* q);
 
 #endif /* WIRE_QUERY_H */

--- a/signer/src/wire/sock.h
+++ b/signer/src/wire/sock.h
@@ -99,7 +99,7 @@ struct tcp_data {
  * \return ods_status status
  *
  */
-ods_status sock_listen(socklist_type* sockets, listener_type* listener);
+extern ods_status sock_listen(socklist_type* sockets, listener_type* listener);
 
 /**
  * Handle incoming udp queries.
@@ -108,7 +108,7 @@ ods_status sock_listen(socklist_type* sockets, listener_type* listener);
  * \param[in] event_types the types of events that should be checked for
  *
  */
-void sock_handle_udp(netio_type* netio, netio_handler_type* handler,
+extern void sock_handle_udp(netio_type* netio, netio_handler_type* handler,
     netio_events_type event_types);
 
 /**
@@ -118,7 +118,7 @@ void sock_handle_udp(netio_type* netio, netio_handler_type* handler,
  * \param[in] event_types the types of events that should be checked for
  *
  */
-void sock_handle_tcp_accept(netio_type* netio, netio_handler_type* handler,
+extern void sock_handle_tcp_accept(netio_type* netio, netio_handler_type* handler,
     netio_events_type event_types);
 
 /**
@@ -128,7 +128,7 @@ void sock_handle_tcp_accept(netio_type* netio, netio_handler_type* handler,
  * \param[in] event_types the types of events that should be checked for
  *
  */
-void sock_handle_tcp_read(netio_type* netio, netio_handler_type* handler,
+extern void sock_handle_tcp_read(netio_type* netio, netio_handler_type* handler,
     netio_events_type event_types);
 
 /**
@@ -138,7 +138,7 @@ void sock_handle_tcp_read(netio_type* netio, netio_handler_type* handler,
  * \param[in] event_types the types of events that should be checked for
  *
  */
-void sock_handle_tcp_write(netio_type* netio, netio_handler_type* handler,
+extern void sock_handle_tcp_write(netio_type* netio, netio_handler_type* handler,
     netio_events_type event_types);
 
 #endif /* WIRE_SOCK_H */

--- a/signer/src/wire/tcpset.h
+++ b/signer/src/wire/tcpset.h
@@ -77,7 +77,7 @@ struct tcp_set_struct {
  * \return tcp_conn_type* TCP connection.
  *
  */
-tcp_conn_type* tcp_conn_create(void);
+extern tcp_conn_type* tcp_conn_create(void);
 
 /**
  * Create a set of tcp connections.
@@ -85,14 +85,14 @@ tcp_conn_type* tcp_conn_create(void);
  * \return tcp_set_type* set of tcp connection.
  *
  */
-tcp_set_type* tcp_set_create(void);
+extern tcp_set_type* tcp_set_create(void);
 
 /**
  * Make tcp connection ready for reading.
  * \param[in] tcp tcp connection
  *
  */
-void tcp_conn_ready(tcp_conn_type* tcp);
+extern void tcp_conn_ready(tcp_conn_type* tcp);
 
 /*
  * Read from a tcp connection.
@@ -104,7 +104,7 @@ void tcp_conn_ready(tcp_conn_type* tcp);
  *              1 on completed read.
  *
  */
-int tcp_conn_read(tcp_conn_type* tcp);
+extern int tcp_conn_read(tcp_conn_type* tcp);
 
 /*
  * Write to a tcp connection.
@@ -116,7 +116,7 @@ int tcp_conn_read(tcp_conn_type* tcp);
  *              1 on completed write.
  *
  */
-int tcp_conn_write(tcp_conn_type* tcp);
+extern int tcp_conn_write(tcp_conn_type* tcp);
 
 /**
  * Clean up set of tcp connections.
@@ -124,6 +124,6 @@ int tcp_conn_write(tcp_conn_type* tcp);
  * \param[in] allocator memory allocator
  *
  */
-void tcp_set_cleanup(tcp_set_type* set);
+extern void tcp_set_cleanup(tcp_set_type* set);
 
 #endif /* WIRE_TCPSET_H */

--- a/signer/src/wire/tsig-openssl.h
+++ b/signer/src/wire/tsig-openssl.h
@@ -44,13 +44,13 @@
  * \return ods_status status
  *
  */
-ods_status tsig_handler_openssl_init(void);
+extern ods_status tsig_handler_openssl_init(void);
 
 /**
  * Finalize OpenSSL support for TSIG.
  *
  */
-void tsig_handler_openssl_finalize(void);
+extern void tsig_handler_openssl_finalize(void);
 
 #endif /* HAVE_SSL */
 #endif /* WIRE_TSIG_OPENSSL_H */

--- a/signer/src/wire/tsig.h
+++ b/signer/src/wire/tsig.h
@@ -150,27 +150,27 @@ struct tsig_rr_struct {
  * \return ods_status status
  *
  */
-ods_status tsig_handler_init(void);
+extern ods_status tsig_handler_init(void);
 
 /**
  * Clean up TSIG handler.
  *
  */
-void tsig_handler_cleanup(void);
+extern void tsig_handler_cleanup(void);
 
 /**
  * Add key to TSIG handler.
  * \param[in] key tsig key
  *
  */
-void tsig_handler_add_key(tsig_key_type* key);
+extern void tsig_handler_add_key(tsig_key_type* key);
 
 /**
  * Add algorithm to TSIG handler.
  * \param[in] algo tsig algorithm
  *
  */
-void tsig_handler_add_algo(tsig_algo_type* algo);
+extern void tsig_handler_add_algo(tsig_algo_type* algo);
 
 /**
  * Create new TSIG.
@@ -181,7 +181,7 @@ void tsig_handler_add_algo(tsig_algo_type* algo);
  * \return tsig_type* TSIG
  *
  */
-tsig_type* tsig_create(char* name, char* algo,
+extern tsig_type* tsig_create(char* name, char* algo,
     char* secret);
 
 /**
@@ -191,7 +191,7 @@ tsig_type* tsig_create(char* name, char* algo,
  * \return tsig_type* TSIG
  *
  */
-tsig_type* tsig_lookup_by_name(tsig_type* tsig, const char* name);
+extern tsig_type* tsig_lookup_by_name(tsig_type* tsig, const char* name);
 
 /**
  * Lookup TSIG algorithm by name.
@@ -199,7 +199,7 @@ tsig_type* tsig_lookup_by_name(tsig_type* tsig, const char* name);
  * \return tsig_algo_type* TSIG algorithm
  *
  */
-tsig_algo_type* tsig_lookup_algo(const char* name);
+extern tsig_algo_type* tsig_lookup_algo(const char* name);
 
 /**
  * Create new TSIG RR.
@@ -207,7 +207,7 @@ tsig_algo_type* tsig_lookup_algo(const char* name);
  * \return tsig_rr_type* TSIG RR
  *
  */
-tsig_rr_type* tsig_rr_create(void);
+extern tsig_rr_type* tsig_rr_create(void);
 
 /**
  * Reset TSIG RR.
@@ -216,7 +216,7 @@ tsig_rr_type* tsig_rr_create(void);
  * \param[in] key tsig key
  *
  */
-void tsig_rr_reset(tsig_rr_type* trr, tsig_algo_type* algo, tsig_key_type* key);
+extern void tsig_rr_reset(tsig_rr_type* trr, tsig_algo_type* algo, tsig_key_type* key);
 
 /**
  * Find TSIG RR.
@@ -225,7 +225,7 @@ void tsig_rr_reset(tsig_rr_type* trr, tsig_algo_type* algo, tsig_key_type* key);
  * \return int 1 if not present or present and valid, 0 otherwise.
  *
  */
-int tsig_rr_find(tsig_rr_type* trr, buffer_type* buffer);
+extern int tsig_rr_find(tsig_rr_type* trr, buffer_type* buffer);
 
 /**
  * Parse TSIG RR.
@@ -234,7 +234,7 @@ int tsig_rr_find(tsig_rr_type* trr, buffer_type* buffer);
  * \return int 1 if not TSIG RR or TSIG RR and valid, 0 otherwise.
  *
  */
-int tsig_rr_parse(tsig_rr_type* trr, buffer_type* buffer);
+extern int tsig_rr_parse(tsig_rr_type* trr, buffer_type* buffer);
 
 /**
  * Lookup TSIG RR.
@@ -242,14 +242,14 @@ int tsig_rr_parse(tsig_rr_type* trr, buffer_type* buffer);
  * \return int 1 if succeeded, 0 if unknown
  *
  */
-int tsig_rr_lookup(tsig_rr_type* trr);
+extern int tsig_rr_lookup(tsig_rr_type* trr);
 
 /**
  * Prepare TSIG RR.
  * \param[in] trr TSIG RR
  *
  */
-void tsig_rr_prepare(tsig_rr_type* trr);
+extern void tsig_rr_prepare(tsig_rr_type* trr);
 
 /**
  * Update TSIG RR.
@@ -260,14 +260,14 @@ void tsig_rr_prepare(tsig_rr_type* trr);
  *                   query idfrom TSIG.
  *
  */
-void tsig_rr_update(tsig_rr_type* trr, buffer_type* buffer, size_t length);
+extern void tsig_rr_update(tsig_rr_type* trr, buffer_type* buffer, size_t length);
 
 /**
  * Sign TSIG RR.
  * \param[in] trr TSIG RR
  *
  */
-void tsig_rr_sign(tsig_rr_type* trr);
+extern void tsig_rr_sign(tsig_rr_type* trr);
 
 /**
  * Verify TSIG RR.
@@ -275,7 +275,7 @@ void tsig_rr_sign(tsig_rr_type* trr);
  * \return int 1 if verified, 0 on error
  *
  */
-int tsig_rr_verify(tsig_rr_type* trr);
+extern int tsig_rr_verify(tsig_rr_type* trr);
 
 /**
  * Append TSIG RR.
@@ -283,7 +283,7 @@ int tsig_rr_verify(tsig_rr_type* trr);
  * \param[in] buffer packet buffer
  *
  */
-void tsig_rr_append(tsig_rr_type* trr, buffer_type* buffer);
+extern void tsig_rr_append(tsig_rr_type* trr, buffer_type* buffer);
 
 /*
  * The amount of space to reserve in the response for the TSIG data.
@@ -291,14 +291,14 @@ void tsig_rr_append(tsig_rr_type* trr, buffer_type* buffer);
  * \return size_t reserved space size
  *
  */
-size_t tsig_rr_reserved_space(tsig_rr_type *trr);
+extern size_t tsig_rr_reserved_space(tsig_rr_type *trr);
 
 /**
  * Reply with error TSIG RR.
  * \param[in] trr TSIG RR
  *
  */
-void tsig_rr_error(tsig_rr_type* trr);
+extern void tsig_rr_error(tsig_rr_type* trr);
 
 /**
  * Get human readable TSIG error code.
@@ -306,7 +306,7 @@ void tsig_rr_error(tsig_rr_type* trr);
  * \return const char* TSIG status
  *
  */
-const char* tsig_status2str(tsig_status status);
+extern const char* tsig_status2str(tsig_status status);
 
 /**
  * Get human readable TSIG error code.
@@ -314,21 +314,21 @@ const char* tsig_status2str(tsig_status status);
  * \return const char* readable error code
  *
  */
-const char* tsig_strerror(uint16_t error);
+extern const char* tsig_strerror(uint16_t error);
 
 /**
  * Free TSIG RR.
  * \param[in] trr TSIG RR
  *
  */
-void tsig_rr_free(tsig_rr_type* trr);
+extern void tsig_rr_free(tsig_rr_type* trr);
 
 /**
  * Cleanup TSIG RR
  * \param[in] trr TSIG RR
  *
  */
-void tsig_rr_cleanup(tsig_rr_type* trr);
+extern void tsig_rr_cleanup(tsig_rr_type* trr);
 
 /**
  * Clean up TSIG.
@@ -336,6 +336,6 @@ void tsig_rr_cleanup(tsig_rr_type* trr);
  * \param[in] allocator memory allocator
  *
  */
-void tsig_cleanup(tsig_type* tsig);
+extern void tsig_cleanup(tsig_type* tsig);
 
 #endif /* WIRE_TSIG_H */

--- a/signer/src/wire/xfrd.h
+++ b/signer/src/wire/xfrd.h
@@ -147,7 +147,7 @@ struct xfrd_struct
  * \return xfrd_type* zone transfer structure.
  *
  */
-xfrd_type* xfrd_create(xfrhandler_type* xfrhandler, zone_type* zone);
+extern xfrd_type* xfrd_create(xfrhandler_type* xfrhandler, zone_type* zone);
 
 /**
  * Set timeout for zone transfer to now.
@@ -177,7 +177,7 @@ void xfrd_set_timer_refresh(xfrd_type* xfrd);
  * \return socklen_t length of address
  *
  */
-socklen_t xfrd_acl_sockaddr_to(acl_type* acl,
+extern socklen_t xfrd_acl_sockaddr_to(acl_type* acl,
     struct sockaddr_storage* to);
 
 /**
@@ -186,6 +186,6 @@ socklen_t xfrd_acl_sockaddr_to(acl_type* acl,
  * \param[in] backup backup transfer variables.
  *
  */
-void xfrd_cleanup(xfrd_type* xfrd, int backup);
+extern void xfrd_cleanup(xfrd_type* xfrd, int backup);
 
 #endif /* WIRE_XFRD_H */


### PR DESCRIPTION
These are fixes, mostly sprinkling extern's to make it compile on gcc10.

Based on the work I did to make 2.1.6 compile in fedora. Final result untested because the tree doesn't compile for me for a variety of other reasons, like undefined variables (prevss vs ss). The build gets far enough at least to see these problems now :)