### PR TITLE
OPENDNSSEC-964: No keys exported when exporting all keys with mysql back-end

### DIFF
--- a/enforcer/src/db/db_backend_mysql.c
+++ b/enforcer/src/db/db_backend_mysql.c
@@ -945,9 +945,6 @@ static int __db_backend_mysql_bind_clause(db_backend_mysql_bind_t** bind, const 
     if (!bind) {
         return DB_ERROR_UNKNOWN;
     }
-    if (!*bind) {
-        return DB_ERROR_UNKNOWN;
-    }
     if (!clause_list) {
         return DB_ERROR_UNKNOWN;
     }


### PR DESCRIPTION
When a query is submitted without parameters, because there are non using this particular call, it is not necessary to verify the existence of a parameter list. Within the subsequent while loop, when trying to fill parameters, this check is done already.  Which is the proper place as at that time there indeed should be parameters.