### PR TITLE
backup_hsmkeys_cmd: Fix argument handling 

### DIFF
--- a/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
+++ b/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
@@ -210,8 +210,9 @@ run(cmdhandler_ctx_type* context, int argc, char* argv[])
         {0, 0, 0, 0}
     };
 
-    for(opt = longgetopt(argc, argv, "r:", long_options, &long_index, &optctx); opt != -1;
-        opt = longgetopt(argc, argv, NULL, long_options, &long_index, &optctx)) {
+    /* Note: longgetopt reorders argv, only pass args after "backup" "prepare|commit|..." to it. */
+    for(opt = longgetopt(argc-2, argv+2, "r:", long_options, &long_index, &optctx); opt != -1;
+        opt = longgetopt(argc-2, argv+2, NULL, long_options, &long_index, &optctx)) {
         switch (opt) {
             case 'r':
                 repository = optctx.optarg;

--- a/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
+++ b/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
@@ -199,6 +199,12 @@ run(cmdhandler_ctx_type* context, int argc, char* argv[])
     db_clause_list_t* clause_list;
     db_connection_t* dbconn = getconnectioncontext(context);
 
+    if (argc < 2) {
+        client_printf_err(sockfd, "too few arguments\n");
+        ods_log_error("[%s] too few arguments for backup command", module_str);
+        return -1;
+    }
+
     static struct option long_options[] = {
         {"repository", required_argument, 0, 'r'},
         {0, 0, 0, 0}


### PR DESCRIPTION
This PR fixes two regressions in the OpenDNSSEC 2.1.13 release affecting the `ods-enforcer backup` command:
1. Running `ods-enforcer backup` without a subcommand like `list` following, the enforcer daemon crashes.
2. The `-r`/`--repository` option for the `ods-enforcer backup` subcommands no longer worked and behaved like an unknown command was called.

For details why this happened and the fix, please check the individual commit messages.

Note: there seems to be another regression in the 2.1.13 release where returning `-1` from the command's `run()` function no longer causes the usage to be printed, which is not addressed by this PR (see #848 for that) resulting in the error cases still producing unhelpful output.