### PR TITLE
Fix implicit function declarations

### DIFF
--- a/enforcer/src/utils/kaspcheck.c
+++ b/enforcer/src/utils/kaspcheck.c
@@ -26,6 +26,7 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <getopt.h>
+#include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
 

--- a/enforcer/src/utils/kc_helper.c
+++ b/enforcer/src/utils/kc_helper.c
@@ -27,6 +27,7 @@
 #include <syslog.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <errno.h>


### PR DESCRIPTION
Discovered in Fedora rawhide with https://fedoraproject.org/wiki/Changes/PortingToModernC

utils/kaspcheck.c:101:33: error: implicit declaration of function ‘exit’
utils/kaspcheck.c:136:17: error: implicit declaration of function ‘free’
utils/kc_helper.c:47:40: error: implicit declaration of function ‘free’
utils/kc_helper.c:519:85: error: implicit declaration of function ‘atoi’
utils/kc_helper.c:569:83: error: implicit declaration of function ‘malloc’
utils/kc_helper.c:1122:28: error: implicit declaration of function ‘strtol’
utils/kc_helper.c:1274:25: error: implicit declaration of function ‘exit’
utils/kc_helper.c:1375:21: error: implicit declaration of function ‘calloc’
