### PR TITLE
Update query.c

### DIFF
--- a/signer/src/wire/query.c
+++ b/signer/src/wire/query.c
@@ -277,6 +277,13 @@ query_process_notify(query_type* q, ldns_rr_type qtype, engine_type* engine)
     ods_log_assert(q->zone->name);
     ods_log_verbose("[%s] incoming notify for zone %s", query_str,
         q->zone->name);
+
+    // Ensure that we read the message from the start as the read cursor
+    // may have been advanced past any OPT record present causing the skip
+    // past the header that happens below to attempt to move beyond the end
+    // of the buffer.
+    buffer_set_position(q->buffer, 0);
+
     if (buffer_pkt_rcode(q->buffer) != LDNS_RCODE_NOERROR ||
         buffer_pkt_qr(q->buffer) ||
         !buffer_pkt_aa(q->buffer) ||


### PR DESCRIPTION
I have a locally modified version of the test suite which uses https://github.com/NLnetLabs/dnst to send the NOTIFY instead of using `ldns-notify` and this caused OpenDNSSEC to crash because `dnst` includes an OPT record in the NOTIFY request.

The crash occurs because OpenDNSSEC moves past the OPT record then doesn't reset the read cursor before attempting to skip past the DNS header causing an assertion failure in `buffer_skip()`.

A quick test with a local instance of NSD shows that the NOTIFY it sends does NOT include an OPT record. As we haven't heard of this issue it is likely that most tooling that sends a NOTIFY do not include OPT records in the request, and a PR to `dnst` will be made to disable inclusion of an OPT record in the NOTIFY it sends.

Thus this likely isn't a real world issue, but good to patch anyway.