### PR TITLE
cmdhandler: show usage when runarg/runargs returns an error

### DIFF
--- a/common/cmdhandler.c
+++ b/common/cmdhandler.c
@@ -210,6 +210,15 @@ cmdhandler_perform_command(const char *arg, struct cmdhandler_ctx_struct* contex
             }
             free(buf);
         }
+        if (status == -1) {
+            /* Syntax error, print usage for cmd */
+            client_printf_err(context->sockfd, "Error parsing arguments %s command line %s\n",
+                command->name, arg);
+            if (command->usage != NULL) {
+                client_printf(context->sockfd, "Usage:\n\n");
+                command->usage(context->sockfd);
+            }
+        }
     } else {
         client_printf_err(context->sockfd, "Unknown command %s\n", argv[argi]);
         /* Unhandled command, print general error */


### PR DESCRIPTION
There's a regression in OpenDNSSEC 2.1.13 where `ods-enforcer` commands no longer show their usage when called with invalid arguments, see the examples below. This was changed by 7d4dfa2ea62cd0db57d51f870ad9210b16dbe0ae from #845. This PR restores the previous behavior.

The return value of runarg and runargs is documented in the struct definition as follows, so it's useful to show the usage in that situation:

> -1 Errors parsing commandline / missing params

https://github.com/opendnssec/opendnssec/blob/cce8d02042b4d1d0780f2a623d8da779d275cbc3/common/cmdhandler.h#L60-L72

### OpenDNSSEC 2.1.12

```console
$ ods-enforcer rollover list --invalid
unknown arguments
Error parsing arguments rollover list command line rollover list --invalid
Usage:

rollover list
    [--zone <zone>]             aka -z
```

### OpenDNSSEC 2.1.13 (unpatched)

```console
$ ods-enforcer rollover list --invalid
unknown arguments
```

### OpenDNSSEC 2.1.13 with this patch

```console
$ ods-enforcer rollover list --invalid
unknown arguments
Error parsing arguments rollover list command line rollover list --invalid
Usage:

rollover list
    [--zone <zone>]             aka -z
```

**Note:** I'm not exactly sure what `statusstr` is intended to do, but maybe the existing `if (status == -1)` in the `command->runarg()` case right above my change should be merged into the `if` I added.