### PR TITLE
Fix portability of `struct option` and friends

### DIFF
--- a/common/longgetopt.h
+++ b/common/longgetopt.h
@@ -8,6 +8,15 @@ struct option
   int *flag;
   int val;
 };
+# ifndef  no_argument
+#  define no_argument 0
+# endif
+# ifndef  required_argument
+#  define required_argument 1
+# endif
+# ifndef  optional_argument
+#  define optional_argument 2
+# endif
 #endif
 
 struct longgetopt {


### PR DESCRIPTION
`struct option` is a companion of the `getopt_long()` function, and is repurposed for the functional equivalent `longgetopt()` function. An integral part of the `struct option` definition are the possible values of its `has_arg` struct member. If `struct option` needs to be defined, because it was detected during configure that `getopt_long()` is not available, then also the valuees of the `has_arg` struct member need to be defined.

Please see [the man page for `getopt_long()`](https://man.freebsd.org/cgi/man.cgi?getopt_long(3)) to confirm that `no_argument`, `required_argument` and `optional_argument` are required for proper usage of `struct option` with `getopt_long()`, and because `longgetopt()` is functionally equivalent with `getopt_long()`, also with our custom `longgetopt()`

**Note!** The first BSD implementation of `getopt_long()` appeared in NetBSD 1.5, the first BSD implementation of `getopt_long_only()` in OpenBSD 3.3. FreeBSD first included `getopt_long()` in FreeBSD 5.0.

**Note!** This does not change behavior of `longgetopt()` function at all. It only fixes to enable compilation of OpenDNSSEC on systems that did not have `getopt_long()` (see previous note for an overview of what those systems may be)