### PR TITLE
Log which zone isn't found in "zone not found" message.

### DIFF
--- a/signer/src/wire/query.c
+++ b/signer/src/wire/query.c
@@ -849,7 +849,12 @@ query_process(query_type* q, engine_type* engine)
     }
     pthread_mutex_unlock(&engine->zonelist->zl_lock);
     if (!q->zone) {
-        ods_log_debug("[%s] zone not found", query_str);
+	char *zn = ldns_rdf2str(ldns_rr_owner(rr));
+	if (zn) {
+            ods_log_debug("[%s] zone %s not found", query_str, zn);
+	} else {
+            ods_log_debug("[%s] zone (unknown?) not found", query_str);
+	}
         return query_servfail(q);
     }
     /* see if it is tsig signed */


### PR DESCRIPTION
This is so that the operator might discern between noise and
an actual configuration error or oversight.
