### PR TITLE
SUPPORT-253: Use correct key tag for CSK

### DIFF
--- a/enforcer/src/db/hsm_key.h
+++ b/enforcer/src/db/hsm_key.h
@@ -54,6 +54,8 @@ typedef enum hsm_key_role {
 } hsm_key_role_t;
 extern const db_enum_t hsm_key_enum_set_role[];
 
+#define HSM_KEY_ROLE_SEP(role) ((role) == HSM_KEY_ROLE_KSK || (role) == HSM_KEY_ROLE_CSK)
+
 typedef enum hsm_key_key_type {
     HSM_KEY_KEY_TYPE_INVALID = -1,
     HSM_KEY_KEY_TYPE_RSA = 1

--- a/enforcer/src/db/key_data.h
+++ b/enforcer/src/db/key_data.h
@@ -45,6 +45,8 @@ typedef enum key_data_role {
 } key_data_role_t;
 extern const db_enum_t key_data_enum_set_role[];
 
+#define KEY_DATA_ROLE_SEP(role) ((role) == KEY_DATA_ROLE_KSK || (role) == KEY_DATA_ROLE_CSK)
+
 typedef enum key_data_ds_at_parent {
     KEY_DATA_DS_AT_PARENT_INVALID = -1,
     KEY_DATA_DS_AT_PARENT_UNSUBMITTED = 0,

--- a/enforcer/src/enforcer/enforcer.c
+++ b/enforcer/src/enforcer/enforcer.c
@@ -2463,10 +2463,7 @@ updatePolicy(engine_type *engine, db_connection_t *dbconn, policy_t const *polic
 		 * Generate keytag for the new key and set it.
 		 */
 		err = hsm_keytag(hsm_key_locator(hsmkey), hsm_key_algorithm(hsmkey),
-			((hsm_key_role(hsmkey) == HSM_KEY_ROLE_KSK
-				|| hsm_key_role(hsmkey) == HSM_KEY_ROLE_CSK)
-				? 1 : 0),
-			&tag);
+			HSM_KEY_ROLE_SEP(hsm_key_role(hsmkey)), &tag);
 		if (err || key_data_set_keytag(mutkey, tag))
 		{
 			/* TODO: better log error */

--- a/enforcer/src/keystate/keystate_export_cmd.c
+++ b/enforcer/src/keystate/keystate_export_cmd.c
@@ -78,7 +78,7 @@ get_dnskey(const char *id, const char *zone, const char *keytype, int alg, uint3
     sign_params->algorithm = (ldns_algorithm) alg;
     sign_params->flags = LDNS_KEY_ZONE_KEY;
 
-    if (keytype && !strcasecmp(keytype, "KSK"))
+    if (keytype && (!strcasecmp(keytype, "KSK") || !strcasecmp(keytype, "CSK")))
         sign_params->flags = sign_params->flags | LDNS_KEY_SEP_KEY;
 		
     /* Get the DNSKEY record */

--- a/enforcer/src/keystate/keystate_import_cmd.c
+++ b/enforcer/src/keystate/keystate_import_cmd.c
@@ -172,7 +172,7 @@ perform_keydata_import(int sockfd, db_connection_t *dbconn,
         hsm_destroy_context(hsm_ctx);
         return -1;
     }
-    if (hsm_keytag(ckaid, alg, keytype == 1 ? 1 : 0, &tag)) {
+    if (hsm_keytag(ckaid, alg, KEY_DATA_ROLE_SEP(keytype), &tag)) {
         ods_log_error("[%s] Error: Keytag for this key %s is not correct", module_str, ckaid);
     }
 

--- a/enforcer/src/ods-migrate.c
+++ b/enforcer/src/ods-migrate.c
@@ -41,6 +41,7 @@
 #include "libhsm.h"
 #include "daemon/cfg.h"
 #include "libhsmdns.h"
+#include "db/key_data.h"
 extern hsm_repository_t* parse_conf_repositories(const char* cfgfile);
 
 int verbosity;
@@ -308,14 +309,14 @@ compute(char **argv, int* id, uint16_t* keytag)
 {
     char *locator;
     int algorithm;
-    int ksk;
+    int sep;
 
     *id = atoi(argv[0]);
     algorithm = atoi(argv[1]);
-    ksk = (atoi(argv[2]) == 1);
+    sep = KEY_DATA_ROLE_SEP(atoi(argv[2]));
     *keytag = atoi(argv[3]);
     locator = argv[4];
-    hsm_keytag(locator, algorithm, ksk, keytag);
+    hsm_keytag(locator, algorithm, sep, keytag);
     keytagcount += 1;
     
     return 0;

--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -3011,7 +3011,7 @@ hsm_sign_rrset(hsm_ctx_t *ctx,
 }
 
 int
-hsm_keytag(const char* loc, int alg, int ksk, uint16_t* keytag)
+hsm_keytag(const char* loc, int alg, int sep, uint16_t* keytag)
 {
 	uint16_t tag;
 	hsm_ctx_t *hsm_ctx;
@@ -3036,7 +3036,7 @@ hsm_keytag(const char* loc, int alg, int ksk, uint16_t* keytag)
 	sign_params->owner = ldns_rdf_new_frm_str(LDNS_RDF_TYPE_DNAME, "dummy");
 	sign_params->algorithm = (ldns_algorithm) alg;
 	sign_params->flags = LDNS_KEY_ZONE_KEY;
-	if (ksk)
+	if (sep)
 		sign_params->flags |= LDNS_KEY_SEP_KEY;
 
 	hsmkey = hsm_find_key_by_id(hsm_ctx, loc);

--- a/libhsm/src/lib/libhsmdns.h
+++ b/libhsm/src/lib/libhsmdns.h
@@ -99,10 +99,10 @@ hsm_get_dnskey(hsm_ctx_t *ctx,
  * Calculate keytag
  * @param loc: Locator of keydata on HSM
  * @param alg: Algorithm of key
- * @param ksk: 0 for zsk, positive int for ksk|csk
+ * @param sep: 0 for zsk, positive int for ksk|csk (DNSKEY Secure Entry Point)
  * @param[out] keytag: the calculated keytag
  * return: non-zero in case of failure
  */
-int hsm_keytag(const char* loc, int alg, int ksk, uint16_t* keytag);
+int hsm_keytag(const char* loc, int alg, int sep, uint16_t* keytag);
 
 #endif /* HSMDNS_H */


### PR DESCRIPTION
Fix key export for [SUPPORT-253](https://issues.opendnssec.org/browse/SUPPORT-253) by using the correct key flags.

Fix other key operations that use the wrong key flag for CSKs.