### PR TITLE
Remove futile condition

### DIFF
--- a/common/longgetopt.c
+++ b/common/longgetopt.c
@@ -142,7 +142,7 @@ longgetopt(int argc, char** argv, const char* optstring, const struct option* lo
             context->_permute = 0;
         if(optstring[0] == '+') {
             context->_permute = 0;
-            context->_optstring = (optstring[0] == '\0' ? optstring : &optstring[1]);
+            context->_optstring = &optstring[1];
         } else
             context->_optstring = optstring;
         context->_optarray = longopts;


### PR DESCRIPTION
`optstring[0]` is never `'\0'` on this path where `optstring[0]` was already established to be `'+'`.

**Note!**: Since this code didn't do anything in the first place, it has no impact on `longgetopt()` usage by the OpenDNSSEC code base and is therefore safe to merge.