### PR TITLE
m4/acx_broken_setres.m4: Improve compatibility with C99

### DIFF
--- a/m4/acx_broken_setres.m4
+++ b/m4/acx_broken_setres.m4
@@ -4,6 +4,7 @@ AC_DEFUN([ACX_BROKEN_SETRES],[
 		AC_MSG_CHECKING(if setresuid seems to work)
 		AC_RUN_IFELSE(
 			[AC_LANG_SOURCE([[
+#include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
 int main(){errno=0; setresuid(0,0,0); if (errno==ENOSYS) exit(1); else exit(0);}
@@ -20,6 +21,7 @@ int main(){errno=0; setresuid(0,0,0); if (errno==ENOSYS) exit(1); else exit(0);}
 		AC_MSG_CHECKING(if setresgid seems to work)
 		AC_RUN_IFELSE(
 			[AC_LANG_SOURCE([[
+#include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
 int main(){errno=0; setresgid(0,0,0); if (errno==ENOSYS) exit(1); else exit(0);}


### PR DESCRIPTION
Include <unistd.h> for the setresuid and setresgid functions, to avoid an implicit function declaration.

This is necessary to avoid build errors with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
