### PR TITLE
SUPPORT-278: concurrency problem resulting in "[hsm] hsm_get_dnskey(): Got NULL key"

### DIFF
--- a/signer/src/hsm.c
+++ b/signer/src/hsm.c
@@ -33,6 +33,10 @@
 #include "hsm.h"
 #include "log.h"
 
+#include <pthread.h>
+
+pthread_mutex_t _hsm_get_dnskey_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 static const char* hsm_str = "hsm";
 
 /**
@@ -108,7 +112,9 @@ llibhsm_key_start:
 
     /* get dnskey */
     if (!key_id->dnskey) {
+        pthread_mutex_lock(&_hsm_get_dnskey_mutex);
         key_id->dnskey = hsm_get_dnskey(ctx, keylookup(ctx, key_id->locator), key_id->params);
+        pthread_mutex_unlock(&_hsm_get_dnskey_mutex);
     }
     if (!key_id->dnskey) {
         error = hsm_get_error(ctx);


### PR DESCRIPTION
This patch fixes SUPPORT-278, https://issues.opendnssec.org/browse/SUPPORT-278.

See also:

https://lists.opendnssec.org/pipermail/opendnssec-user/2023-April/004730.html
https://lists.opendnssec.org/pipermail/opendnssec-user/2022-June/004702.html
https://lists.opendnssec.org/pipermail/opendnssec-user/2021-August/004690.html
https://lists.opendnssec.org/pipermail/opendnssec-user/2021-May/004655.html
https://lists.opendnssec.org/pipermail/opendnssec-user/2020-September/004533.html
https://lists.opendnssec.org/pipermail/opendnssec-user/2019-February/004317.html
https://lists.opendnssec.org/pipermail/opendnssec-user/2018-June/004259.html