### PR TITLE
tests: Mark data as string literals

### DIFF
--- a/enforcer/src/db/test/test.sqlite
+++ b/enforcer/src/db/test/test.sqlite
@@ -28,11 +28,11 @@ CREATE TABLE test (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name VARCHAR(255)
 );
-INSERT INTO test ( name ) VALUES ( "test" );
+INSERT INTO test ( name ) VALUES ( 'test' );
 
 CREATE TABLE test2 (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     rev INTEGER NOT NULL,
     name VARCHAR(255)
 );
-INSERT INTO test2 ( rev, name ) VALUES ( 1, "test" );
+INSERT INTO test2 ( rev, name ) VALUES ( 1, 'test' );


### PR DESCRIPTION
As of sqlite3 2023-02-21 (3.41.0):
> The double-quoted string misfeature is now disabled by default for CLI
  builds

See https://www.sqlite.org/quirks.html#dblquote for details.

This led to tests failure:
```console
[user@host dir]$ make check
...
sqlite3 test.db < ./test.sqlite
Parse error near line 31: no such column: test
  INSERT INTO test ( name ) VALUES ( "test" );
                       error here ---^
Parse error near line 38: no such column: test
  INSERT INTO test2 ( rev, name ) VALUES ( 1, "test" );
                                error here ---^
make[3]: *** [Makefile:843: regress-db] Error 1
```