### PR TITLE
Fix ods-enforcer backup -r usage

### DIFF
--- a/common/longgetopt.c
+++ b/common/longgetopt.c
@@ -142,7 +142,7 @@ longgetopt(int argc, char** argv, const char* optstring, const struct option* lo
             context->_permute = 0;
         if(optstring[0] == '+') {
             context->_permute = 0;
-            context->_optstring = (optstring[0] == '\0' ? optstring : &optstring[1]);
+            context->_optstring = &optstring[1];
         } else
             context->_optstring = optstring;
         context->_optarray = longopts;

--- a/common/longgetopt.h
+++ b/common/longgetopt.h
@@ -8,6 +8,15 @@ struct option
   int *flag;
   int val;
 };
+# ifndef  no_argument
+#  define no_argument 0
+# endif
+# ifndef  required_argument
+#  define required_argument 1
+# endif
+# ifndef  optional_argument
+#  define optional_argument 2
+# endif
 #endif
 
 struct longgetopt {

--- a/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
+++ b/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
@@ -216,6 +216,8 @@ run(cmdhandler_ctx_type* context, int argc, char* argv[])
                 return -1;
         }
     }
+    argv += optctx.optind;
+    argc -= optctx.optind;
 
     /* iterate the keys */
     if (!(clause_list = db_clause_list_new())) {
@@ -229,7 +231,7 @@ run(cmdhandler_ctx_type* context, int argc, char* argv[])
     }
     
     /* Find out what we need to do */
-    if (argc < 2) {
+    if (argc != 2) {
         client_printf_err(sockfd, "Usage:\n\nbackup [list|prepare|commit|rollback]\n   --repository <repository>                    aka -r\n\n");
         status = -1;
     } else if (ods_check_command(argv[1],"prepare"))


### PR DESCRIPTION
Reposition argv and argc after longgetopt usage in order to correctly act upon the subcommand.

As pointed out by @subbink