### PR TITLE
Fedora 41 compilation fixes

### DIFF
--- a/common/scheduler/task.c
+++ b/common/scheduler/task.c
@@ -40,6 +40,7 @@
 #include "duration.h"
 #include "file.h"
 #include "log.h"
+#include "utilities.h"
 
 static const char* task_str = "task";
 static pthread_mutex_t worklock = PTHREAD_MUTEX_INITIALIZER;

--- a/enforcer/src/utils/kaspcheck.c
+++ b/enforcer/src/utils/kaspcheck.c
@@ -25,6 +25,7 @@
 
 #define _GNU_SOURCE
 #include <stdio.h>
+#include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
 #include <syslog.h>

--- a/enforcer/src/utils/kc_helper.c
+++ b/enforcer/src/utils/kc_helper.c
@@ -27,6 +27,7 @@
 #include <syslog.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <errno.h>


### PR DESCRIPTION
To compile on my Fedora 41 developer machine I need the fixes included in this PR _**and**_ I also need to do run `configure` with the following CFLAGS set:

```
CFLAGS="-fPIE -D_XOPEN_SOURCE=700" ./configure
```

Without those CFLAGS compilation fails. Note that `-fPIE` is already present in `contrib/distros/opendnssec.spec`.

The `-fPIE` resolves error:

```
/usr/bin/ld: hsmutil.o: relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIE
```

The `-D_XOPEN_SOURCE=700` resolves error:

```
daemon/time_leap_cmd.c:117:21: error: implicit declaration of function ‘strptime’; did you mean ‘strftime’? [-Wimplicit-function-declaration]
```

@wtoorop: A few questions for you:

1. Does this PR look sane to you?
2. Do the CFLAGS look sane to you?
3. If so, is there a way to automatically include them via the automake inputs (or some other way) or is this just something to document?