### PR TITLE
Fix automatic resalting after a migration from 1.4 in SQLite installation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+OpenDNSSEC 2.1.10 - T.B.D.
+* Fix immediate resalting after migration from 1.4
+* Emit warning on ods-kaspcheck for NSEC iteration count that is deemed too
+  high.
+
 OpenDNSSEC 2.1.9 - 2021-05-03
 
 * OPENDNSSEC-955: Prevent concurrency between C_Login/C_OpenSession and

--- a/enforcer/src/utils/kc_helper.c
+++ b/enforcer/src/utils/kc_helper.c
@@ -428,6 +428,7 @@ int check_policy(xmlNode *curNode, const char *policy_name, char **repo_list, in
 	int nsec = 0;
 	int resalt = 0;
 	int hash_algo = 0;
+	int hash_iters = 0;
         int find_alg = 0;
 	
 	enum {KSK = 1, ZSK, CSK};
@@ -511,7 +512,7 @@ int check_policy(xmlNode *curNode, const char *policy_name, char **repo_list, in
 							StrFree(temp_char);
 						} else if (xmlStrEqual(childNode2->name, (const xmlChar *)"Hash")) {
 							childNode3 = childNode2->children;
-							while (childNode3) {								
+							while (childNode3) {
 								if (xmlStrEqual(childNode3->name, (const xmlChar *)"Algorithm")) {
 									temp_char = (char *) xmlNodeGetContent(childNode3);
 									/* we know temp_char is a number */
@@ -521,6 +522,14 @@ int check_policy(xmlNode *curNode, const char *policy_name, char **repo_list, in
 											"in %s is %d but should be 1", policy_name,
 											kasp, hash_algo);
 										status++;
+									}
+									StrFree(temp_char);
+								} else if (xmlStrEqual(childNode3->name, (const xmlChar *)"Iterations")) {
+									temp_char = (char *) xmlNodeGetContent(childNode3);
+									/* we know temp_char is a number */
+									hash_iters = atoi(temp_char);
+									if (hash_iters > 100) {
+										dual_log("WARNING: NSEC3 Hash iterations for %s Policy in %s is %d which is larger than the recommended maximum of 100", policy_name, kasp, hash_iters);
 									}
 									StrFree(temp_char);
 								}

--- a/enforcer/utils/1.4-2.0_db_convert/sqlite_convert.sql
+++ b/enforcer/utils/1.4-2.0_db_convert/sqlite_convert.sql
@@ -222,17 +222,17 @@ SET denialSalt = (
 WHERE (
 	SELECT salt
 	FROM  REMOTE.policies
-	WHERE REMOTE.policies.id = policy.id) != null;
+	WHERE REMOTE.policies.id = policy.id) IS NOT NULL;
 
 UPDATE policy
 SET denialSaltLastChange = (
-	SELECT salt_stamp
+	SELECT strftime("%s",salt_stamp)
 	FROM  REMOTE.policies
 	WHERE REMOTE.policies.id = policy.id)
 WHERE (
 	SELECT salt_stamp
 	FROM  REMOTE.policies
-	WHERE REMOTE.policies.id = policy.id) != null;
+	WHERE REMOTE.policies.id = policy.id) IS NOT NULL;
 
 UPDATE policy
 SET keysTtl = (

--- a/version.m4
+++ b/version.m4
@@ -1,3 +1,3 @@
 # this file contains the current OpenDNSSEC version
 
-define([OPENDNSSEC_VERSION], [2.1.9])
+define([OPENDNSSEC_VERSION], [2.1.10rc1])


### PR DESCRIPTION
This only occurs when no explicit salt is specified.
This problem does not exist for MySQL installations.

Also included is a small warning for large NSEC3 iteration count.
