### PR TITLE
FIX: undefined reference to 'strlcat' caused by the merge of PR #866.

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -30,6 +30,7 @@
  */
 
 #include "config.h"
+#include "compat.h"
 #include "file.h"
 #include "log.h"
 #include "clientpipe.h"

--- a/enforcer/src/db/test/Makefile.am
+++ b/enforcer/src/db/test/Makefile.am
@@ -1,4 +1,5 @@
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+LIBCOMPAT = ${top_builddir}/common/libcompat.a
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/common \
@@ -54,7 +55,8 @@ test_LDADD = \
 	${top_builddir}/common/duration.o \
 	${top_builddir}/common/log.o \
 	${top_builddir}/common/file.o \
-	$(BACKEND_LDADD_CUSTOM)
+	$(BACKEND_LDADD_CUSTOM) \
+	${LIBCOMPAT}
 
 test_LDFLAGS = -no-install \
 	@XML2_LIBS@ \


### PR DESCRIPTION
I didn't notice this issue when merging PR https://github.com/opendnssec/opendnssec/pull/866 as it was working on my Fedora host, but discovered afterwards that it fails in an Ubuntu container.

Note to self: Add CI for Fedora and Ubuntu!