### PR TITLE
WORK-IN-PROGRESS Implementation of ZoneMD

### DIFF
--- a/common/scheduler/schedule.c
+++ b/common/scheduler/schedule.c
@@ -468,6 +468,25 @@ schedule_pop_task(schedule_type* schedule)
 }
 
 task_type*
+schedule_pop_task_nowait(schedule_type* schedule)
+{
+    time_t timeout, now = time_now();
+    task_type* task;
+
+    pthread_mutex_lock(&schedule->schedule_lock);
+    task = schedule_get_first_task(schedule);
+    if(task) {
+        if(task->due_date <= now) {
+            ods_log_debug("[%s] pop task for zone %s", schedule_str, task->owner);
+            task = unschedule_task(schedule, task);
+        } else
+            task = NULL;
+    }
+    pthread_mutex_unlock(&schedule->schedule_lock);
+    return task;
+}
+
+task_type*
 schedule_pop_first_task(schedule_type* schedule)
 {
     task_type *task;

--- a/common/scheduler/schedule.c
+++ b/common/scheduler/schedule.c
@@ -471,6 +471,25 @@ schedule_pop_task(schedule_type* schedule)
 }
 
 task_type*
+schedule_pop_task_nowait(schedule_type* schedule)
+{
+    time_t timeout, now = time_now();
+    task_type* task;
+
+    pthread_mutex_lock(&schedule->schedule_lock);
+    task = schedule_get_first_task(schedule);
+    if(task) {
+        if(task->due_date <= now) {
+            ods_log_debug("[%s] pop task for zone %s", schedule_str, task->owner);
+            task = unschedule_task(schedule, task);
+        } else
+            task = NULL;
+    }
+    pthread_mutex_unlock(&schedule->schedule_lock);
+    return task;
+}
+
+task_type*
 schedule_pop_first_task(schedule_type* schedule)
 {
     task_type *task;

--- a/common/scheduler/schedule.h
+++ b/common/scheduler/schedule.h
@@ -135,10 +135,20 @@ void schedule_unscheduletask(schedule_type* schedule, task_id task, const char* 
  * NULL when the caller is awoken. 
  *
  * \param[in] schedule schedule
+ * \return task_type* popped task, or NULL when no task available
+                      */
+task_type* schedule_pop_task(schedule_type* schedule);
+
+/**
+ * Pop the first scheduled task that is due. If an item is directly
+ * available it will be returned, in case there is no task NULL
+ * is returned.
+ *
+ * \param[in] schedule schedule
  * \return task_type* popped task, or NULL when no task available or
  * no task due
  */
-task_type* schedule_pop_task(schedule_type* schedule);
+task_type* schedule_pop_task_nowait(schedule_type* schedule);
 
 /**
  * Pop the first scheduled task. regardless of its due time.

--- a/conf/kasp.rnc
+++ b/conf/kasp.rnc
@@ -121,6 +121,9 @@ start = element KASP {
 		},
 
 		element Zone {
+			# Add or update ZoneMD scheme
+			element ZoneMD { attribute algorithm { xsd:nonNegativeInteger } }*,
+
 			# Expected propagation delay in child publication
 			propagationdelay,
 

--- a/conf/signconf.rnc
+++ b/conf/signconf.rnc
@@ -35,6 +35,9 @@ zone = element Zone {
 		# Do not touch contents of zonefile.
 		& element Passthrough { empty }?
 
+		# Add or update ZoneMD scheme
+		& element ZoneMD { attribute algorithm { xsd:nonNegativeInteger } }*
+
 		# this section is taken directly from the corresponding KASP policy
 		& element Signatures {
 			element Resign { xsd:duration }

--- a/enforcer/src/db/policy.c
+++ b/enforcer/src/db/policy.c
@@ -700,7 +700,7 @@ int policy_copy(policy_t* policy, const policy_t* policy_copy) {
     policy->parent_ds_ttl = policy_copy->parent_ds_ttl;
     policy->parent_soa_ttl = policy_copy->parent_soa_ttl;
     policy->parent_soa_minimum = policy_copy->parent_soa_minimum;
-    policy->passthrough = policy_copy->passthrough;
+    policy->zonemodus = policy_copy->zonemodus;
     return DB_OK;
 }
 
@@ -768,7 +768,7 @@ int policy_from_result(policy_t* policy, const db_result_t* result) {
         || db_value_to_uint32(db_value_set_at(value_set, 32), &(policy->parent_ds_ttl))
         || db_value_to_uint32(db_value_set_at(value_set, 33), &(policy->parent_soa_ttl))
         || db_value_to_uint32(db_value_set_at(value_set, 34), &(policy->parent_soa_minimum))
-        || db_value_to_uint32(db_value_set_at(value_set, 35), &(policy->passthrough)))
+        || db_value_to_uint32(db_value_set_at(value_set, 35), &(policy->zonemodus)))
     {
         return DB_ERROR_UNKNOWN;
     }
@@ -1087,7 +1087,7 @@ unsigned int policy_passthrough(const policy_t* policy) {
         return 0;
     }
 
-    return policy->passthrough;
+    return policy->zonemodus;
 }
 
 zone_list_db_t* policy_zone_list(policy_t* policy) {
@@ -1532,7 +1532,7 @@ int policy_set_passthrough(policy_t* policy, unsigned int passthrough) {
         return DB_ERROR_UNKNOWN;
     }
 
-    policy->passthrough = passthrough;
+    policy->zonemodus = passthrough;
 
     return DB_OK;
 }
@@ -1971,7 +1971,7 @@ int policy_create(policy_t* policy) {
         || db_value_from_uint32(db_value_set_get(value_set, 30), policy->parent_ds_ttl)
         || db_value_from_uint32(db_value_set_get(value_set, 31), policy->parent_soa_ttl)
         || db_value_from_uint32(db_value_set_get(value_set, 32), policy->parent_soa_minimum)
-        || db_value_from_uint32(db_value_set_get(value_set, 33), policy->passthrough))
+        || db_value_from_uint32(db_value_set_get(value_set, 33), policy->zonemodus))
     {
         db_value_set_free(value_set);
         db_object_field_list_free(object_field_list);
@@ -2522,7 +2522,7 @@ int policy_update(policy_t* policy) {
         || db_value_from_uint32(db_value_set_get(value_set, 30), policy->parent_ds_ttl)
         || db_value_from_uint32(db_value_set_get(value_set, 31), policy->parent_soa_ttl)
         || db_value_from_uint32(db_value_set_get(value_set, 32), policy->parent_soa_minimum)
-        || db_value_from_uint32(db_value_set_get(value_set, 33), policy->passthrough))
+        || db_value_from_uint32(db_value_set_get(value_set, 33), policy->zonemodus))
     {
         db_value_set_free(value_set);
         db_object_field_list_free(object_field_list);

--- a/enforcer/src/db/policy.h
+++ b/enforcer/src/db/policy.h
@@ -62,9 +62,7 @@ struct policy {
     db_value_t id;
     db_value_t rev;
     char* name;
-    /* if passthrough set, no modifications to the zonefile should
-     * be made. I.e. No signatures added or removed */
-    unsigned int passthrough;
+    unsigned int zonemodus;
     char* description;
     unsigned int signatures_resign;
     unsigned int signatures_refresh;

--- a/enforcer/src/db/policy_ext.c
+++ b/enforcer/src/db/policy_ext.c
@@ -130,7 +130,7 @@ static int __xmlNode2policy(policy_t* policy, xmlNodePtr policy_node, int* updat
             }
         }
         else if (!strcmp((char*)node->name, "Passthrough")) {
-            passthrough = 1;
+            passthrough |= 0x01;
         }
         else if (!strcmp((char*)node->name, "Signatures")) {
             for (node2 = node->children; node2; node2 = node2->next) {
@@ -785,7 +785,6 @@ static int __xmlNode2policy(policy_t* policy, xmlNodePtr policy_node, int* updat
                 if (node2->type != XML_ELEMENT_NODE) {
                     continue;
                 }
-
                 if (!strcmp((char*)node2->name, "PropagationDelay")) {
                     if (!(xml_text = xmlNodeGetContent(node2))) {
                         return DB_ERROR_UNKNOWN;
@@ -914,6 +913,19 @@ static int __xmlNode2policy(policy_t* policy, xmlNodePtr policy_node, int* updat
                             ods_log_deeebug("[policy_*_from_xml] unknown %s", (char*)node3->name);
                             return DB_ERROR_UNKNOWN;
                         }
+                    }
+                }
+                else if (!strcmp((char*)node2->name, "ZoneMD")) {
+                    if (!(xml_text = xmlGetProp(node2, (xmlChar*)"algorithm"))) {
+                        passthrough |= 0x02;
+                    } else {
+                        if(atoi((char*)xml_text) == 2) {
+                            passthrough |= 0x04;
+                        } else {
+                            passthrough |= 0x02;
+                        }
+                        xmlFree(xml_text);
+                        xml_text = NULL;
                     }
                 }
                 else {
@@ -1201,8 +1213,6 @@ static int __xmlNode2policy(policy_t* policy, xmlNodePtr policy_node, int* updat
     }
     /* Check if passtrough has toggled */
     if (passthrough != policy_passthrough(policy)) {
-        ods_log_deeebug("[policy_*_from_xml] - passthrough set to %d",
-            passthrough);
         if (check_if_updated)
             *updated = 1;
         if (policy_set_passthrough(policy, passthrough)) {

--- a/enforcer/src/enforcer/enforce_task.c
+++ b/enforcer/src/enforcer/enforce_task.c
@@ -78,7 +78,7 @@ perform_enforce(int sockfd, engine_type *engine, char const *zonename,
 		return -1;
 	}
 
-	if (policy_passthrough(policy)) {
+	if (policy_passthrough(policy) & 0x01) {
 		ods_log_info("Passing through zone %s.\n", zone_db_name(zone));
 		bSignerConfNeedsWriting = 1;
 		t_next = schedule_SUCCESS;

--- a/enforcer/src/policy/policy_resalt_task.c
+++ b/enforcer/src/policy/policy_resalt_task.c
@@ -120,7 +120,7 @@ performresalt(task_type* task, char const *policyname, void *userdata,
 	}
 
 	if  (policy_denial_type(policy) != POLICY_DENIAL_TYPE_NSEC3
-		|| policy_passthrough(policy))
+		|| policy_passthrough(policy) & 0x01)
 	{
 		policy_free(policy);
 		return schedule_SUCCESS;

--- a/enforcer/src/policy/policy_resalt_task.c
+++ b/enforcer/src/policy/policy_resalt_task.c
@@ -121,7 +121,7 @@ perform_policy_resalt(task_type* task, char const *policyname, void *userdata,
 	}
 
 	if  (policy_denial_type(policy) != POLICY_DENIAL_TYPE_NSEC3
-		|| policy_passthrough(policy))
+		|| policy_passthrough(policy) & 0x01)
 	{
 		policy_free(policy);
 		return schedule_SUCCESS;

--- a/enforcer/src/signconf/signconf_xml.c
+++ b/enforcer/src/signconf/signconf_xml.c
@@ -213,8 +213,10 @@ static int signconf_xml_export(int sockfd, const policy_t* policy, zone_db_t* zo
     error = 1;
     if (!xmlNewProp(node, (xmlChar*)"name", (xmlChar*)zone_db_name(zone))
         || !(error = 26)
-        || (policy_passthrough(policy) && !(node2 = xmlNewChild(node, NULL, (xmlChar*)"Passthrough", NULL)))
+        || ((policy_passthrough(policy)&0x01) && !(node2 = xmlNewChild(node, NULL, (xmlChar*)"Passthrough", NULL)))
         || !(error = 2)
+        || ((policy_passthrough(policy)&0x02) && !((node2 = xmlNewChild(node, NULL, (xmlChar*)"ZoneMD", NULL)) && xmlNewProp(node2,(xmlChar*)"algorithm",(xmlChar*)"1")))
+        || ((policy_passthrough(policy)&0x04) && !((node2 = xmlNewChild(node, NULL, (xmlChar*)"ZoneMD", NULL)) && xmlNewProp(node2,(xmlChar*)"algorithm",(xmlChar*)"2")))
         || !(node2 = xmlNewChild(node, NULL, (xmlChar*)"Signatures", NULL))
         || !(error = 3)
         || duration_set_time(duration, policy_signatures_resign(policy))

--- a/signer/src/daemon/engine.c
+++ b/signer/src/daemon/engine.c
@@ -290,7 +290,6 @@ engine_stop_threads(engine_type* engine)
 void
 engine_wakeup_workers(engine_type* engine)
 {
-    size_t i = 0;
     ods_log_assert(engine);
     ods_log_assert(engine->config);
     ods_log_debug("[%s] wake up workers", engine_str);
@@ -337,7 +336,6 @@ engine_setup(void)
     int sockets[2] = {0,0};
     int pipefd[2];
     char buff = '\0';
-    int fd, error;
 
     ods_log_debug("[%s] setup signer engine", engine_str);
     if (!engine || !engine->config) {
@@ -480,27 +478,49 @@ engine_setup(void)
 static void
 engine_run(engine_type* engine)
 {
-    if (!engine) {
-        return;
-    }
-    engine_start_workers(engine);
-
-    while (!engine->need_to_exit && !engine->need_to_reload) {
-        /* We must use locking here to avoid race conditions. We want
-         * to sleep indefinitely and want to wake up on signal. This
-         * is to make sure we never mis the signal. */
-        pthread_mutex_lock(&engine->signal_lock);
-        if (!engine->need_to_exit && !engine->need_to_reload) {
-            /* TODO: this silly. We should be handling the commandhandler
-             * connections. No reason to spawn that as a thread.
-             * Also it would be easier to wake up the command hander
-             * as signals will reach it if it is the main thread! */
-            ods_log_debug("[%s] taking a break", engine_str);
-            pthread_cond_wait(&engine->signal_cond, &engine->signal_lock);
+    if (engine->config->num_worker_threads == 0) {
+        task_type* task;
+        worker_type singleworker;
+        struct worker_context singleworkercontext;
+        engine_start_workers(engine);
+        singleworker.context = &singleworkercontext;
+        singleworker.name = "single";
+        singleworker.need_to_exit = 0;
+        singleworker.taskq = engine->taskq;
+        singleworker.thread_id = 0;
+        singleworker.tasksOutstanding = 0;
+        singleworker.tasksFailed = 0;
+        pthread_cond_init(&singleworker.tasksBlocker, NULL);
+        singleworkercontext.engine = engine;
+        singleworkercontext.worker = &singleworker;
+        singleworkercontext.signq  = engine->taskq->signq;
+        do {
+            task = schedule_pop_task_nowait(engine->taskq);
+            if(task) {
+                task_perform(engine->taskq, task, &singleworkercontext);
+            }
+        } while(task && !engine->need_to_reload);
+        if(!task)
+            engine->need_to_exit = 1;
+    } else {
+        engine_start_workers(engine);
+        while (!engine->need_to_exit && !engine->need_to_reload) {
+            /* We must use locking here to avoid race conditions. We want
+             * to sleep indefinitely and want to wake up on signal. This
+             * is to make sure we never mis the signal. */
+            pthread_mutex_lock(&engine->signal_lock);
+            if (!engine->need_to_exit && !engine->need_to_reload) {
+                /* TODO: this silly. We should be handling the commandhandler
+                 * connections. No reason to spawn that as a thread.
+                 * Also it would be easier to wake up the command hander
+                 * as signals will reach it if it is the main thread! */
+                ods_log_debug("[%s] taking a break", engine_str);
+                pthread_cond_wait(&engine->signal_cond, &engine->signal_lock);
+            }
+            pthread_mutex_unlock(&engine->signal_lock);
         }
-        pthread_mutex_unlock(&engine->signal_lock);
+        ods_log_debug("[%s] signer halted", engine_str);
     }
-    ods_log_debug("[%s] signer halted", engine_str);
     engine_stop_threads(engine);
 }
 
@@ -785,7 +805,7 @@ engine_start(const char* cfgfile, int cmdline_verbosity, int daemonize, int info
         ods_log_error("[%s] cfgfile %s has errors", engine_str, cfgfile);
         goto earlyexit;
     }
-    if (info) {
+    if (info == 1) {
         char* stacktrace;
         char* stacktraceptr;
         stacktrace = janitor_backtrace_string();
@@ -800,6 +820,8 @@ engine_start(const char* cfgfile, int cmdline_verbosity, int daemonize, int info
         fprintf(stdout, "Configuration:\n");
         engine_config_print(stdout, engine->config); /* for debugging */
         goto earlyexit;
+    } else if (info == 2) {
+        engine->config->num_worker_threads = 0;
     }
     /* check pidfile */
     if (!util_check_pidfile(engine->config->pid_filename)) {

--- a/signer/src/daemon/engine.c
+++ b/signer/src/daemon/engine.c
@@ -289,7 +289,6 @@ engine_stop_threads(engine_type* engine)
 void
 engine_wakeup_workers(engine_type* engine)
 {
-    size_t i = 0;
     ods_log_assert(engine);
     ods_log_assert(engine->config);
     ods_log_debug("[%s] wake up workers", engine_str);
@@ -336,7 +335,6 @@ engine_setup(void)
     int sockets[2] = {0,0};
     int pipefd[2];
     char buff = '\0';
-    int fd, error;
 
     ods_log_debug("[%s] setup signer engine", engine_str);
     if (!engine || !engine->config) {
@@ -479,27 +477,49 @@ engine_setup(void)
 static void
 engine_run(engine_type* engine)
 {
-    if (!engine) {
-        return;
-    }
-    engine_start_workers(engine);
-
-    while (!engine->need_to_exit && !engine->need_to_reload) {
-        /* We must use locking here to avoid race conditions. We want
-         * to sleep indefinitely and want to wake up on signal. This
-         * is to make sure we never mis the signal. */
-        pthread_mutex_lock(&engine->signal_lock);
-        if (!engine->need_to_exit && !engine->need_to_reload) {
-            /* TODO: this silly. We should be handling the commandhandler
-             * connections. No reason to spawn that as a thread.
-             * Also it would be easier to wake up the command hander
-             * as signals will reach it if it is the main thread! */
-            ods_log_debug("[%s] taking a break", engine_str);
-            pthread_cond_wait(&engine->signal_cond, &engine->signal_lock);
+    if (engine->config->num_worker_threads == 0) {
+        task_type* task;
+        worker_type singleworker;
+        struct worker_context singleworkercontext;
+        engine_start_workers(engine);
+        singleworker.context = &singleworkercontext;
+        singleworker.name = "single";
+        singleworker.need_to_exit = 0;
+        singleworker.taskq = engine->taskq;
+        singleworker.thread_id = 0;
+        singleworker.tasksOutstanding = 0;
+        singleworker.tasksFailed = 0;
+        pthread_cond_init(&singleworker.tasksBlocker, NULL);
+        singleworkercontext.engine = engine;
+        singleworkercontext.worker = &singleworker;
+        singleworkercontext.signq  = engine->taskq->signq;
+        do {
+            task = schedule_pop_task_nowait(engine->taskq);
+            if(task) {
+                task_perform(engine->taskq, task, &singleworkercontext);
+            }
+        } while(task && !engine->need_to_reload);
+        if(!task)
+            engine->need_to_exit = 1;
+    } else {
+        engine_start_workers(engine);
+        while (!engine->need_to_exit && !engine->need_to_reload) {
+            /* We must use locking here to avoid race conditions. We want
+             * to sleep indefinitely and want to wake up on signal. This
+             * is to make sure we never mis the signal. */
+            pthread_mutex_lock(&engine->signal_lock);
+            if (!engine->need_to_exit && !engine->need_to_reload) {
+                /* TODO: this silly. We should be handling the commandhandler
+                 * connections. No reason to spawn that as a thread.
+                 * Also it would be easier to wake up the command hander
+                 * as signals will reach it if it is the main thread! */
+                ods_log_debug("[%s] taking a break", engine_str);
+                pthread_cond_wait(&engine->signal_cond, &engine->signal_lock);
+            }
+            pthread_mutex_unlock(&engine->signal_lock);
         }
-        pthread_mutex_unlock(&engine->signal_lock);
+        ods_log_debug("[%s] signer halted", engine_str);
     }
-    ods_log_debug("[%s] signer halted", engine_str);
     engine_stop_threads(engine);
 }
 
@@ -784,9 +804,11 @@ engine_start(const char* cfgfile, int cmdline_verbosity, int daemonize, int info
         ods_log_error("[%s] cfgfile %s has errors", engine_str, cfgfile);
         goto earlyexit;
     }
-    if (info) {
+    if (info == 1) {
         engine_config_print(stdout, engine->config); /* for debugging */
         goto earlyexit;
+    } else if (info == 2) {
+        engine->config->num_worker_threads = 0;
     }
     /* check pidfile */
     if (!util_check_pidfile(engine->config->pid_filename)) {

--- a/signer/src/daemon/signertasks.c
+++ b/signer/src/daemon/signertasks.c
@@ -91,7 +91,9 @@ worker_queue_domain(struct worker_context* context, fifoq_type* q, domain_type* 
     ods_log_assert(domain);
     rrset = domain->rrsets;
     while (rrset) {
-        worker_queue_rrset(context, q, rrset, nsubtasks);
+        if (rrset->rrtype != LDNS_RR_TYPE_ZONEMD) {
+            worker_queue_rrset(context, q, rrset, nsubtasks);
+        }
         rrset = rrset->next;
     }
     denial = (denial_type*) domain->denial;
@@ -264,6 +266,141 @@ do_forcereadsignconf(task_type* task, const char* zonename, void* zonearg, void 
     }
 }
 
+static void
+zonemdinitialize(struct worker_context* context, zone_type* zone, rrset_type** zonemdrr)
+{
+    *zonemdrr = zone_lookup_rrset(zone, zone->apex, LDNS_RR_TYPE_ZONEMD);
+    if(*zonemdrr) {
+        for(int i=0; i<(*zonemdrr)->rr_count; i++) {
+            ldns_rdf* oldserial;
+            oldserial = ldns_rr_set_rdf((*zonemdrr)->rrs[i].rr, ldns_native2rdf_int32(LDNS_RDF_TYPE_INT32, zone->db->intserial), 0);
+            if (oldserial)
+                ldns_rdf_deep_free(oldserial);
+        }
+    } else if (zone->signconf->zonemodus & 0x06) {
+        ldns_rr* soa = zone_lookup_rrset(zone, zone->apex, LDNS_RR_TYPE_SOA)->rrs[0].rr;
+        if(zone->signconf->zonemodus & 0x02) {
+            ldns_rr* rr = ldns_rr_new_frm_type(LDNS_RR_TYPE_ZONEMD);
+            ldns_rr_set_class(rr, LDNS_RR_CLASS_IN);
+            ldns_rr_set_owner(rr, ldns_rdf_clone(ldns_rr_owner(soa)));
+            ldns_rr_set_rdf(rr, ldns_rdf_clone(ldns_rr_rdf(soa, 2)), 0);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 1), 1);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 1), 2);
+            ldns_rr_set_rdf(rr, ldns_rdf_new(LDNS_RDF_TYPE_HEX, LDNS_SHA384_DIGEST_LENGTH, LDNS_XMALLOC(uint8_t, LDNS_SHA384_DIGEST_LENGTH)), 3);
+            zone_add_rr(zone, rr, 1);
+        }
+        if(zone->signconf->zonemodus & 0x04) {
+            ldns_rr* rr = ldns_rr_new_frm_type(LDNS_RR_TYPE_ZONEMD);
+            ldns_rr_set_class(rr, LDNS_RR_CLASS_IN);
+            ldns_rr_set_owner(rr, ldns_rdf_clone(ldns_rr_owner(soa)));
+            ldns_rr_set_rdf(rr, ldns_rdf_clone(ldns_rr_rdf(soa, 2)), 0);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 1), 1);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 2), 2);
+            ldns_rr_set_rdf(rr, ldns_rdf_new(LDNS_RDF_TYPE_HEX, LDNS_SHA512_DIGEST_LENGTH, LDNS_XMALLOC(uint8_t, LDNS_SHA512_DIGEST_LENGTH)), 3);
+            zone_add_rr(zone, rr, 1);
+        }
+        *zonemdrr = zone_lookup_rrset(zone, zone->apex, LDNS_RR_TYPE_ZONEMD);
+        for(int i=0; i<(*zonemdrr)->rr_count; i++) {
+            (*zonemdrr)->rrs[i].exists = 1;
+        }
+    }
+}
+
+static void
+worker_zonemdrrset(rrset_type* rrset, ldns_sha512_CTX* sha384ctx, ldns_sha512_CTX* sha512ctx)
+{
+    uint8_t data[65536];
+    ldns_buffer buf;
+    ldns_status status;
+    ldns_rr_list* list;
+    ldns_rr* rr;
+
+    buf._data = data;
+    buf._position = 0;
+    buf._limit = sizeof(data);
+    buf._capacity = sizeof(data);
+    buf._fixed = 0;
+    buf._status = LDNS_STATUS_OK;
+
+    list = ldns_rr_list_new();
+    for(int i=0; i<rrset->rr_count; i++) {
+        ldns_rr_list_push_rr(list, rrset->rrs[i].rr);
+    }
+    ldns_rr_list_sort(list);
+    while((rr = ldns_rr_list_pop_rr(list))) {
+        status = ldns_rr2buffer_wire_canonical(&buf, rr, LDNS_SECTION_ANSWER);
+        assert(!status);
+        if(sha384ctx)
+            ldns_sha512_update(sha384ctx, data, buf._position);
+        if(sha512ctx)
+            ldns_sha512_update(sha512ctx, data, buf._position);
+    }
+    ldns_rr_list_free(list);
+}
+
+static void
+zomemdprocess(struct worker_context* context, zone_type* zone, rrset_type* zonemdrr)
+{
+    ldns_rbnode_t* node1 = LDNS_RBTREE_NULL;
+    ldns_rbnode_t* node2 = LDNS_RBTREE_NULL;
+    domain_type* domain;
+    denial_type* denial;
+    rrset_type* rrsets;
+    ldns_sha384_CTX sha384ctx;
+    ldns_sha512_CTX sha512ctx;
+    uint8_t sha384value[LDNS_SHA384_DIGEST_LENGTH];
+    uint8_t sha512value[LDNS_SHA512_DIGEST_LENGTH];
+    ldns_rr* sha384rr = NULL;
+    ldns_rr* sha512rr = NULL;
+
+    for(int i=0; i<zonemdrr->rr_count; i++) {
+        ldns_rdf* rdf = ldns_rr_rdf(zonemdrr->rrs[i].rr, 2);
+        switch(ldns_rdf2native_int8(rdf)) {
+            case 1:
+                sha384rr = zonemdrr->rrs[i].rr;
+                break;
+            case 2:
+                sha512rr = zonemdrr->rrs[i].rr;
+                break;
+        }
+    }
+    
+    if (zone->db->domains->root != LDNS_RBTREE_NULL) {
+        node1 = ldns_rbtree_first(zone->db->domains);
+    }
+    if (zone->db->denials->root != LDNS_RBTREE_NULL) {
+        node2 = ldns_rbtree_first(zone->db->denials);
+    }
+    ldns_sha384_init(&sha384ctx);
+    ldns_sha512_init(&sha512ctx);
+    while ((node1 && node1 != LDNS_RBTREE_NULL) || (node2 && node2 != LDNS_RBTREE_NULL)) {
+        domain = ((node1 && node1 != LDNS_RBTREE_NULL) ? (domain_type*) node1->data :  NULL);
+        denial = ((node2 && node2 != LDNS_RBTREE_NULL) ? (denial_type*) node2->data :  NULL);
+        if(!denial || (domain && ldns_dname_compare(domain->dname, denial->dname) < 0)) {
+            rrsets = domain->rrsets;
+            node1 = ldns_rbtree_next(node1);
+        } else {
+            rrsets = denial->rrset;
+            node2 = ldns_rbtree_next(node2);
+        }
+        if(rrsets != zonemdrr) {
+            worker_zonemdrrset(rrsets, (sha384rr ? &sha384ctx : NULL), (sha512rr ? &sha512ctx : NULL));
+        }
+    }
+    ldns_sha384_final(sha384value, &sha384ctx);
+    ldns_sha512_final(sha512value, &sha512ctx);
+
+    if(sha384rr)
+        memcpy(ldns_rdf_data(ldns_rr_rdf(sha384rr, 3)), sha384value, LDNS_SHA384_DIGEST_LENGTH);
+    if(sha512rr)
+        memcpy(ldns_rdf_data(ldns_rr_rdf(sha512rr, 3)), sha512value, LDNS_SHA512_DIGEST_LENGTH);
+
+    long nsubtasks = 0;
+    long nsubtasksfailed = 0;
+    worker_queue_rrset(context, context->signq, zonemdrr, &nsubtasks);
+    fifoq_waitfor(context->signq, context->worker, nsubtasks, &nsubtasksfailed);
+}
+
 time_t
 do_signzone(task_type* task, const char* zonename, void* zonearg, void *contextarg)
 {
@@ -271,12 +408,15 @@ do_signzone(task_type* task, const char* zonename, void* zonearg, void *contexta
     engine_type* engine = context->engine;
     worker_type* worker = context->worker;
     zone_type* zone = zonearg;
+    rrset_type* zonemdrr;
     ods_status status;
     time_t start = 0;
     time_t end = 0;
     long nsubtasks = 0;
     long nsubtasksfailed = 0;
+
     context->clock_in = time_now();
+
     status = zone_update_serial(zone);
     if (status != ODS_STATUS_OK) {
         if(!strcmp(zone->signconf->soa_serial,"keep") && (status == ODS_STATUS_FOPEN_ERR || status == ODS_STATUS_CONFLICT_ERR)) {
@@ -295,6 +435,8 @@ do_signzone(task_type* task, const char* zonename, void* zonearg, void *contexta
             return schedule_DEFER;
         }
     }
+    zonemdinitialize(context, zone, &zonemdrr);
+
     /* start timer */
     start = time(NULL);
     if (zone->stats) {
@@ -334,6 +476,10 @@ do_signzone(task_type* task, const char* zonename, void* zonearg, void *contexta
     if (status == ODS_STATUS_OK) {
         status = worker_check_jobs(worker, task, nsubtasks, nsubtasksfailed);
     }
+
+    if(zonemdrr)
+        zomemdprocess(context, zone, zonemdrr);
+
     if (status == ODS_STATUS_OK && zone->stats) {
         pthread_mutex_lock(&zone->stats->stats_lock);
         zone->stats->sig_time = (end - start);

--- a/signer/src/daemon/signertasks.c
+++ b/signer/src/daemon/signertasks.c
@@ -91,7 +91,9 @@ worker_queue_domain(struct worker_context* context, fifoq_type* q, domain_type* 
     ods_log_assert(domain);
     rrset = domain->rrsets;
     while (rrset) {
-        worker_queue_rrset(context, q, rrset, nsubtasks);
+        if (rrset->rrtype != LDNS_RR_TYPE_ZONEMD) {
+            worker_queue_rrset(context, q, rrset, nsubtasks);
+        }
         rrset = rrset->next;
     }
     denial = (denial_type*) domain->denial;
@@ -264,6 +266,141 @@ do_forcereadsignconf(task_type* task, const char* zonename, void* zonearg, void 
     }
 }
 
+static void
+zonemdinitialize(struct worker_context* context, zone_type* zone, rrset_type** zonemdrr)
+{
+    *zonemdrr = zone_lookup_rrset(zone, zone->apex, LDNS_RR_TYPE_ZONEMD);
+    if(*zonemdrr) {
+        for(int i=0; i<(*zonemdrr)->rr_count; i++) {
+            ldns_rdf* oldserial;
+            oldserial = ldns_rr_set_rdf((*zonemdrr)->rrs[i].rr, ldns_native2rdf_int32(LDNS_RDF_TYPE_INT32, zone->db->intserial), 0);
+            if (oldserial)
+                ldns_rdf_deep_free(oldserial);
+        }
+    } else if (zone->signconf->zonemodus & 0x06) {
+        ldns_rr* soa = zone_lookup_rrset(zone, zone->apex, LDNS_RR_TYPE_SOA)->rrs[0].rr;
+        if(zone->signconf->zonemodus & 0x02) {
+            ldns_rr* rr = ldns_rr_new_frm_type(LDNS_RR_TYPE_ZONEMD);
+            ldns_rr_set_class(rr, LDNS_RR_CLASS_IN);
+            ldns_rr_set_owner(rr, ldns_rdf_clone(ldns_rr_owner(soa)));
+            ldns_rr_set_rdf(rr, ldns_rdf_clone(ldns_rr_rdf(soa, 2)), 0);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 1), 1);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 1), 2);
+            ldns_rr_set_rdf(rr, ldns_rdf_new(LDNS_RDF_TYPE_HEX, LDNS_SHA384_DIGEST_LENGTH, LDNS_XMALLOC(uint8_t, LDNS_SHA384_DIGEST_LENGTH)), 3);
+            zone_add_rr(zone, rr, 1);
+        }
+        if(zone->signconf->zonemodus & 0x04) {
+            ldns_rr* rr = ldns_rr_new_frm_type(LDNS_RR_TYPE_ZONEMD);
+            ldns_rr_set_class(rr, LDNS_RR_CLASS_IN);
+            ldns_rr_set_owner(rr, ldns_rdf_clone(ldns_rr_owner(soa)));
+            ldns_rr_set_rdf(rr, ldns_rdf_clone(ldns_rr_rdf(soa, 2)), 0);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 1), 1);
+            ldns_rr_set_rdf(rr, ldns_native2rdf_int8(LDNS_RDF_TYPE_INT8, 2), 2);
+            ldns_rr_set_rdf(rr, ldns_rdf_new(LDNS_RDF_TYPE_HEX, LDNS_SHA512_DIGEST_LENGTH, LDNS_XMALLOC(uint8_t, LDNS_SHA512_DIGEST_LENGTH)), 3);
+            zone_add_rr(zone, rr, 1);
+        }
+        *zonemdrr = zone_lookup_rrset(zone, zone->apex, LDNS_RR_TYPE_ZONEMD);
+        for(int i=0; i<(*zonemdrr)->rr_count; i++) {
+            (*zonemdrr)->rrs[i].exists = 1;
+        }
+    }
+}
+
+static void
+worker_zonemdrrset(rrset_type* rrset, ldns_sha512_CTX* sha384ctx, ldns_sha512_CTX* sha512ctx)
+{
+    uint8_t data[65536];
+    ldns_buffer buf;
+    ldns_status status;
+    ldns_rr_list* list;
+    ldns_rr* rr;
+
+    buf._data = data;
+    buf._position = 0;
+    buf._limit = sizeof(data);
+    buf._capacity = sizeof(data);
+    buf._fixed = 0;
+    buf._status = LDNS_STATUS_OK;
+
+    list = ldns_rr_list_new();
+    for(int i=0; i<rrset->rr_count; i++) {
+        ldns_rr_list_push_rr(list, rrset->rrs[i].rr);
+    }
+    ldns_rr_list_sort(list);
+    while((rr = ldns_rr_list_pop_rr(list))) {
+        status = ldns_rr2buffer_wire_canonical(&buf, rr, LDNS_SECTION_ANSWER);
+        assert(!status);
+        if(sha384ctx)
+            ldns_sha512_update(sha384ctx, data, buf._position);
+        if(sha512ctx)
+            ldns_sha512_update(sha512ctx, data, buf._position);
+    }
+    ldns_rr_list_free(list);
+}
+
+static void
+zomemdprocess(struct worker_context* context, zone_type* zone, rrset_type* zonemdrr)
+{
+    ldns_rbnode_t* node1 = LDNS_RBTREE_NULL;
+    ldns_rbnode_t* node2 = LDNS_RBTREE_NULL;
+    domain_type* domain;
+    denial_type* denial;
+    rrset_type* rrsets;
+    ldns_sha384_CTX sha384ctx;
+    ldns_sha512_CTX sha512ctx;
+    uint8_t sha384value[LDNS_SHA384_DIGEST_LENGTH];
+    uint8_t sha512value[LDNS_SHA512_DIGEST_LENGTH];
+    ldns_rr* sha384rr = NULL;
+    ldns_rr* sha512rr = NULL;
+
+    for(int i=0; i<zonemdrr->rr_count; i++) {
+        ldns_rdf* rdf = ldns_rr_rdf(zonemdrr->rrs[i].rr, 2);
+        switch(ldns_rdf2native_int8(rdf)) {
+            case 1:
+                sha384rr = zonemdrr->rrs[i].rr;
+                break;
+            case 2:
+                sha512rr = zonemdrr->rrs[i].rr;
+                break;
+        }
+    }
+    
+    if (zone->db->domains->root != LDNS_RBTREE_NULL) {
+        node1 = ldns_rbtree_first(zone->db->domains);
+    }
+    if (zone->db->denials->root != LDNS_RBTREE_NULL) {
+        node2 = ldns_rbtree_first(zone->db->denials);
+    }
+    ldns_sha384_init(&sha384ctx);
+    ldns_sha512_init(&sha512ctx);
+    while ((node1 && node1 != LDNS_RBTREE_NULL) || (node2 && node2 != LDNS_RBTREE_NULL)) {
+        domain = ((node1 && node1 != LDNS_RBTREE_NULL) ? (domain_type*) node1->data :  NULL);
+        denial = ((node2 && node2 != LDNS_RBTREE_NULL) ? (denial_type*) node2->data :  NULL);
+        if(!denial || (domain && ldns_dname_compare(domain->dname, denial->dname) < 0)) {
+            rrsets = domain->rrsets;
+            node1 = ldns_rbtree_next(node1);
+        } else {
+            rrsets = denial->rrset;
+            node2 = ldns_rbtree_next(node2);
+        }
+        if(rrsets != zonemdrr) {
+            worker_zonemdrrset(rrsets, (sha384rr ? &sha384ctx : NULL), (sha512rr ? &sha512ctx : NULL));
+        }
+    }
+    ldns_sha384_final(sha384value, &sha384ctx);
+    ldns_sha512_final(sha512value, &sha512ctx);
+
+    if(sha384rr)
+        memcpy(ldns_rdf_data(ldns_rr_rdf(sha384rr, 3)), sha384value, LDNS_SHA384_DIGEST_LENGTH);
+    if(sha512rr)
+        memcpy(ldns_rdf_data(ldns_rr_rdf(sha512rr, 3)), sha512value, LDNS_SHA512_DIGEST_LENGTH);
+
+    long nsubtasks = 0;
+    long nsubtasksfailed = 0;
+    worker_queue_rrset(context, context->signq, zonemdrr, &nsubtasks);
+    fifoq_waitfor(context->signq, context->worker, nsubtasks, &nsubtasksfailed);
+}
+
 time_t
 do_signzone(task_type* task, const char* zonename, void* zonearg, void *contextarg)
 {
@@ -271,12 +408,15 @@ do_signzone(task_type* task, const char* zonename, void* zonearg, void *contexta
     engine_type* engine = context->engine;
     worker_type* worker = context->worker;
     zone_type* zone = zonearg;
+    rrset_type* zonemdrr;
     ods_status status;
     time_t start = 0;
     time_t end = 0;
     long nsubtasks = 0;
     long nsubtasksfailed = 0;
+
     context->clock_in = time_now();
+
     status = zone_update_serial(zone);
     if (status != ODS_STATUS_OK) {
         ods_log_error("[%s] unable to sign zone %s: failed to increment serial", worker->name, task->owner);
@@ -284,6 +424,8 @@ do_signzone(task_type* task, const char* zonename, void* zonearg, void *contexta
                 worker->name, task->owner, ods_status2str(status));
         return schedule_DEFER; /* backoff */
     }
+    zonemdinitialize(context, zone, &zonemdrr);
+
     /* start timer */
     start = time(NULL);
     if (zone->stats) {
@@ -324,6 +466,10 @@ do_signzone(task_type* task, const char* zonename, void* zonearg, void *contexta
     if (status == ODS_STATUS_OK) {
         status = worker_check_jobs(worker, task, nsubtasks, nsubtasksfailed);
     }
+
+    if(zonemdrr)
+        zomemdprocess(context, zone, zonemdrr);
+
     if (status == ODS_STATUS_OK && zone->stats) {
         pthread_mutex_lock(&zone->stats->stats_lock);
         zone->stats->sig_time = (end - start);

--- a/signer/src/ods-signerd.c
+++ b/signer/src/ods-signerd.c
@@ -131,6 +131,7 @@ main(int argc, char* argv[])
         {"help", no_argument, 0, 'h'},
         {"info", no_argument, 0, 'i'},
         {"verbose", no_argument, 0, 'v'},
+        {"single-run", no_argument, 0, '1'},
         {"version", no_argument, 0, 'V'},
         {"set-time", required_argument, 0, 256},
         { 0, 0, 0, 0}
@@ -145,7 +146,7 @@ main(int argc, char* argv[])
     }
 
     /* parse the commandline */
-    while ((c=getopt_long(argc, argv, "c:dhivV",
+    while ((c=getopt_long(argc, argv, "c:dh1ivV",
         long_options, &options_index)) != -1) {
         switch (c) {
             case 'c':
@@ -159,7 +160,17 @@ main(int argc, char* argv[])
                 exit(0);
                 break;
             case 'i':
-                info = 1;
+                if(info == 0)
+                    info = 1;
+                else
+                    fprintf(stderr, "Error: Option -1|--single-run and -i|--info are mutually exclusive.\n");
+                break;
+            case '1':
+                if(info == 0) {
+                    daemonize = 0;
+                    info = 2;
+                } else
+                    fprintf(stderr, "Error: Option -1|--single-run and -i|--info are mutually exclusive.\n");
                 break;
             case 'v':
                 cmdline_verbosity++;

--- a/signer/src/parser/confparser.h
+++ b/signer/src/parser/confparser.h
@@ -67,6 +67,9 @@ const char* parse_conf_string(const char* cfgfile, const char* expr,
  */
 hsm_repository_t* parse_conf_repositories(const char* cfgfile);
 
+
+extern int parse_conf_zonemds(const char* cfgfile);
+
 /**
  * Parse the listener interfaces.
  * \param[in] allocator the allocator

--- a/signer/src/parser/signconfparser.c
+++ b/signer/src/parser/signconfparser.c
@@ -515,6 +515,22 @@ parse_sc_passthrough(const char* cfgfile)
     return ret;
 }
 
+int
+parse_sc_zonemd(const char* cfgfile)
+{
+    int ret = 0;
+    const char* str = parse_conf_string(cfgfile,
+        "//SignerConfiguration/Zone/ZoneMD/@algorithm",
+        0);
+    if (str) {
+        ret = atoi(str);
+        if(ret == 0)
+            ret = 1;
+        free((void*)str);
+    }
+    return ret;
+} 
+
 /**
  * Parse elements from the configuration file.
  *

--- a/signer/src/parser/signconfparser.h
+++ b/signer/src/parser/signconfparser.h
@@ -104,6 +104,13 @@ extern int parse_sc_passthrough(const char* cfgfile);
 /**
  * Parse elements from the configuration file.
  * \param[in] cfgfile the configuration file name.
+ * \return boolean
+ */
+extern int parse_sc_zonemd(const char* cfgfile);
+
+/**
+ * Parse elements from the configuration file.
+ * \param[in] cfgfile the configuration file name.
  * \return const char* string
  *
  */

--- a/signer/src/signer/namedb.c
+++ b/signer/src/signer/namedb.c
@@ -548,7 +548,7 @@ namedb_add_denial_trigger(namedb_type* db, domain_type* domain)
         zone = domain->zone;
         ods_log_assert(zone);
         ods_log_assert(zone->signconf);
-        if (!zone->signconf->passthrough) {
+        if (!(zone->signconf->zonemodus & 0x01)) {
             if (zone->signconf->nsec_type == LDNS_RR_TYPE_NSEC) {
                 namedb_add_nsec_trigger(db, domain);
             } else {

--- a/signer/src/signer/signconf.c
+++ b/signer/src/signer/signconf.c
@@ -49,7 +49,7 @@ signconf_create(void)
     signconf_type* sc = NULL;
     CHECKALLOC(sc = (signconf_type*) malloc(sizeof(signconf_type)));
     sc->filename = NULL;
-    sc->passthrough = 0;
+    sc->zonemodus = 0;
     /* Signatures */
     sc->sig_resign_interval = NULL;
     sc->sig_refresh_interval = NULL;
@@ -105,7 +105,7 @@ signconf_read(signconf_type* signconf, const char* scfile)
     fd = ods_fopen(scfile, NULL, "r");
     if (fd) {
         signconf->filename = strdup(scfile);
-        signconf->passthrough = parse_sc_passthrough(scfile);
+        signconf->zonemodus = parse_sc_passthrough(scfile) | (parse_sc_zonemd(scfile) << 1);
         signconf->sig_resign_interval = parse_sc_sig_resign_interval(scfile);
         signconf->sig_refresh_interval = parse_sc_sig_refresh_interval(scfile);
         signconf->sig_validity_default = parse_sc_sig_validity_default(scfile);
@@ -319,7 +319,7 @@ signconf_check(signconf_type* sc)
             sc->nsec_type);
         status = ODS_STATUS_CFG_ERR;
     }
-    if ((!sc->keys || sc->keys->count == 0) && !sc->passthrough) {
+    if ((!sc->keys || sc->keys->count == 0) && !(sc->zonemodus & 0x01)) {
         ods_log_error("[%s] check failed: no keys found", sc_str);
         status = ODS_STATUS_CFG_ERR;
     }
@@ -421,7 +421,7 @@ signconf_log(signconf_type* sc, const char* name)
             name?name:"(null)",
             resign?resign:"(null)",
             refresh?refresh:"(null)",
-            sc->passthrough?"PASSTHROUGH ":"",
+            (sc->zonemodus&0x01)?"PASSTHROUGH ":"",
             validity?validity:"(null)",
             denial?denial:"(null)",
             keyset?keyset:"(null)",

--- a/signer/src/signer/signconf.h
+++ b/signer/src/signer/signconf.h
@@ -41,7 +41,7 @@ typedef struct signconf_struct signconf_type;
 struct signconf_struct {
     /* Zone */
     const char* name;
-    int passthrough;
+    int zonemodus;
     /* Signatures */
     duration_type* sig_resign_interval;
     duration_type* sig_refresh_interval;

--- a/signer/src/signer/tools.c
+++ b/signer/src/signer/tools.c
@@ -112,7 +112,7 @@ tools_input(zone_type* zone)
         return status;
     }
     /* Denial of Existence Rollover? */
-    if (!zone->signconf->passthrough)
+    if (!(zone->signconf->zonemodus & 0x01))
         status = zone_publish_nsec3param(zone);
     if (status != ODS_STATUS_OK) {
         ods_log_error("[%s] unable to read zone %s: failed to "

--- a/signer/src/signer/zone.c
+++ b/signer/src/signer/zone.c
@@ -952,7 +952,7 @@ zone_recover2(engine_type* engine, zone_type* zone)
             goto recover_error2;
         }
         /* publish nsec3param */
-        if (!zone->signconf->passthrough)
+        if (!(zone->signconf->zonemodus & 0x01))
             status = zone_publish_nsec3param(zone);
         if (status != ODS_STATUS_OK) {
             ods_log_error("[%s] corrupted backup file zone %s: unable to "


### PR DESCRIPTION
Implementation finished of ZoneMD (RFC 8976).
The implementation is finished, but could do with some testing.
To use: add <ZoneMD/> as first child element of the <Zone> element in the kasp.xml.  Optionally with an argument denoting the algorithm, ie. <ZoneMD algorithm="2"/>.
Misuses the passthrough field in the kasp database and signconf to also store whether digest is used and algorithm type, thus needing no upgrade script for database and forward compatible ONLY.   The (mis)use of this field isn't nice, and would be better to have a separate field, but with the current database this is a bridge too far.
computing the digest requires an extra pass over the zone thus making the signing process a bit slower.