### PR TITLE
replace USE_ED25519/USE_ED448 constants with cpp macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,9 +142,6 @@ ACX_LIBC
 ACX_SSL
 ACX_CUNIT
 
-AC_DEFINE(USE_ED25519, 1, [Enable ldns ED25519 support])
-AC_DEFINE(USE_ED448, 1, [Enable ldns ED448 support])
-
 # cunit
 AM_CONDITIONAL([WITH_CUNIT], [test "${with_cunit}" != "no" -a -n "$CUNIT_LIBS"])
 

--- a/enforcer/src/hsmkey/hsm_key_factory.c
+++ b/enforcer/src/hsmkey/hsm_key_factory.c
@@ -264,10 +264,12 @@ hsm_key_factory_generate(engine_type* engine, const db_connection_t* connection,
             case LDNS_ECDSAP384SHA384:
                 key = hsm_generate_ecdsa_key(hsm_ctx, policy_key_repository(policy_key), "P-384");
                 break;
-#if (LDNS_REVISION >= ((1<<16)|(7<<8)|(0)))
+#if USE_ED25519
             case LDNS_ED25519:
                 key = hsm_generate_eddsa_key(hsm_ctx, policy_key_repository(policy_key), "edwards25519");
                 break;
+#endif
+#if USE_ED448
             case LDNS_ED448:
                 key = hsm_generate_eddsa_key(hsm_ctx, policy_key_repository(policy_key), "edwards448");
                 break;

--- a/libhsm/src/bin/hsmtest.c
+++ b/libhsm/src/bin/hsmtest.c
@@ -116,10 +116,14 @@ hsm_test (const char *repository, hsm_ctx_t* ctx)
         LDNS_ECDSAP256SHA256,
         LDNS_ECDSAP384SHA384
     };
-#if (LDNS_REVISION >= ((1<<16)|(7<<8)|(0)))
+#if USE_ED25519 || USE_ED448
     const ldns_algorithm ed_curves[] = {
+#if USE_ED25519
         LDNS_ED25519,
+#endif
+#if USE_ED448
         LDNS_ED448,
+#endif
     };
 #endif
     ldns_algorithm curve;
@@ -367,19 +371,23 @@ hsm_test (const char *repository, hsm_ctx_t* ctx)
         }
     }
 
-#if (LDNS_REVISION >= ((1<<16)|(7<<8)|(0)))
+#if USE_ED25519 || USE_ED448
     for (i=0; i<(sizeof(ed_curves)/sizeof(ldns_algorithm)); i++) {
         curve = ed_curves[i];
 
         switch(curve) {
+#if USE_ED25519
         case LDNS_ED25519:
             printf("Generating ED25519 key... ");
             key = hsm_generate_eddsa_key(ctx, repository, "edwards25519");
             break;
+#endif
+#if USE_ED448
          case LDNS_ED448:
             printf("Generating ED448 key... ");
             key = hsm_generate_eddsa_key(ctx, repository, "edwards448");
             break;
+#endif
         default:
             continue;
         }

--- a/libhsm/src/bin/hsmutil.c
+++ b/libhsm/src/bin/hsmutil.c
@@ -502,7 +502,7 @@ cmd_dnskey (int argc, char *argv[])
                 return -1;
             }
             break;
-#if (LDNS_REVISION >= ((1<<16)|(7<<8)|(0)))
+#if USE_ED25519
         case LDNS_SIGN_ED25519:
             if (strcmp(key_info->algorithm_name, "EDDSA") != 0) {
                 printf("Not an EDDSA key, the key is of algorithm %s.\n", key_info->algorithm_name);
@@ -521,6 +521,8 @@ cmd_dnskey (int argc, char *argv[])
                 return -1;
             }
             break;
+#endif
+#if USE_ED448
         case LDNS_SIGN_ED448:
             if (strcmp(key_info->algorithm_name, "EDDSA") != 0) {
                 printf("Not an EDDSA key, the key is of algorithm %s.\n", key_info->algorithm_name);

--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -2174,10 +2174,12 @@ hsm_sign_buffer(hsm_ctx_t *ctx,
                                             CKM_GOSTR3411, digest_len,
                                             sign_buf);
             break;
-#if (LDNS_REVISION >= ((1<<16)|(7<<8)|(0)))
+#if USE_ED25519
         case LDNS_SIGN_ED25519:
             data_direct = 1;
             break;
+#endif
+#if USE_ED448
         case LDNS_SIGN_ED448:
             data_direct = 1;
             break;

--- a/libhsm/src/lib/libhsm.h
+++ b/libhsm/src/lib/libhsm.h
@@ -29,6 +29,7 @@
 #define HSM_H 1
 
 #include <stdint.h>
+#include <ldns/common.h>
 #include <ldns/rbtree.h>
 #include <pthread.h>
 
@@ -75,6 +76,17 @@
 #define HSM_PIN_RETRY	1	/* Used when we failed to login the first time. */
 #define HSM_PIN_SAVE	2	/* The latest PIN can be saved for future use. Called
 				   after a successful login. */
+
+#if (LDNS_REVISION >= ((1<<16)|(8<<8)|(0)))
+#  define USE_ED25519 LDNS_BUILD_CONFIG_USE_ED25519
+#  define USE_ED448 LDNS_BUILD_CONFIG_USE_ED448
+#elif (LDNS_REVISION >= ((1<<16)|(7<<8)|(0)))
+#  define USE_ED25519 1
+#  define USE_ED448 1
+#else
+#  define USE_ED25519 0
+#  define USE_ED448 0
+#endif
 
 /*! HSM configuration */
 typedef struct {


### PR DESCRIPTION
Currently the autoconf input file hardcodes USE_ED25519 and USE_ED448 to 1, and actual use of Ed25519/Ed448 is gated on LDNS_REVISION checks. In ldns 1.8 this no longer works because the LDNS_SIGN_EDxxx constants are not provided unless ldns was built with support for them. i.e. without this or an alternative fix, opendnssec will not build at all on a system with ldns 1.8 that was not built with Ed support. 

This PR removes the hardcoded autoconf USE_EDxxx=1 and replaces them with plain preprocessor macros of the same name. For ldns 1.7.x they do the same as before. For 1.8 they use the new LDNS_BUILD_CONFIG_USE_EDxxx macros provided by ldns.

Fixes building opendnssec on OpenBSD with 1.8 (libressl of course has some Ed support, but it doesn't provide the full API from newer openssl yet, so ldns doesn't enable it).