### PR TITLE
Pass right remaining buffer size in hsm_hex_unparse to handle string …

### DIFF
--- a/libhsm/src/lib/libhsm.c
+++ b/libhsm/src/lib/libhsm.c
@@ -1382,7 +1382,7 @@ hsm_hex_unparse(char *dst, const unsigned char *src, size_t len)
     size_t i;
 
     for (i = 0; i < len; i++) {
-        snprintf(dst + (2*i), dst_len, "%02x", src[i]);
+        snprintf(dst + (2*i), dst_len - (2*i), "%02x", src[i]);
     }
     dst[len*2] = '\0';
 }


### PR DESCRIPTION
…fortification

When string fortification is in use (-DFORTIFY_SOURCE=3), GCC and glibc will cut few bytes off the string buffer for prevention of buffer overruns. As a result, hsm_hex_unparse() will call into snprintf() with a buffer length bigger than the size of the buffer as seen by the GCC/glibc pair.

See also: https://pagure.io/freeipa/issue/9312

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>