### PR TITLE
Prevent failure due to fortified code

### DIFF
--- a/enforcer/src/hsmkey/hsm_key_factory.c
+++ b/enforcer/src/hsmkey/hsm_key_factory.c
@@ -835,21 +835,20 @@ hsm_key_factory_delete_key(const db_connection_t* connection)
 
     while((hsm_key = hsm_key_list_get_next(hsm_key_list))) {
 
-    key_data_t* key_data;
-    int count;
-    db_clause_list_t* lookup_clause_list;
-    if (!(lookup_clause_list = db_clause_list_new())
-        || !(key_data = key_data_new(connection))
-        || !key_data_hsm_key_id_clause(lookup_clause_list, hsm_key_id(hsm_key))
-        || key_data_count(key_data, lookup_clause_list, &count))
-    {
-        ods_log_debug("[hsm_key_factory_delete_key] unable to check usage of hsm_key, database or memory allocation error");
-        count = -1;
-    }
-    key_data_free(key_data);
-    db_clause_list_free(lookup_clause_list);
-    if(count != 0)
-        continue;
+        key_data_t* key_data;
+        int numhsmkeys;
+        db_clause_list_t* lookup_clause_list;
+        if(!(lookup_clause_list = db_clause_list_new())
+                || !(key_data = key_data_new(connection))
+                || !key_data_hsm_key_id_clause(lookup_clause_list, hsm_key_id(hsm_key))
+                || key_data_count(key_data, lookup_clause_list, &numhsmkeys)) {
+            ods_log_debug("[hsm_key_factory_delete_key] unable to check usage of hsm_key, database or memory allocation error");
+            numhsmkeys = -1;
+        }
+        key_data_free(key_data);
+        db_clause_list_free(lookup_clause_list);
+        if(numhsmkeys != 0)
+            continue;
 
         hsmkey = hsm_find_key_by_id(hsm_ctx, hsm_key_locator(hsm_key));
         if(hsm_remove_key(hsm_ctx, hsmkey)) {

--- a/version.m4
+++ b/version.m4
@@ -1,3 +1,3 @@
 # this file contains the current OpenDNSSEC version
 
-define([OPENDNSSEC_VERSION], [2.1.11-rc3])
+define([OPENDNSSEC_VERSION], [2.1.11])


### PR DESCRIPTION
- degrade error to warning that update failed.  Althrough this is an … error, the action will be retried and succeed next run.
- incorrect calculated number of deleted keys
- upon deleted keys from hsm, restart update zone action as this might conflict with current action.