### PR TITLE
`ods-enforcer backup` has only one subcommand

### DIFF
--- a/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
+++ b/enforcer/src/hsmkey/backup_hsmkeys_cmd.c
@@ -231,7 +231,7 @@ run(cmdhandler_ctx_type* context, int argc, char* argv[])
     }
     
     /* Find out what we need to do */
-    if (argc < 2) {
+    if (argc != 2) {
         client_printf_err(sockfd, "Usage:\n\nbackup [list|prepare|commit|rollback]\n   --repository <repository>                    aka -r\n\n");
         status = -1;
     } else if (ods_check_command(argv[1],"prepare"))


### PR DESCRIPTION
The code allowed for more than one argument after the first and only to be processed subcommend. Those excess arguments would just be ignored.
This fix has that corrected so that only a single subcommand is allowed and any excess arguments will result in an error.

**Note!** The base for this PR is the [2.1/bugfix/ods-enforcer-backup-options](https://github.com/opendnssec/opendnssec/tree/2.1/bugfix/ods-enforcer-backup-options) branch for which there is PR #858 .
This PR should be merged before PR #858 in order for this fix to make it to the [2.1/develop](https://github.com/opendnssec/opendnssec/tree/2.1/develop) branch.