### PR TITLE
 SUPPORT-291: Wrong inception time in keyData after migration

### DIFF
--- a/enforcer/utils/1.4-2.0_db_convert/mysql_convert.sql
+++ b/enforcer/utils/1.4-2.0_db_convert/mysql_convert.sql
@@ -541,7 +541,7 @@ SELECT
 	NULL, 1, REMOTE.dnsseckeys.zone_id,
 	REMOTE.dnsseckeys.keypair_id, REMOTE.keypairs.algorithm,
 	CASE WHEN REMOTE.dnsseckeys.publish IS NOT NULL THEN
-		UNIX_TIMESTAMP(REMOTE.dnsseckeys.publish)
+		UNIX_TIMESTAMP( (SELECT REMOTE.keypairs.generate WHERE REMOTE.keypairs.id=REMOTE.dnsseckeys.keypair_id) ) 
 		ELSE UNIX_TIMESTAMP() END,
 	(~REMOTE.dnsseckeys.keytype&1)+1,
 	REMOTE.dnsseckeys.state <= 4, -- introducing


### PR DESCRIPTION
SUPPORT-291, https://issues.opendnssec.org/browse/SUPPORT-291

During migration from 1.4 MySQL database to 2.1.x, a conversion script with associated SQL in /usr/share/opendnssec/migration/1.4-2.0_db_convert/mysql_convert.sql creates new db structure TABLE keyData.

The table has field 'inception', which in 1.4 parlance is 'generate', i.e. the time when the key was born into existence.

The migration script incorrectly uses 'dnsseckeys.publish' and not 'keypairs.generate' when populating TABLE keyData, so a time-wise logical impossibility ensues.

This is a problem (at least) when ZSKs autoroll. New key is taken from HSM and becomes 'ready' and old key becomes 'retire'. However, nothing happens after that and the zone ends up with both keys, and both keys are used for signing, i.e. double signature. DNS will not break, but it's an annoyance and I believe it doubles the reply size. The situation can possibly be resolved doing manual 'sudo -u ods ods-enforcer key rollover -t ZSK -p ...' or similar, but it is annoying nonetheless.

This patch fixes the issue.